### PR TITLE
Open specialist-publisher history before trying to view it

### DIFF
--- a/spec/specialist_publisher_spec.rb
+++ b/spec/specialist_publisher_spec.rb
@@ -4,7 +4,6 @@ require "faker"
 require "date"
 
 describe "specialist publisher", type: :feature do
-
   feature "Publishes an AAIB Report" do
     let(:title) { Faker::Book.title }
     let(:summary) { Faker::Lorem.sentence }

--- a/spec/support/specialist_publisher_assertion_helpers.rb
+++ b/spec/support/specialist_publisher_assertion_helpers.rb
@@ -6,6 +6,7 @@ module SpecialistPublisherAssertionHelpers
   end
 
   def expect_change_note(change_note)
+    click_link("+ full page history")
     within("#full-history") do
       expect(page).to have_content(change_note)
     end


### PR DESCRIPTION
This now needs a fix as I think it was only passing previously due to static files failing to load.