### PR TITLE
Set capybara default_max_wait_time to 10 seconds

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -114,6 +114,7 @@ Capybara.configure do |config|
   config.run_server = false
   config.default_driver = :poltergeist
   config.save_path = __dir__ + "/../tmp"
+  config.default_max_wait_time = 10
 end
 
 # Capybara::Webkit.configure do |config|


### PR DESCRIPTION
Hard to know the exact sweet spot for this but 10 seconds seems to avoid
some of the timeout related issues seen so far (and seems like an
eternity in web time)