### PR TITLE
reload_page_while_failing method to work around waiting for items to appear on content store

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -116,7 +116,7 @@ Capybara.configure do |config|
   config.run_server = false
   config.default_driver = :poltergeist
   config.save_path = __dir__ + "/../tmp"
-  config.default_max_wait_time = 10
+  config.default_max_wait_time = 3
 end
 
 # Capybara::Webkit.configure do |config|

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -108,6 +108,8 @@ RSpec.configure do |config|
   # as the one that triggered the failure.
   Kernel.srand config.seed
 =end
+
+  config.add_setting :reload_page_attempts, default: 5
 end
 
 Capybara.configure do |config|

--- a/spec/support/reload_page_helpers.rb
+++ b/spec/support/reload_page_helpers.rb
@@ -1,0 +1,15 @@
+module ReloadPageHelpers
+  def reload_page_while_failing
+    attempt = 1
+    begin
+      yield
+    rescue Capybara::ElementNotFound, RSpec::Expectations::ExpectationNotMetError => e
+      raise e if attempt >= RSpec.configuration.reload_page_attempts
+      attempt += 1
+      visit(page.current_url)
+      retry
+    end
+  end
+
+  RSpec.configuration.include ReloadPageHelpers
+end

--- a/spec/support/specialist_publisher_assertion_helpers.rb
+++ b/spec/support/specialist_publisher_assertion_helpers.rb
@@ -1,22 +1,28 @@
 module SpecialistPublisherAssertionHelpers
   def expect_title(title)
-    within(".govuk-title") do
-      expect(page).to have_content(title)
+    reload_page_while_failing do
+      within(".govuk-title") do
+        expect(page).to have_content(title)
+      end
     end
   end
 
   def expect_change_note(change_note)
-    click_link("+ full page history")
-    within("#full-history") do
-      expect(page).to have_content(change_note)
+    reload_page_while_failing do
+      click_link("+ full page history")
+      within("#full-history") do
+        expect(page).to have_content(change_note)
+      end
     end
   end
 
   def expect_rendering_app_meta
-    expect(page).to have_selector(
-      "meta[name='govuk:rendering-application'][content='specialist-frontend']",
-      visible: false
-    )
+    reload_page_while_failing do
+      expect(page).to have_selector(
+        "meta[name='govuk:rendering-application'][content='specialist-frontend']",
+        visible: false
+      )
+    end
   end
 
   def expect_error(message)


### PR DESCRIPTION
The capybara wait mechanism is based on the concept that a page may take
a while to display the correct contents. In our scenario however we want
to continuously reload the page - as it will be waiting for content that
is being added to the content store.

Originally this began as a way of changing the way wait worked when it was for something that we were wanting to reload, however I decided this was a big 'magical' and have switched to have a configured number of retries. As these can take a very long time with a long `default_max_wait_time` I have lowered this to 3 seconds. Passes quickly on my machine, but may need tweaking if others struggle with it.