### PR TITLE
Making the specialist publisher E2E test more reliable

### DIFF
--- a/spec/specialist_publisher_spec.rb
+++ b/spec/specialist_publisher_spec.rb
@@ -5,7 +5,7 @@ require "date"
 
 describe "specialist publisher", type: :feature do
   feature "Publishes an AAIB Report" do
-    let(:title) { Faker::Book.author }
+    let(:title) { title_timestamp }
     let(:summary) { Faker::Lorem.sentence }
 
     scenario "successfully publishing an AAIB report" do
@@ -19,7 +19,7 @@ describe "specialist publisher", type: :feature do
   end
 
   feature "Creates a draft of an AAIB Report" do
-    let(:title) { Faker::Book.author }
+    let(:title) { title_timestamp }
     let(:summary) { "Aubergine crop has failed in Turkmenistan" }
 
     scenario "successfully creating an AAIB report" do
@@ -89,7 +89,7 @@ describe "specialist publisher", type: :feature do
   end
 
   feature "Discarding drafts" do
-    let(:title) { Faker::Book.author }
+    let(:title) { title_timestamp }
     let(:summary) { "Draft which will be discarded" }
 
     scenario "Discarding drafts that are not published" do
@@ -139,7 +139,7 @@ describe "specialist publisher", type: :feature do
   end
 
   feature "Documents with attachment" do
-    let(:title) { Faker::Book.author }
+    let(:title) { title_timestamp }
     let(:summary) { "Documents with attachment" }
     let(:file) { File.expand_path("./fixtures/Charities_and_corporation_tax_returns.pdf", File.dirname(__FILE__)) }
 

--- a/spec/specialist_publisher_spec.rb
+++ b/spec/specialist_publisher_spec.rb
@@ -16,12 +16,6 @@ describe "specialist publisher", type: :feature do
       expect_rendering_app_meta
       expect(page).to have_current_path(%r{^/aaib-reports})
     end
-
-    scenario "unsuccessfully creating a draft" do
-      create_aaib_report(title, "", Faker::Lorem.paragraph)
-      save_draft
-      expect_error("Summary can't be blank")
-    end
   end
 
   feature "Creates a draft of an AAIB Report" do
@@ -154,18 +148,16 @@ describe "specialist publisher", type: :feature do
       save_and_edit_draft
       select_add_attachment
       save_draft
+      expect_attached_file
+      publish_draft
     end
 
     scenario "Publishing documents with attachment" do
-      expect_attached_file
-      publish_draft
       view_frontend
       expect_attached_file_frontend
     end
 
     scenario "Removing attachments and publishing draft" do
-      expect_attached_file
-      publish_draft
       visit_aaib_index
       edit_first_published_document
       remove_attachment_and_save_draft

--- a/spec/specialist_publisher_spec.rb
+++ b/spec/specialist_publisher_spec.rb
@@ -149,21 +149,19 @@ describe "specialist publisher", type: :feature do
       select_add_attachment
       save_draft
       expect_attached_file
-      publish_draft
     end
 
     scenario "Publishing documents with attachment" do
-      view_frontend
+      preview_draft
       expect_attached_file_frontend
     end
 
     scenario "Removing attachments and publishing draft" do
       visit_aaib_index
-      edit_first_published_document
+      edit_first_draft_document
       remove_attachment_and_save_draft
-      expect_preview_draft_link
-      publish_draft
-      view_frontend
+      expect_attached_file_removed
+      preview_draft
       expect_removed_file_frontend
     end
   end

--- a/spec/support/specialist_publisher_assertion_helpers.rb
+++ b/spec/support/specialist_publisher_assertion_helpers.rb
@@ -25,12 +25,6 @@ module SpecialistPublisherAssertionHelpers
     end
   end
 
-  def expect_error(message)
-    within(".elements-error-summary") do
-      expect(page).to have_content(message)
-    end
-  end
-
   def expect_preview_draft_link
     expect(page).to have_link("Preview draft")
   end

--- a/spec/support/specialist_publisher_navigation_helpers.rb
+++ b/spec/support/specialist_publisher_navigation_helpers.rb
@@ -125,7 +125,7 @@ module SpecialistPublisherNavigationHelpers
   end
 
   def ensure_published_aaib_report
-    create_aaib_report(Faker::Book.author, "Summary", "Body")
+    create_aaib_report(title_timestamp, "Summary", "Body")
     save_and_publish
   end
 
@@ -173,6 +173,10 @@ module SpecialistPublisherNavigationHelpers
     fill_in("Summary", with: summary)
     fill_in("Body", with: body)
     esi_fund_closing_date(Date.today)
+  end
+
+  def title_timestamp
+    Faker::Book.author << " #{Time.now.to_i}"
   end
 
   def discard_draft

--- a/spec/support/specialist_publisher_navigation_helpers.rb
+++ b/spec/support/specialist_publisher_navigation_helpers.rb
@@ -68,6 +68,11 @@ module SpecialistPublisherNavigationHelpers
     raise "Published-with-new-draft document not found"
   end
 
+  def edit_first_published_document
+    visit_first_published_document
+    click_link("Edit document")
+  end
+
   def edit_first_unpublished_document
     visit_first_unpublished_document
     click_link("Edit document")
@@ -77,8 +82,8 @@ module SpecialistPublisherNavigationHelpers
     click_link("Edit document")
   end
 
-  def edit_first_published_document
-    visit_first_published_document
+  def edit_first_draft_document
+    select_drafted_content
     click_link("Edit document")
   end
 
@@ -94,7 +99,9 @@ module SpecialistPublisherNavigationHelpers
 
   def save_and_publish
     save_draft
-    click_button("Publish")
+    page.accept_confirm do
+      click_button("Publish")
+    end
   end
 
   def save_and_edit_draft
@@ -154,9 +161,7 @@ module SpecialistPublisherNavigationHelpers
     expect_attachment_removed
     fill_in("Summary", with: "Removing the attachment")
     fill_in("Body", with: "Removed attached document")
-    set_minor_update
     save_draft
-    expect_attached_file_removed
   end
 
   def create_aaib_report(title, summary, body)


### PR DESCRIPTION
A few changes has been made to improve the reliability of the specialist publisher end to end test. Although attaching a file scenario might fail intermittently.This is because responses from the asset manager which is responsible for attaching files are slower than expected. A story has been created to investigate/improve the speed of the Asset Manager in the specialist publisher.