### PR TITLE
Allow passing a tags=tag1,tag2 argument to make

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -29,8 +29,20 @@ start:
 	docker-compose run travel-advice-publisher bundle exec rake db:seed
 	docker-compose up -d
 
+
+# `make test` will run just the test command
+#
+# whereas if you run `make test tags=<comma separated list of test tags>` you
+# can run particularly tagged tests
+#
+TEST_COMMAND = docker-compose run publishing-e2e-tests bundle exec rspec --format d
+comma = ,
 test:
-	docker-compose run publishing-e2e-tests bundle exec rspec --format d
+ifdef tags
+	$(TEST_COMMAND) --tag $(subst $(comma), --tag ,$(tags))
+else
+	$(TEST_COMMAND)
+endif
 
 stop:
 	docker-compose down


### PR DESCRIPTION
This will allow specific tags to run specific groups of tests in rspec.

Eg

`make test` will run all tags

`make test tags=travel_advice_publisher` will just run tests tagged with "travel_advice_publisher"

I don't know anything about makefiles so cobbled this together with some googling, so suggestions on how to improve this are welcome. 

