### PR TITLE
Swap reset back for a merge fast forward

### DIFF
--- a/bin/clone-app
+++ b/bin/clone-app
@@ -7,7 +7,7 @@ class App
 
   def prepare
     Dir.chdir("apps") do
-      File.directory?(name) ? update : clone
+      File.directory?(name) ? update : (clone && checkout)
     end
   end
 

--- a/bin/clone-app
+++ b/bin/clone-app
@@ -26,7 +26,7 @@ private
   end
 
   def checkout
-    unless system "git checkout #{commitish}"
+    unless system "git checkout -f #{commitish}"
       raise "git failed to checkout #{commitish}"
     end
   end

--- a/bin/clone-app
+++ b/bin/clone-app
@@ -37,9 +37,10 @@ private
     end
   end
 
-  def reset
-    unless system "git reset --hard HEAD"
-      raise "reset failed for #{name}"
+  def merge
+    return if detached?
+    unless system "git merge --ff-only origin/#{commitish}"
+      raise "merge failed for #{commitish}"
     end
   end
 
@@ -50,7 +51,7 @@ private
       else
         fetch_origin
         checkout
-        reset
+        merge
       end
     end
   end
@@ -65,6 +66,10 @@ private
 
   def commitish
     ENV.fetch("#{upper_name}_COMMITISH", "master")
+  end
+
+  def detached?
+    `git rev-parse --abbrev-ref HEAD` == "HEAD\n"
   end
 end
 


### PR DESCRIPTION
My poor understanding of HEAD failed me and we do actually need to do a
fast forward to get the up to date value for HEAD.

We can only merge though if we are on a branch hence the check for
detached.