### PR TITLE
Create correct exchange for RabbitMQ

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -27,7 +27,7 @@ setup:
 	docker-compose run publishing-api bundle exec rake db:setup
 	docker-compose run -e RUMMAGER_INDEX=all rummager bundle exec rake rummager:migrate_index
 	docker-compose run publishing-api-worker rails runner 'Sidekiq::Queue.new.clear'
-	docker-compose run publishing-api-worker bundle exec rails runner 'channel = Bunny.new.start.create_channel;Bunny::Exchange.new(channel, :topic, "test")'
+	docker-compose run publishing-api-worker bundle exec rails runner 'channel = Bunny.new.start.create_channel;Bunny::Exchange.new(channel, :topic, "published_documents")'
 	docker-compose run specialist-publisher bundle exec rake db:seed
 	docker-compose run specialist-publisher bundle exec rake publishing_api:publish_finders
 	docker-compose run travel-advice-publisher bundle exec rake db:seed


### PR DESCRIPTION
We should probably look into moving this and the clear sidekiq queue
into rake tasks in Publishing API but this gets us past the immediate
issue.