### PR TITLE
Remove docker label

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -3,7 +3,7 @@
 REPOSITORY = "publishing-e2e-tests"
 DEFAULT_PUBLISHING_API_COMMITISH = "master"
 
-node("docker") {
+node {
 
   def govuk = load("/var/lib/jenkins/groovy_scripts/govuk_jenkinslib.groovy")
 


### PR DESCRIPTION
We're docker by default in CI now so we should stop pinning to a single CI machine and spread the load.