### PR TITLE
Set a different redis database for draft static

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -327,6 +327,7 @@ services:
       PLEK_HOSTNAME_PREFIX: draft-
       PLEK_SERVICE_ERRBIT_URI: http://errbit.dev.gov.uk
       PORT: 3113
+      REDIS_URL: redis://redis/1
       VIRTUAL_HOST: draft-static.dev.gov.uk
     ports:
       - "3113:3113"


### PR DESCRIPTION
Static has it's redis database set in state Dockerfile see: https://github.com/alphagov/static/pull/1004