### PR TITLE
Build apps against deployed-to-production branch

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,9 +1,9 @@
 #!/usr/bin/env groovy
 
 REPOSITORY = "publishing-e2e-tests"
-DEFAULT_PUBLISHING_API_COMMITISH = "master"
-DEFAULT_CONTENT_STORE_COMMITISH = "master"
-DEFAULT_TRAVEL_ADVICE_PUBLISHER_COMMITISH = "master"
+DEFAULT_PUBLISHING_API_COMMITISH = "deployed-to-production"
+DEFAULT_CONTENT_STORE_COMMITISH = "deployed-to-production"
+DEFAULT_TRAVEL_ADVICE_PUBLISHER_COMMITISH = "deployed-to-production"
 
 node {
 


### PR DESCRIPTION
Apps in the Jenkinsfile currently build against `master` but should build
against `deployed-to-production`.

https://trello.com/c/NwvQLJMs/957-run-e2e-tests-as-part-of-content-store-and-travel-advice-publisher-builds-1