### PR TITLE
Bump the router timeout

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -2,10 +2,6 @@ require "httparty"
 require "plek"
 require_relative "lib/retry_while_false"
 
-task :hello do
-  puts "hi"
-end
-
 task :wait_for_router do
   outcome = RetryWhileFalse.call(reload_seconds: 60, interval_seconds: 1) do
     live = HTTParty.head(Plek.find("www")).code

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -64,6 +64,7 @@ services:
     environment:
       VIRTUAL_HOST: www.dev.gov.uk
       VIRTUAL_PORT: 3054
+      ROUTER_BACKEND_HEADER_TIMEOUT: 60s
     links:
       - mongo
       - nginx-proxy:government-frontend.dev.gov.uk
@@ -77,6 +78,7 @@ services:
       GOVUK_APP_NAME: draft-router
       PLEK_HOSTNAME_PREFIX: draft-
       PLEK_SERVICE_ERRBIT_URI: http://errbit.dev.gov.uk
+      ROUTER_BACKEND_HEADER_TIMEOUT: 60s
       ROUTER_PUBADDR: ":3154"
       ROUTER_APIADDR: ":3155"
       ROUTER_MONGO_DB: draft-router


### PR DESCRIPTION
Since the update to Rails 5 of static we seem to be getting 504 errors timeout errors communicating with government frontend. This change bumps the timeouts allowed by router from 15s to 60s to allow for more room.  The problems only seem to occur initially when caches are cold.



