### PR TITLE
Specify Mongo version 2.4

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,7 +15,7 @@ services:
     image: postgres:9.6
 
   mongo:
-    image: mongo
+    image: mongo:2.4
 
   redis:
     image: redis


### PR DESCRIPTION
It's prudent that the version of MongoDB in the e2e tests roughly matches
the one that is used in our hosting environments.