### PR TITLE
Create rummager indices correctly

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -26,7 +26,7 @@ setup:
 	docker-compose run draft-content-store bundle exec rake db:purge
 	docker-compose run asset-manager bundle exec rake db:purge
 	docker-compose run publishing-api bundle exec rake db:setup
-	docker-compose run -e RUMMAGER_INDEX=all rummager bundle exec rake rummager:migrate_index
+	docker-compose run -e RUMMAGER_INDEX=all rummager bundle exec rake rummager:create_all_indices
 	docker-compose run publishing-api-worker rails runner 'Sidekiq::Queue.new.clear'
 	# docker-compose run publishing-api-worker bundle exec rails runner 'channel = Bunny.new.start.create_channel;Bunny::Exchange.new(channel, :topic, "published_documents")'
 	docker-compose run specialist-publisher bundle exec rake db:seed


### PR DESCRIPTION
The old rake task, `migrate_indices`, was removed, but it's been replaced by `create_all_indices`.

See https://github.com/alphagov/rummager/pull/948 for the related change in rummager.