### PR TITLE
Ability to specify commitish of apps

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -26,6 +26,11 @@ node {
       ),
       stringParam(
         defaultValue: DEFAULT_COMMITISH,
+        description: "Which commit/branch/tag of asset-manager to clone",
+        name: "ASSET_MANAGER_COMMITISH"
+      ),
+      stringParam(
+        defaultValue: DEFAULT_COMMITISH,
         description: "Which commit/branch/tag of content-store to clone",
         name: "CONTENT_STORE_COMMITISH"
       ),
@@ -56,6 +61,7 @@ node {
     "ORIGIN_REPO": "",
     "ORIGIN_COMMIT": "",
     "TEST_COMMAND": "test",
+    "ASSET_MANAGER_COMMITISH": DEFAULT_COMMITISH,
     "CONTENT_STORE_COMMITISH": DEFAULT_COMMITISH,
     "PUBLISHING_API_COMMITISH": DEFAULT_COMMITISH,
     "ROUTER_API_COMMITISH": DEFAULT_COMMITISH,
@@ -86,6 +92,7 @@ node {
 
       stage("Clone applications") {
         withEnv([
+          "ASSET_MANAGER_COMMITISH=${params.ASSET_MANAGER_COMMITISH}",
           "CONTENT_STORE_COMMITISH=${params.CONTENT_STORE_COMMITISH}",
           "PUBLISHING_API_COMMITISH=${params.PUBLISHING_API_COMMITISH}",
           "ROUTER_API_COMMITISH=${params.ROUTER_API_COMMITISH}",

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -36,6 +36,11 @@ node {
       ),
       stringParam(
         defaultValue: DEFAULT_COMMITISH,
+        description: "Which commit/branch/tag of government-frontend to clone",
+        name: "GOVERNMENT_FRONTEND_COMMITISH"
+      ),
+      stringParam(
+        defaultValue: DEFAULT_COMMITISH,
         description: "Which commit/branch/tag of publishing-api to clone",
         name: "PUBLISHING_API_COMMITISH"
       ),
@@ -73,6 +78,7 @@ node {
     "TEST_COMMAND": "test",
     "ASSET_MANAGER_COMMITISH": DEFAULT_COMMITISH,
     "CONTENT_STORE_COMMITISH": DEFAULT_COMMITISH,
+    "GOVERNMENT_FRONTEND_COMMITISH": DEFAULT_COMMITISH,
     "PUBLISHING_API_COMMITISH": DEFAULT_COMMITISH,
     "ROUTER_API_COMMITISH": DEFAULT_COMMITISH,
     "RUMMAGER_COMMITISH": DEFAULT_COMMITISH,
@@ -106,6 +112,7 @@ node {
         withEnv([
           "ASSET_MANAGER_COMMITISH=${params.ASSET_MANAGER_COMMITISH}",
           "CONTENT_STORE_COMMITISH=${params.CONTENT_STORE_COMMITISH}",
+          "GOVERNMENT_FRONTEND_COMMITISH=${params.GOVERNMENT_FRONTEND_COMMITISH}",
           "PUBLISHING_API_COMMITISH=${params.PUBLISHING_API_COMMITISH}",
           "ROUTER_API_COMMITISH=${params.ROUTER_API_COMMITISH}",
           "RUMMAGER_COMMITISH=${params.RUMMAGER_COMMITISH}",

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -56,6 +56,11 @@ node {
       ),
       stringParam(
         defaultValue: DEFAULT_COMMITISH,
+        description: "Which commit/branch/tag of static to clone",
+        name: "STATIC_COMMITISH"
+      ),
+      stringParam(
+        defaultValue: DEFAULT_COMMITISH,
         description: "Which commit/branch/tag of travel-advice-publisher to clone",
         name: "TRAVEL_ADVICE_PUBLISHER_COMMITISH"
       ),
@@ -72,6 +77,7 @@ node {
     "ROUTER_API_COMMITISH": DEFAULT_COMMITISH,
     "RUMMAGER_COMMITISH": DEFAULT_COMMITISH,
     "SPECIALIST_PUBLISHER_COMMITISH": DEFAULT_COMMITISH,
+    "STATIC_COMMITISH": DEFAULT_COMMITISH,
     "TRAVEL_ADVICE_PUBLISHER_COMMITISH": DEFAULT_COMMITISH,
   ])
 
@@ -104,6 +110,7 @@ node {
           "ROUTER_API_COMMITISH=${params.ROUTER_API_COMMITISH}",
           "RUMMAGER_COMMITISH=${params.RUMMAGER_COMMITISH}",
           "SPECIALIST_PUBLISHER_COMMITISH=${params.SPECIALIST_PUBLISHER_COMMITISH}",
+          "STATIC_COMMITISH=${params.STATIC_COMMITISH}",
           "TRAVEL_ADVICE_PUBLISHER_COMMITISH=${params.TRAVEL_ADVICE_PUBLISHER_COMMITISH}",
         ]) {
           sh("make clone -j4")

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -46,6 +46,11 @@ node {
       ),
       stringParam(
         defaultValue: DEFAULT_COMMITISH,
+        description: "Which commit/branch/tag of rummager to clone",
+        name: "RUMMAGER_COMMITISH"
+      ),
+      stringParam(
+        defaultValue: DEFAULT_COMMITISH,
         description: "Which commit/branch/tag of specialist-publisher to clone",
         name: "SPECIALIST_PUBLISHER_COMMITISH"
       ),
@@ -65,6 +70,7 @@ node {
     "CONTENT_STORE_COMMITISH": DEFAULT_COMMITISH,
     "PUBLISHING_API_COMMITISH": DEFAULT_COMMITISH,
     "ROUTER_API_COMMITISH": DEFAULT_COMMITISH,
+    "RUMMAGER_COMMITISH": DEFAULT_COMMITISH,
     "SPECIALIST_PUBLISHER_COMMITISH": DEFAULT_COMMITISH,
     "TRAVEL_ADVICE_PUBLISHER_COMMITISH": DEFAULT_COMMITISH,
   ])
@@ -96,6 +102,7 @@ node {
           "CONTENT_STORE_COMMITISH=${params.CONTENT_STORE_COMMITISH}",
           "PUBLISHING_API_COMMITISH=${params.PUBLISHING_API_COMMITISH}",
           "ROUTER_API_COMMITISH=${params.ROUTER_API_COMMITISH}",
+          "RUMMAGER_COMMITISH=${params.RUMMAGER_COMMITISH}",
           "SPECIALIST_PUBLISHER_COMMITISH=${params.SPECIALIST_PUBLISHER_COMMITISH}",
           "TRAVEL_ADVICE_PUBLISHER_COMMITISH=${params.TRAVEL_ADVICE_PUBLISHER_COMMITISH}",
         ]) {


### PR DESCRIPTION
This adds ability to specify the commitish of the various apps that haven't yet been configured to run e2e tests as part of their builds.