### PR TITLE
Wait for travel advice to be published before asserting

### DIFF
--- a/spec/support/travel_advice_publisher_helpers.rb
+++ b/spec/support/travel_advice_publisher_helpers.rb
@@ -66,6 +66,11 @@ module TravelAdvicePublisherHelpers
     visit(Plek.find("travel-advice-publisher") + path)
   end
 
+  def reload_until_travel_advice_summary_displayed(url, summary)
+    reload_url_until_status_code(url, 200)
+    reload_url_until_match(url, :has_text?, ignore_quotes_regex(summary))
+  end
+
   def self.included(base)
     if SignonHelpers::use_signon?
       default_permissions = %w[gds_editor]

--- a/spec/travel_advice_publisher/creating_draft_spec.rb
+++ b/spec/travel_advice_publisher/creating_draft_spec.rb
@@ -33,8 +33,7 @@ feature "Creating a draft on Travel Advice Publisher", feature: true, travel_adv
 
   def then_i_can_preview_it_on_draft_gov_uk
     url = find_link("Preview saved version")[:href]
-    reload_url_until_status_code(url, 200)
-    reload_url_until_match(url, :has_text?, ignore_quotes_regex(summary))
+    reload_until_travel_advice_summary_displayed(url, summary)
 
     @window = window_opened_by { click_link("Preview saved version") }
     within_window(@window) do

--- a/spec/travel_advice_publisher/creating_live_spec.rb
+++ b/spec/travel_advice_publisher/creating_live_spec.rb
@@ -31,8 +31,7 @@ feature "Creating a live edition on Travel Advice Publisher", feature: true, tra
 
   def then_i_can_view_it_on_gov_uk
     url = find_link("view")[:href]
-    reload_url_until_status_code(url, 200)
-    reload_url_until_match(url, :has_text?, ignore_quotes_regex(summary))
+    reload_until_travel_advice_summary_displayed(url, summary)
 
     @window = window_opened_by { click_link("view") }
     within_window(@window) do

--- a/spec/travel_advice_publisher/upload_attachments_spec.rb
+++ b/spec/travel_advice_publisher/upload_attachments_spec.rb
@@ -33,7 +33,7 @@ feature "Upload attachments on Travel Advice Publisher", feature: true, travel_a
 
   def then_i_can_view_these_files_on_draft_gov_uk
     url = find_link("Preview saved version")[:href]
-    reload_url_until_status_code(url, 200)
+    reload_until_travel_advice_summary_displayed(url, summary)
 
     window = window_opened_by { click_link("Preview saved version") }
     within_window(window) do


### PR DESCRIPTION
We found that the upload attachments spec would sometimes fail to find
the text it was expecting even after the url returned a 200