### PR TITLE
Enable profiling when running tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ APPS = asset-manager content-store govuk-content-schemas government-frontend \
 	publishing-api router router-api rummager \
 	specialist-publisher static travel-advice-publisher
 
-TEST_CMD = docker-compose run publishing-e2e-tests bundle exec rspec
+TEST_CMD = docker-compose run publishing-e2e-tests bundle exec rspec --profile
 
 all: clone build start test stop
 


### PR DESCRIPTION
  Want to know if there are tests which are taking more than their
  fair share of time