### PR TITLE
Add end-to-end test for publishing a topic

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,7 @@
 APPS = asset-manager content-store govuk-content-schemas government-frontend \
 	publishing-api router router-api rummager \
-	specialist-publisher static travel-advice-publisher
+	specialist-publisher static travel-advice-publisher collections-publisher \
+	collections
 
 TEST_CMD = docker-compose run publishing-e2e-tests bundle exec rspec
 
@@ -20,6 +21,7 @@ build: down
 setup:
 	docker-compose run publishing-e2e-tests bash -c 'rm -rf /app/tmp/*'
 	docker-compose up -d elasticsearch
+	docker-compose up -d mysql
 	docker-compose run router-api bundle exec rake db:purge
 	docker-compose run draft-router-api bundle exec rake db:purge
 	docker-compose run content-store bundle exec rake db:purge
@@ -32,6 +34,7 @@ setup:
 	docker-compose run specialist-publisher bundle exec rake db:seed
 	docker-compose run specialist-publisher bundle exec rake publishing_api:publish_finders
 	docker-compose run travel-advice-publisher bundle exec rake db:seed
+	docker-compose run collections-publisher bundle exec rake db:setup
 	docker-compose run publishing-e2e-tests bundle exec rake wait_for_router
 
 up:
@@ -47,6 +50,9 @@ test-specialist-publisher:
 
 test-travel-advice-publisher:
 	$(TEST_CMD) --tag travel_advice_publisher
+
+test-collections-publisher:
+	$(TEST_CMD) --tag collections_publisher
 
 stop: down
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,6 +14,11 @@ services:
   db:
     image: postgres:9.6
 
+  mysql:
+    image: mysql:5.5.58
+    environment:
+      MYSQL_ROOT_PASSWORD: root
+
   mongo:
     image: mongo:2.4
 
@@ -68,6 +73,7 @@ services:
     links:
       - mongo
       - nginx-proxy:government-frontend.dev.gov.uk
+      - nginx-proxy:collections.dev.gov.uk
     ports:
       - "33054:3054"
       - "33055:3055"
@@ -273,6 +279,61 @@ services:
       SENTRY_DSN: http://user:password@error-handler.dev.gov.uk/123
     ports: []
 
+  collections-publisher: &collections-publisher
+      build: apps/collections-publisher
+      depends_on:
+        - publishing-api
+        - mysql
+        - rummager
+        - collections-publisher-worker
+        - diet-error-handler
+      environment:
+        SENTRY_CURRENT_ENV: collections-publisher
+        SENTRY_DSN: http://user:password@error-handler.dev.gov.uk/123
+        VIRTUAL_HOST: collections-publisher.dev.gov.uk
+      links:
+        - mysql
+        - nginx-proxy:rummager.dev.gov.uk
+        - nginx-proxy:publishing-api.dev.gov.uk
+        - nginx-proxy:error-handler.dev.gov.uk
+      ports:
+        - "33071:3071"
+      volumes:
+        - ./apps/collections-publisher/log:/app/log
+
+  collections-publisher-worker:
+    << : *collections-publisher
+    command: bundle exec sidekiq -C ./config/sidekiq.yml
+    depends_on:
+      - publishing-api
+      - diet-error-handler
+    environment:
+      SENTRY_CURRENT_ENV: collections-publisher-worker
+      SENTRY_DSN: http://user:password@error-handler.dev.gov.uk/123
+    ports: []
+
+  collections: &collections
+      build: apps/collections
+      depends_on:
+        - content-store
+        - static
+        - rummager
+        - diet-error-handler
+      environment:
+        PLEK_SERVICE_SEARCH_URI: http://rummager.dev.gov.uk
+        SENTRY_CURRENT_ENV: collections
+        SENTRY_DSN: http://user:password@error-handler.dev.gov.uk/123
+        VIRTUAL_HOST: collections.dev.gov.uk
+      links:
+        - nginx-proxy:rummager.dev.gov.uk
+        - nginx-proxy:content-store.dev.gov.uk
+        - nginx-proxy:static.dev.gov.uk
+        - nginx-proxy:error-handler.dev.gov.uk
+      ports:
+        - "33070:3070"
+      volumes:
+        - ./apps/collections/log:/app/log
+
   asset-manager: &asset-manager
     build: apps/asset-manager
     depends_on:
@@ -401,6 +462,8 @@ services:
       - government-frontend
       - draft-government-frontend
       - travel-advice-publisher
+      - collections-publisher
+      - collections
     links:
       - nginx-proxy:www.dev.gov.uk
       - nginx-proxy:assets-origin.dev.gov.uk
@@ -409,5 +472,7 @@ services:
       - nginx-proxy:draft-static.dev.gov.uk
       - nginx-proxy:specialist-publisher.dev.gov.uk
       - nginx-proxy:travel-advice-publisher.dev.gov.uk
+      - nginx-proxy:collections-publisher.dev.gov.uk
+      - nginx-proxy:collections.dev.gov.uk
     volumes:
       - ./tmp:/app/tmp

--- a/spec/collections_publisher/publishing_spec.rb
+++ b/spec/collections_publisher/publishing_spec.rb
@@ -1,0 +1,40 @@
+feature "Publishing a topic on Collections Publisher", collections_publisher: true do
+
+  let(:title) { title_with_timestamp }
+  let(:slug) { slug_with_timestamp }
+  let(:link) { "/topic/" + slug }
+
+  scenario "Publishing a topic" do
+    when_i_create_a_topic
+    when_i_publish_it
+    then_i_can_view_it_on_gov_uk
+  end
+
+  private
+
+  def when_i_create_a_topic
+    visit(Plek.find("collections-publisher") + "/topics/new")
+
+    fill_in "Slug", with: slug
+    fill_in "Title", with: title
+    fill_in "Description", with: paragraph_with_timestamp
+
+    click_button "Create"
+
+    expect(page).to have_text(title)
+  end
+
+  def when_i_publish_it
+    click_link("Publish topic")
+    expect(page).to have_text("published")
+  end
+
+  def then_i_can_view_it_on_gov_uk
+    url = find_link(link)[:href]
+    reload_url_until_status_code(url, 200)
+
+    click_link(link)
+    expect_rendering_application("collections")
+    expect(page).to have_content(title)
+  end
+end

--- a/spec/support/text_helpers.rb
+++ b/spec/support/text_helpers.rb
@@ -7,6 +7,9 @@ module TextHelpers
     "#{Faker::Book.title.gsub(/'/, '')} #{Time.now.to_i}"
   end
 
+  def slug_with_timestamp
+    "#{Faker::Internet.slug(nil, "-")}-#{Time.now.to_i}"
+  end
 
   def paragraph_with_timestamp
     "#{Faker::Lorem.paragraph} #{Time.now.to_i}"


### PR DESCRIPTION
This allows for increased confidence when publishing a topic from the collections publisher and provides a base for building end-to-end tests that will cover the collections applications.