### PR TITLE
Comply with linting rules

### DIFF
--- a/lib/retry_while_false.rb
+++ b/lib/retry_while_false.rb
@@ -1,6 +1,6 @@
 class RetryWhileFalse
   ## Inspired by (/copied from) https://github.com/natritmeyer/site_prism/blob/master/lib/site_prism/waiter.rb
-  def self.call(reload_seconds: 30, interval_seconds: nil, &block)
+  def self.call(reload_seconds: 30, interval_seconds: nil)
     start_time = Time.now.utc
     interval_seconds = interval_seconds || 0.5
     loop do
@@ -11,4 +11,3 @@ class RetryWhileFalse
     false
   end
 end
-

--- a/spec/collections_publisher/publishing_spec.rb
+++ b/spec/collections_publisher/publishing_spec.rb
@@ -1,5 +1,4 @@
 feature "Publishing a topic on Collections Publisher", collections_publisher: true do
-
   let(:title) { title_with_timestamp }
   let(:slug) { slug_with_timestamp }
   let(:link) { "/topic/" + slug }

--- a/spec/support/retry_helpers.rb
+++ b/spec/support/retry_helpers.rb
@@ -6,7 +6,7 @@ module RetryHelpers
 
   def reload_url_until_match(url, capybara_method, value, options = {})
     reload_options = {
-      fail_reason: "#{url} didn't match #{value} for #{capybara_method.to_s}",
+      fail_reason: "#{url} didn't match #{value} for #{capybara_method}",
       reload_seconds: options[:reload_seconds] || nil,
       interval_seconds: options[:interval_seconds] || nil,
     }
@@ -23,7 +23,7 @@ module RetryHelpers
     end
 
     code = HTTParty.head(url).code
-    unless (status_codes).include?(code)
+    unless status_codes.include?(code)
       raise "#{url} returned a status code of #{code}"
     end
 

--- a/spec/support/signon_helpers.rb
+++ b/spec/support/signon_helpers.rb
@@ -7,13 +7,13 @@ module SignonHelpers
     attr_reader :email, :passphrase, :number
     attr_accessor :two_step_verification_secret
 
-    @@next_user_number = 1
+    @next_user_number = 1
 
     def initialize(superuser: false)
-      @number = superuser ? 0 : User::get_next_user_number
+      @number = superuser ? 0 : User.get_next_user_number
 
-      if @number >= User::available_user_count
-        raise "Only #{User::available_user_count} available"
+      if @number >= User.available_user_count
+        raise "Only #{User.available_user_count} available"
       end
 
       @email = ENV.fetch("SIGNON_USER_#{@number}_EMAIL")
@@ -25,29 +25,29 @@ module SignonHelpers
     end
 
     def self.get_next_user_number
-      number = @@next_user_number
-      @@next_user_number += 1
+      number = @next_user_number
+      @next_user_number += 1
       number
     end
 
     def self.reset_next_user_number
-      @@next_user_number = 1
+      @next_user_number = 1
     end
 
     def self.available_user_count
       count = ENV['SIGNON_USER_COUNT']
       count.nil? ? nil : count.to_i
     end
-  end
 
-  def get_superuser
-    @@_superuser ||= User.new(superuser: true)
+    def self.superuser
+      @_superuser ||= User.new(superuser: true)
+    end
   end
 
   def get_next_user(permissions = {})
     user = User.new
 
-    signin_with_user(get_superuser)
+    signin_with_user(User.superuser)
     set_user_permissions(user.email, permissions)
 
     user

--- a/spec/support/signon_helpers.rb
+++ b/spec/support/signon_helpers.rb
@@ -68,8 +68,8 @@ module SignonHelpers
       first(:link, 'Sign out').click
     end
 
-    fill_in('Email', :with => user.email)
-    fill_in('Passphrase', :with => user.passphrase)
+    fill_in('Email', with: user.email)
+    fill_in('Passphrase', with: user.passphrase)
     click_button('Sign in')
 
     if current_path == '/users/two_step_verification/prompt'
@@ -84,14 +84,14 @@ module SignonHelpers
 
       fill_in(
         'Code from your phone',
-        :with => user.two_step_verification_code
+        with: user.two_step_verification_code
       )
 
       click_button('submit_code')
     elsif current_path == '/users/two_step_verification/session/new'
       fill_in(
         'Verification code',
-        :with => user.two_step_verification_code
+        with: user.two_step_verification_code
       )
 
       click_button('Sign in')
@@ -108,7 +108,7 @@ module SignonHelpers
     return if app_permissions.empty?
 
     visit_signon('/users')
-    fill_in('Name or email', :with => email)
+    fill_in('Name or email', with: email)
     click_button('Search')
 
     within('td', text: email) do

--- a/spec/support/text_helpers.rb
+++ b/spec/support/text_helpers.rb
@@ -4,11 +4,11 @@ module TextHelpers
   def title_with_timestamp
     # As quotes are changed to curly quotes by govspeak they are a pain to
     # match, so we strip them here
-    "#{Faker::Book.title.gsub(/'/, '')} #{Time.now.to_i}"
+    "#{Faker::Book.title.delete("'")} #{Time.now.to_i}"
   end
 
   def slug_with_timestamp
-    "#{Faker::Internet.slug(nil, "-")}-#{Time.now.to_i}"
+    "#{Faker::Internet.slug(nil, '-')}-#{Time.now.to_i}"
   end
 
   def paragraph_with_timestamp


### PR DESCRIPTION
Since we've only recently added a linter there are a few errors that
occur but aren't seen as CI lints a diff. This fixes them so that a
future developer doesn't get caught by them tweaking one of these files.