### PR TITLE
Add end to end tests for mainstream publisher

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 APPS = asset-manager content-store govuk-content-schemas government-frontend \
 	publishing-api router router-api rummager \
 	specialist-publisher static travel-advice-publisher collections-publisher \
-	collections
+	collections frontend publisher calendars
 
 TEST_CMD = docker-compose run publishing-e2e-tests bundle exec rspec
 
@@ -35,6 +35,8 @@ setup:
 	docker-compose run specialist-publisher bundle exec rake publishing_api:publish_finders
 	docker-compose run travel-advice-publisher bundle exec rake db:seed
 	docker-compose run collections-publisher bundle exec rake db:setup
+	docker-compose run publisher bundle exec rake db:setup
+	docker-compose run frontend bundle exec rake publishing_api:publish_special_routes
 	docker-compose run publishing-e2e-tests bundle exec rake wait_for_router
 
 up:
@@ -54,7 +56,11 @@ test-travel-advice-publisher:
 test-collections-publisher:
 	$(TEST_CMD) --tag collections_publisher
 
+test-publisher:
+	$(TEST_CMD) --tag publisher
+
 stop: down
 
 .PHONY: all $(APPS) clone down build setup start up test stop \
-	test-specialist-publisher test-travel-advice-publisher
+	test-specialist-publisher test-travel-advice-publisher \
+	test-collections-publisher test-publisher

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -74,6 +74,8 @@ services:
       - mongo
       - nginx-proxy:government-frontend.dev.gov.uk
       - nginx-proxy:collections.dev.gov.uk
+      - nginx-proxy:frontend.dev.gov.uk
+      - nginx-proxy:calendars.dev.gov.uk
     ports:
       - "33054:3054"
       - "33055:3055"
@@ -93,6 +95,7 @@ services:
     links:
       - mongo
       - nginx-proxy:draft-government-frontend.dev.gov.uk
+      - nginx-proxy:draft-frontend.dev.gov.uk
     ports:
       - "33154:3154"
       - "33155:3155"
@@ -336,6 +339,111 @@ services:
       volumes:
         - ./apps/collections/log:/app/log
 
+  publisher: &publisher
+      build: apps/publisher
+      depends_on:
+        - publishing-api
+        - publisher-worker
+        - diet-error-handler
+        - calendars
+      environment:
+        SENTRY_CURRENT_ENV: publisher
+        SENTRY_DSN: http://user:password@error-handler.dev.gov.uk/123
+        VIRTUAL_HOST: publisher.dev.gov.uk
+        GOVUK_CONTENT_SCHEMAS_PATH: /govuk-content-schemas/
+      volumes:
+        - apps/govuk-content-schemas/:/govuk-content-schemas/
+      links:
+        - redis
+        - mongo
+        - nginx-proxy:publishing-api.dev.gov.uk
+        - nginx-proxy:error-handler.dev.gov.uk
+        - nginx-proxy:calendars.dev.gov.uk
+      ports:
+        - "33000:3000"
+      volumes:
+        - ./apps/publisher/log:/app/log
+
+  publisher-worker:
+    << : *publisher
+    command: bundle exec sidekiq -C ./config/sidekiq.yml
+    depends_on:
+      - publishing-api
+      - diet-error-handler
+    environment:
+      SENTRY_CURRENT_ENV: publisher-worker
+      SENTRY_DSN: http://user:password@error-handler.dev.gov.uk/123
+    ports: []
+
+  frontend: &frontend
+    build: apps/frontend
+    depends_on:
+      - content-store
+      - static
+      - rummager
+      - diet-error-handler
+      - publishing-api
+    environment:
+      PLEK_SERVICE_SEARCH_URI: http://rummager.dev.gov.uk
+      SENTRY_CURRENT_ENV: frontend
+      SENTRY_DSN: http://user:password@error-handler.dev.gov.uk/123
+      VIRTUAL_HOST: frontend.dev.gov.uk
+    links:
+      - nginx-proxy:rummager.dev.gov.uk
+      - nginx-proxy:content-store.dev.gov.uk
+      - nginx-proxy:static.dev.gov.uk
+      - nginx-proxy:error-handler.dev.gov.uk
+      - nginx-proxy:publishing-api.dev.gov.uk
+    ports:
+      - "33005:3005"
+    volumes:
+      - ./apps/frontend/log:/app/log
+
+  draft-frontend:
+    << : *frontend
+    depends_on:
+      - draft-content-store
+      - draft-static
+      - rummager
+      - diet-error-handler
+    environment:
+      PORT: 3105
+      PLEK_HOSTNAME_PREFIX: draft-
+      PLEK_SERVICE_SEARCH_URI: http://rummager.dev.gov.uk
+      SENTRY_CURRENT_ENV: draft-frontend
+      SENTRY_DSN: http://user:password@error-handler.dev.gov.uk/123
+      VIRTUAL_HOST: draft-frontend.dev.gov.uk
+    links:
+      - nginx-proxy:rummager.dev.gov.uk
+      - nginx-proxy:draft-content-store.dev.gov.uk
+      - nginx-proxy:draft-static.dev.gov.uk
+      - nginx-proxy:error-handler.dev.gov.uk
+    ports:
+      - "33105:3105"
+
+  calendars: &calendars
+    build: apps/calendars
+    depends_on:
+      - rummager
+      - content-store
+      - static
+      - publishing-api
+      - diet-error-handler
+    environment:
+      SENTRY_CURRENT_ENV: calendars
+      SENTRY_DSN: http://user:password@error-handler.dev.gov.uk/123
+      VIRTUAL_HOST: calendars.dev.gov.uk
+    links:
+      - nginx-proxy:static.dev.gov.uk
+      - nginx-proxy:content-store.dev.gov.uk
+      - nginx-proxy:rummager.dev.gov.uk
+      - nginx-proxy:publishing-api.dev.gov.uk
+      - nginx-proxy:error-handler.dev.gov.uk
+    ports:
+      - "33011:3011"
+    volumes:
+      - ./apps/calendars/log:/app/log
+
   asset-manager: &asset-manager
     build: apps/asset-manager
     depends_on:
@@ -466,6 +574,9 @@ services:
       - travel-advice-publisher
       - collections-publisher
       - collections
+      - publisher
+      - frontend
+      - draft-frontend
     links:
       - nginx-proxy:www.dev.gov.uk
       - nginx-proxy:assets-origin.dev.gov.uk
@@ -476,5 +587,6 @@ services:
       - nginx-proxy:travel-advice-publisher.dev.gov.uk
       - nginx-proxy:collections-publisher.dev.gov.uk
       - nginx-proxy:collections.dev.gov.uk
+      - nginx-proxy:publisher.dev.gov.uk
     volumes:
       - ./tmp:/app/tmp

--- a/spec/collections_publisher/archiving_child_topic_spec.rb
+++ b/spec/collections_publisher/archiving_child_topic_spec.rb
@@ -34,6 +34,7 @@ feature "Archiving a child topic on Collections Publisher", collections_publishe
     window = window_opened_by { click_link(link) }
     within_window(window) do
       expect_rendering_application("collections")
+      expect_url_matches_live_gov_uk
       expect(page).to have_content(parent_title)
       expect(current_url).to eq(@published_parent_url)
     end

--- a/spec/collections_publisher/publishing_parent_and_child_topic_spec.rb
+++ b/spec/collections_publisher/publishing_parent_and_child_topic_spec.rb
@@ -53,9 +53,11 @@ feature "Publishing a parent and child topic on Collections Publisher", collecti
 
     click_link(link)
     expect_rendering_application("collections")
+    expect_url_matches_live_gov_uk
     expect(page).to have_content(child_title)
 
     first(:link, parent_title).click
+    expect_url_matches_live_gov_uk
     expect(current_url).to end_with(parent_slug)
   end
 end

--- a/spec/publisher/creating_draft_content_spec.rb
+++ b/spec/publisher/creating_draft_content_spec.rb
@@ -1,0 +1,31 @@
+feature "Creating draft content on Publisher", publisher: true do
+  include PublisherHelpers
+
+  let(:title) { title_with_timestamp }
+  let(:slug) { slug_with_timestamp }
+
+  scenario "Creating a draft artefact" do
+    when_i_create_a_new_artefact
+    then_i_can_preview_it_on_draft_gov_uk_and_was_rendered_by_frontend
+  end
+
+  private
+
+  def when_i_create_a_new_artefact
+    create_publisher_artefact(slug: slug, title: title)
+  end
+
+  def then_i_can_preview_it_on_draft_gov_uk_and_was_rendered_by_frontend
+    wait_for_draft_to_be_published
+
+    click_link("Preview")
+    expect(page).to have_content(title)
+    expect_url_matches_draft_gov_uk
+    expect_rendering_application("frontend")
+  end
+
+  def wait_for_draft_to_be_published
+    draft_url = find_link("Preview")[:href]
+    wait_for_artefact_to_be_viewable(draft_url)
+  end
+end

--- a/spec/publisher/publishing_content_to_frontend_spec.rb
+++ b/spec/publisher/publishing_content_to_frontend_spec.rb
@@ -1,0 +1,49 @@
+feature "Publishing content from Publisher to Frontend", publisher: true do
+  include PublisherHelpers
+
+  let(:title) { title_with_timestamp }
+  let(:slug) { slug_with_timestamp }
+  let(:subpart_title) { title_with_timestamp }
+
+  scenario "Publishing an artefact" do
+    given_there_is_a_draft_artefact_with_subpage
+    and_i_publish_it
+    then_i_can_view_the_artefact_on_gov_uk
+    and_i_can_view_the_subpage_on_gov_uk
+  end
+
+  private
+
+  def given_there_is_a_draft_artefact_with_subpage
+    create_publisher_artefact(slug: slug, title: title, format: "Guide")
+    add_part_to_artefact(title: title_with_timestamp)
+    @subpart_slug = add_part_to_artefact(title: subpart_title)
+  end
+
+  def and_i_publish_it
+    publish_artefact
+  end
+
+  def then_i_can_view_the_artefact_on_gov_uk
+    wait_for_artefact_to_be_published
+
+    click_link("View this on the GOV.UK website")
+    expect(page).to have_content(title)
+    expect_url_matches_live_gov_uk
+  end
+
+  def and_i_can_view_the_subpage_on_gov_uk
+    visit(subpage_url)
+    expect(page).to have_content(subpart_title)
+    expect_url_matches_live_gov_uk
+  end
+
+  def wait_for_artefact_to_be_published
+    @published_url = find_link("View this on the GOV.UK website")[:href]
+    wait_for_artefact_to_be_viewable(@published_url)
+  end
+
+  def subpage_url
+    [@published_url, @subpart_slug].join("/")
+  end
+end

--- a/spec/publisher/publishing_content_to_government_frontend_spec.rb
+++ b/spec/publisher/publishing_content_to_government_frontend_spec.rb
@@ -1,0 +1,40 @@
+feature "Publishing content from Publisher to Government Frontend", publisher: true do
+  include PublisherHelpers
+
+  let(:title) { title_with_timestamp }
+  let(:slug) { "help/" + slug_with_timestamp }
+
+  scenario "Publishing a Help guide" do
+    given_there_is_a_draft_help_guide
+    and_i_publish_it
+    then_i_can_view_it_on_gov_uk
+    and_it_was_rendered_by_government_frontend
+  end
+
+  private
+
+  def given_there_is_a_draft_help_guide
+    create_publisher_artefact(slug: slug, title: title, format: "Help page")
+  end
+
+  def and_i_publish_it
+    publish_artefact
+  end
+
+  def then_i_can_view_it_on_gov_uk
+    wait_for_artefact_to_be_published
+
+    click_link("View this on the GOV.UK website")
+    expect(page).to have_content(title)
+    expect_url_matches_live_gov_uk
+  end
+
+  def and_it_was_rendered_by_government_frontend
+    expect_rendering_application("government-frontend")
+  end
+
+  def wait_for_artefact_to_be_published
+    url = find_link("View this on the GOV.UK website")[:href]
+    wait_for_artefact_to_be_viewable(url)
+  end
+end

--- a/spec/publisher/removing_content_with_redirect_spec.rb
+++ b/spec/publisher/removing_content_with_redirect_spec.rb
@@ -1,0 +1,59 @@
+feature "Removing content by redirecting it from Publisher", publisher: true do
+  include PublisherHelpers
+
+  let(:title) { title_with_timestamp }
+  let(:slug) { slug_with_timestamp }
+  let(:redirect_url) { "https://www.gov.uk/help" }
+
+  scenario "Unpublishing an artefact" do
+    given_there_is_a_published_artefact_with_subpages
+    when_i_remove_the_published_artefact_with_a_redirect_to_help
+    then_visiting_the_artefact_redirects_to_help
+    and_visiting_a_subpage_redirects_to_help_with_slug
+  end
+
+  private
+
+  def given_there_is_a_published_artefact_with_subpages
+    create_publisher_artefact(slug: slug, title: title, format: "Guide")
+    add_part_to_artefact(title: title_with_timestamp)
+    @subpart_slug = add_part_to_artefact(title: title_with_timestamp)
+
+    publish_artefact
+    @published_url = find_link("View this on the GOV.UK website")[:href]
+    wait_for_artefact_to_be_viewable(@published_url)
+  end
+
+  def when_i_remove_the_published_artefact_with_a_redirect_to_help
+    switch_to_tab "Unpublish"
+
+    fill_in "redirect_url", with: redirect_url
+
+    page.accept_confirm do
+      click_button "Unpublish"
+    end
+
+    expect(page).to have_content("Content unpublished")
+  end
+
+  def then_visiting_the_artefact_redirects_to_help
+    reload_url_until_status_code(@published_url, 301, keep_retrying_while: [200])
+
+    visit(@published_url)
+
+    expect_url_matches_live_gov_uk
+    expect(page).to have_content("Help")
+    expect(current_url).to end_with("gov.uk/help")
+  end
+
+  def and_visiting_a_subpage_redirects_to_help_with_slug
+    reload_url_until_status_code(subpage_url, 301, keep_retrying_while: [200])
+
+    visit(subpage_url)
+    expect(current_url).to end_with("gov.uk/help/#{@subpart_slug}")
+  end
+
+  def subpage_url
+    [@published_url, @subpart_slug].join("/")
+  end
+end

--- a/spec/publisher/removing_content_without_redirect_spec.rb
+++ b/spec/publisher/removing_content_without_redirect_spec.rb
@@ -1,0 +1,52 @@
+feature "Removing content without a redirect from Publisher", publisher: true do
+  include PublisherHelpers
+
+  let(:title) { title_with_timestamp }
+  let(:slug) { slug_with_timestamp }
+
+  scenario "Unpublishing an artefact" do
+    given_a_published_artefact_with_subpages
+    and_i_remove_the_published_artefact_with_no_redirect
+    then_visiting_the_artefact_gives_a_410_gone_on_gov_uk
+    and_visiting_a_subpage_gives_a_404_on_gov_uk
+  end
+
+  private
+
+  def given_a_published_artefact_with_subpages
+    create_publisher_artefact(slug: slug, title: title, format: "Guide")
+
+    add_part_to_artefact(title: title_with_timestamp)
+    @subpart_slug = add_part_to_artefact(title: title_with_timestamp)
+
+    publish_artefact
+
+    @published_url = find_link("View this on the GOV.UK website")[:href]
+    wait_for_artefact_to_be_viewable(@published_url)
+  end
+
+  def and_i_remove_the_published_artefact_with_no_redirect
+    switch_to_tab "Unpublish"
+
+    page.accept_confirm do
+      click_button "Unpublish"
+    end
+
+    expect(page).to have_content("Content unpublished")
+  end
+
+  def then_visiting_the_artefact_gives_a_410_gone_on_gov_uk
+    reload_url_until_status_code(@published_url, 410, keep_retrying_while: [200])
+
+    visit(@published_url)
+    expect(page).to have_content("gone")
+  end
+
+  def and_visiting_a_subpage_gives_a_404_on_gov_uk
+    reload_url_until_status_code(subpage_url, 404, keep_retrying_while: [200])
+  end
+
+  def subpage_url
+    [@published_url, @subpart_slug].join("/")
+  end
+end

--- a/spec/publisher/updating_published_content_spec.rb
+++ b/spec/publisher/updating_published_content_spec.rb
@@ -1,0 +1,47 @@
+feature "Updating published content from Publisher", publisher: true do
+  include PublisherHelpers
+
+  let(:title) { title_with_timestamp }
+  let(:slug) { slug_with_timestamp }
+
+  scenario "Scheduling downtime for a transaction on Publisher" do
+    given_there_is_a_published_transaction_artefact
+    when_i_schedule_downtime_for_now_on_the_transaction
+    and_i_visit_the_transaction_on_gov_uk
+    then_the_downtime_message_is_shown
+  end
+
+  private
+
+  def given_there_is_a_published_transaction_artefact
+    create_publisher_artefact(slug: slug, title: title)
+    publish_artefact
+
+    @published_url = find_link("View this on the GOV.UK website")[:href]
+    wait_for_artefact_to_be_viewable(@published_url)
+  end
+
+  def when_i_schedule_downtime_for_now_on_the_transaction
+    visit_publisher("/downtimes")
+    click_link(title)
+
+    date = Date.today
+    fill_in_schedule_downtime_form(date)
+
+    @downtime_message = find_field("Message").value
+
+    click_button "Schedule downtime message"
+
+    expect(page).to have_text(title + " downtime message scheduled")
+  end
+
+  def and_i_visit_the_transaction_on_gov_uk
+    url = find_link("/" + slug)[:href]
+    reload_url_until_match(url, :has_text?, @downtime_message)
+    click_link("/" + slug)
+  end
+
+  def then_the_downtime_message_is_shown
+    expect(page).to have_text(@downtime_message)
+  end
+end

--- a/spec/specialist_publisher/change_note_spec.rb
+++ b/spec/specialist_publisher/change_note_spec.rb
@@ -53,6 +53,7 @@ feature "Change notes on Specialist Publisher", specialist_publisher: true do
     reload_url_until_match(url, :has_text?, ignore_quotes_regex(new_body))
 
     click_link("View on website")
+    expect_url_matches_live_gov_uk
     click_link("+ full page history")
     within("#full-history") do
       expect(page).to have_content(ignore_quotes_regex(change_note))

--- a/spec/specialist_publisher/creating_spec.rb
+++ b/spec/specialist_publisher/creating_spec.rb
@@ -24,7 +24,8 @@ feature "Creating a draft on Specialist Publisher", specialist_publisher: true d
     reload_url_until_status_code(url, 200)
 
     click_link("Preview draft")
-    expect_rendering_application("draft-government-frontend")
+    expect_rendering_application("government-frontend")
+    expect_url_matches_draft_gov_uk
     expect(page).to have_content(title)
   end
 end

--- a/spec/specialist_publisher/discarding_draft_spec.rb
+++ b/spec/specialist_publisher/discarding_draft_spec.rb
@@ -32,6 +32,7 @@ feature "Discarding a draft on Specialist Publisher", specialist_publisher: true
     reload_url_until_status_code(@url, 404, keep_retrying_while: 200)
 
     visit(@url)
+    expect_url_matches_draft_gov_uk
     expect(page).to have_text("Not found")
   end
 end

--- a/spec/specialist_publisher/editing_spec.rb
+++ b/spec/specialist_publisher/editing_spec.rb
@@ -35,7 +35,7 @@ feature "Editing with Specialist Publisher", specialist_publisher: true do
     reload_url_until_status_code(url, 200)
 
     click_link("Preview draft")
-    expect_rendering_application("draft-government-frontend")
+    expect_url_matches_draft_gov_uk
     expect(page).to have_content(new_title)
   end
 end

--- a/spec/specialist_publisher/publishing_spec.rb
+++ b/spec/specialist_publisher/publishing_spec.rb
@@ -31,6 +31,7 @@ feature "Publishing with Specialist Publisher", specialist_publisher: true do
 
     click_link("View on website")
     expect_rendering_application("government-frontend")
+    expect_url_matches_live_gov_uk
     expect(page).to have_content(title)
   end
 end

--- a/spec/specialist_publisher/unpublishing_spec.rb
+++ b/spec/specialist_publisher/unpublishing_spec.rb
@@ -38,6 +38,7 @@ feature "Unpublishing with Specialist Publisher", specialist_publisher: true do
     reload_url_until_status_code(@url, 410, keep_retrying_while: 200)
 
     visit(@url)
+    expect_url_matches_live_gov_uk
     expect(page).to have_content("gone")
   end
 end

--- a/spec/support/frontend_helpers.rb
+++ b/spec/support/frontend_helpers.rb
@@ -1,7 +1,7 @@
 module FrontendHelpers
   def expect_rendering_application(application)
     expect(page).to have_selector(
-      "meta[name='govuk:rendering-application'][content='#{application}']",
+      "meta[name='govuk:rendering-application'][content$='#{application}']",
       visible: false
     )
   end
@@ -10,6 +10,14 @@ module FrontendHelpers
     uploaded_file = HTTParty.get(link)
     file_contents = File.read(file_path, encoding: uploaded_file.body.encoding)
     expect(uploaded_file.body).to eq file_contents
+  end
+
+  def expect_url_matches_draft_gov_uk
+    expect(current_url).to start_with("http://draft-origin.dev.gov.uk/")
+  end
+
+  def expect_url_matches_live_gov_uk
+    expect(current_url).to start_with("http://www.dev.gov.uk/")
   end
 
   RSpec.configuration.include FrontendHelpers

--- a/spec/support/publisher_helpers.rb
+++ b/spec/support/publisher_helpers.rb
@@ -18,11 +18,29 @@ module PublisherHelpers
     select format, from: "Format"
   end
 
+  def publish_artefact
+    confirm_action(link: "2nd pair of eyes", button: "Send to 2nd pair of eyes")
+    confirm_action(link: "Skip review", button: "Skip review")
+    confirm_action(link: "Publish", button: "Send to publish")
+  end
+
   def confirm_action(link:, button:)
     click_link link
     click_button button
 
     expect(page).to have_text('Transaction edition was successfully updated.')
+  end
+
+  def add_part_to_artefact(title:, body: sentence)
+    click_link "Add new part"
+
+    slug = within("div#untitled-part") do
+      fill_in "Title", with: title
+      fill_in "Body", with: body
+      find_field("Slug").value
+    end
+    click_button "Save"
+    slug
   end
 
   def switch_to_tab(tab)

--- a/spec/support/publisher_helpers.rb
+++ b/spec/support/publisher_helpers.rb
@@ -1,0 +1,35 @@
+module PublisherHelpers
+  def visit_publisher(path = "/")
+    visit(Plek.find("publisher") + path)
+  end
+
+  def create_publisher_artefact(slug:, title:, format: "Transaction")
+    visit_publisher("/artefacts/new")
+
+    fill_in_new_artefact_form(title: title, slug: slug, format: format)
+
+    click_button "Save and go to item"
+    expect(page).to have_text(title)
+  end
+
+  def fill_in_new_artefact_form(title:, slug:, format:)
+    fill_in "Title", with: title
+    fill_in "Slug", with: slug
+    select format, from: "Format"
+  end
+
+  def confirm_action(link:, button:)
+    click_link link
+    click_button button
+
+    expect(page).to have_text('Transaction edition was successfully updated.')
+  end
+
+  def switch_to_tab(tab)
+    click_link tab
+  end
+
+  def wait_for_artefact_to_be_viewable(url)
+    reload_url_until_status_code(url, 200)
+  end
+end

--- a/spec/support/publisher_helpers.rb
+++ b/spec/support/publisher_helpers.rb
@@ -18,6 +18,12 @@ module PublisherHelpers
     select format, from: "Format"
   end
 
+  def fill_in_schedule_downtime_form(date)
+    select(date.day, from: "downtime_start_time_3i")
+    select(Date::MONTHNAMES[Date.today.month], from: "downtime_start_time_2i")
+    select(date.year, from: "downtime_start_time_1i")
+  end
+
   def publish_artefact
     confirm_action(link: "2nd pair of eyes", button: "Send to 2nd pair of eyes")
     confirm_action(link: "Skip review", button: "Skip review")

--- a/spec/support/publisher_helpers.rb
+++ b/spec/support/publisher_helpers.rb
@@ -34,7 +34,7 @@ module PublisherHelpers
     click_link link
     click_button button
 
-    expect(page).to have_text('Transaction edition was successfully updated.')
+    expect(page).to have_text("edition was successfully updated.")
   end
 
   def add_part_to_artefact(title:, body: sentence)

--- a/spec/travel_advice_publisher/creating_draft_spec.rb
+++ b/spec/travel_advice_publisher/creating_draft_spec.rb
@@ -37,7 +37,8 @@ feature "Creating a draft on Travel Advice Publisher", feature: true, travel_adv
 
     @window = window_opened_by { click_link("Preview saved version") }
     within_window(@window) do
-      expect_rendering_application("draft-government-frontend")
+      expect_rendering_application("government-frontend")
+      expect_url_matches_draft_gov_uk
       expect(page).to have_content(ignore_quotes_regex(summary))
     end
   end

--- a/spec/travel_advice_publisher/creating_live_spec.rb
+++ b/spec/travel_advice_publisher/creating_live_spec.rb
@@ -36,6 +36,7 @@ feature "Creating a live edition on Travel Advice Publisher", feature: true, tra
     @window = window_opened_by { click_link("view") }
     within_window(@window) do
       expect_rendering_application("government-frontend")
+      expect_url_matches_live_gov_uk
       expect(page).to have_content(ignore_quotes_regex(summary))
     end
   end

--- a/spec/travel_advice_publisher/upload_attachments_spec.rb
+++ b/spec/travel_advice_publisher/upload_attachments_spec.rb
@@ -37,7 +37,8 @@ feature "Upload attachments on Travel Advice Publisher", feature: true, travel_a
 
     window = window_opened_by { click_link("Preview saved version") }
     within_window(window) do
-      expect_rendering_application("draft-government-frontend")
+      expect_rendering_application("government-frontend")
+      expect_url_matches_draft_gov_uk
       expect(page).to have_content(ignore_quotes_regex(summary))
 
       image_url = find(".map img")[:src]


### PR DESCRIPTION
This will give increased confidence when creating drafts, publishing, and unpublishing artefacts from the mainstream publisher app to the frontend app.