### PR TITLE
Update postgres instance name to be more specific

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,7 +11,7 @@ services:
       - /var/run/docker.sock:/tmp/docker.sock
       - ./docker/nginx.tmpl:/app/nginx.tmpl
 
-  db:
+  postgres:
     image: postgres:9.6
 
   mysql:
@@ -189,7 +189,7 @@ services:
       SENTRY_DSN: http://user:password@error-handler.dev.gov.uk/123
       VIRTUAL_HOST: publishing-api.dev.gov.uk
     links:
-      - db
+      - postgres
       - redis
       # - rabbitmq
       - nginx-proxy:error-handler.dev.gov.uk
@@ -211,7 +211,7 @@ services:
       SENTRY_CURRENT_ENV: publishing-api-worker
       SENTRY_DSN: http://user:password@error-handler.dev.gov.uk/123
     links:
-      - db
+      - postgres
       - redis
       # - rabbitmq
       - nginx-proxy:content-store.dev.gov.uk

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -184,6 +184,7 @@ services:
       - publishing-api-worker
       - diet-error-handler
     environment:
+      DATABASE_URL: postgresql://postgres@postgres/publishing-api
       DISABLE_QUEUE_PUBLISHER: 1
       SENTRY_CURRENT_ENV: publishing-api
       SENTRY_DSN: http://user:password@error-handler.dev.gov.uk/123
@@ -207,6 +208,7 @@ services:
       - draft-content-store
       - diet-error-handler
     environment:
+      DATABASE_URL: postgresql://postgres@postgres/publishing-api
       DISABLE_QUEUE_PUBLISHER: 1
       SENTRY_CURRENT_ENV: publishing-api-worker
       SENTRY_DSN: http://user:password@error-handler.dev.gov.uk/123


### PR DESCRIPTION
This will bring it into line with the other external service instances such as mongo, redis and mysql