### PR TITLE
Only keep Jenkins jobs for 30 days

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -8,6 +8,12 @@ node {
   def govuk = load("/var/lib/jenkins/groovy_scripts/govuk_jenkinslib.groovy")
 
   properties([
+    [$class: "BuildDiscarderProperty",
+     strategy: [$class: "LogRotator",
+                artifactDaysToKeepStr: "",
+                artifactDaysToKeepStr: "",
+                daysToKeepStr: "30",
+                numToKeepStr: ""]],
     parameters([
       stringParam(
         defaultValue: "",


### PR DESCRIPTION
The builds for the test-against branch are taking up 7.5GB on space on
the Jenkins master, which is a bit too much. Therefore, only keep the
builds for the last 30 days.