### PR TITLE
Remove the expectation on page content for deleting a draft

### DIFF
--- a/spec/specialist_publisher/discarding_draft_spec.rb
+++ b/spec/specialist_publisher/discarding_draft_spec.rb
@@ -29,7 +29,7 @@ feature "Discarding a draft on Specialist Publisher", specialist_publisher: true
   end
 
   def then_i_get_a_404_on_draft_gov_uk
-    reload_url_until_status_code(@url, 404, keep_retrying_while: 200)
+    expect_status_code_eventually(@url, 404, keep_retrying_while: 200)
 
     visit(@url)
     expect_url_matches_draft_gov_uk

--- a/spec/specialist_publisher/discarding_draft_spec.rb
+++ b/spec/specialist_publisher/discarding_draft_spec.rb
@@ -33,6 +33,5 @@ feature "Discarding a draft on Specialist Publisher", specialist_publisher: true
 
     visit(@url)
     expect_url_matches_draft_gov_uk
-    expect(page).to have_text("Not found")
   end
 end

--- a/spec/support/retry_helpers.rb
+++ b/spec/support/retry_helpers.rb
@@ -66,6 +66,8 @@ module RetryHelpers
     end
   end
 
+  alias expect_status_code_eventually reload_url_until_status_code
+
   def retry_while_false(fail_reason: nil, reload_seconds: nil, interval_seconds: nil, &block)
     reload_seconds = reload_seconds || RSpec.configuration.reload_page_wait_time
     interval_seconds = interval_seconds || 0.5


### PR DESCRIPTION
Just check the response code, which is what I think is really being
tested here.