### PR TITLE
Remove overwriting of database_url

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -187,7 +187,6 @@ services:
       - publishing-api-worker
       - diet-error-handler
     environment:
-      DATABASE_URL: postgresql://postgres@postgres/publishing-api
       DISABLE_QUEUE_PUBLISHER: 1
       SENTRY_CURRENT_ENV: publishing-api
       SENTRY_DSN: http://user:password@error-handler.dev.gov.uk/123
@@ -211,7 +210,6 @@ services:
       - draft-content-store
       - diet-error-handler
     environment:
-      DATABASE_URL: postgresql://postgres@postgres/publishing-api
       DISABLE_QUEUE_PUBLISHER: 1
       SENTRY_CURRENT_ENV: publishing-api-worker
       SENTRY_DSN: http://user:password@error-handler.dev.gov.uk/123


### PR DESCRIPTION
DATABASE_URL gets defined by the Dockerfile inside the publishing-api repo.  We shouldn't overwrite it unnecessarily, as it introduces two places to change.