### PR TITLE
Remove hardcoded domains in the FrontendHelpers class

### DIFF
--- a/spec/support/frontend_helpers.rb
+++ b/spec/support/frontend_helpers.rb
@@ -13,11 +13,11 @@ module FrontendHelpers
   end
 
   def expect_url_matches_draft_gov_uk
-    expect(current_url).to start_with("http://draft-origin.dev.gov.uk/")
+    expect(current_url).to start_with(Plek.find("draft-origin"))
   end
 
   def expect_url_matches_live_gov_uk
-    expect(current_url).to start_with("http://www.dev.gov.uk/")
+    expect(current_url).to start_with(Plek.new.website_root)
   end
 
   RSpec.configuration.include FrontendHelpers


### PR DESCRIPTION
Instead, use Plek to find the domains. This means that the tests adapt
to suit their environment, e.g. running with a different root domain,
or running using HTTPS.