### PR TITLE
Revert "Add -- to git checkout to disambiguate"

### DIFF
--- a/bin/clone-app
+++ b/bin/clone-app
@@ -31,7 +31,7 @@ private
   end
 
   def checkout
-    unless system "git checkout -f #{commitish} --"
+    unless system "git checkout -f #{commitish}"
       raise "git failed to checkout #{commitish}"
     end
   end


### PR DESCRIPTION
This appears to hindering more than helping.

This reverts commit 5ab73bc0855ff1888c094a2809b86d48de896c63.