### PR TITLE
Update PhantomJS to use prebuilt version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,17 +1,11 @@
 FROM ruby:2.3.1
 RUN apt-get update -qq && apt-get upgrade -y
 
+RUN curl -sL https://deb.nodesource.com/setup_9.x | bash -
 RUN apt-get install -y build-essential libpq-dev libxml2-dev libxslt1-dev \
-    libfontconfig1 libfontconfig1-dev && \
+    libfontconfig1 libfontconfig1-dev nodejs && \
   apt-get clean
-
-ENV PHANTOM_JS phantomjs-2.1.1-linux-x86_64
-
-RUN wget https://bitbucket.org/ariya/phantomjs/downloads/$PHANTOM_JS.tar.bz2 && \
-  tar xvjf $PHANTOM_JS.tar.bz2 && \
-  mv $PHANTOM_JS /usr/local/share && \
-  ln -sf /usr/local/share/$PHANTOM_JS/bin/phantomjs /bin/phantomjs && \
-  rm $PHANTOM_JS.tar.bz2
+RUN npm install -g phantomjs-prebuilt@2 --unsafe-perm
 
 ENV APP_HOME /app
 RUN mkdir $APP_HOME


### PR DESCRIPTION
This resolves an issue we see with the main PhantomJS package being rate
limited and returning 429s from bitbucket which results in failing
builds.