### PR TITLE
Add tag for tests which cover frontend

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -63,8 +63,12 @@ test-publisher:
 test-manuals-publisher:
 	$(TEST_CMD) --tag manuals_publisher
 
+test-frontend:
+	$(TEST_CMD) --tag frontend
+
 stop: down
 
 .PHONY: all $(APPS) clone down build setup start up test stop \
 	test-specialist-publisher test-travel-advice-publisher \
-	test-collections-publisher test-publisher test-manuals-publisher
+	test-collections-publisher test-publisher test-manuals-publisher \
+	test-frontend

--- a/spec/publisher/creating_draft_content_spec.rb
+++ b/spec/publisher/creating_draft_content_spec.rb
@@ -1,4 +1,4 @@
-feature "Creating draft content on Publisher", publisher: true do
+feature "Creating draft content on Publisher", publisher: true, frontend: true do
   include PublisherHelpers
 
   let(:title) { title_with_timestamp }

--- a/spec/publisher/publishing_content_to_frontend_spec.rb
+++ b/spec/publisher/publishing_content_to_frontend_spec.rb
@@ -1,4 +1,4 @@
-feature "Publishing content from Publisher to Frontend", publisher: true do
+feature "Publishing content from Publisher to Frontend", publisher: true, frontend: true do
   include PublisherHelpers
 
   let(:title) { title_with_timestamp }

--- a/spec/publisher/updating_published_content_spec.rb
+++ b/spec/publisher/updating_published_content_spec.rb
@@ -1,4 +1,4 @@
-feature "Updating published content from Publisher", publisher: true do
+feature "Updating published content from Publisher", publisher: true, frontend: true do
   include PublisherHelpers
 
   let(:title) { title_with_timestamp }


### PR DESCRIPTION
Only half of the mainstream publisher tests cover frontend.  The other half cover government-frontend.

This tag will be used as part of the frontend repos CI, so it runs only the necessary tests.