### PR TITLE
Mark updating published content scenario as skipped

### DIFF
--- a/spec/publisher/updating_published_content_spec.rb
+++ b/spec/publisher/updating_published_content_spec.rb
@@ -4,7 +4,7 @@ feature "Updating published content from Publisher", publisher: true, frontend: 
   let(:title) { title_with_timestamp }
   let(:slug) { slug_with_timestamp }
 
-  scenario "Scheduling downtime for a transaction on Publisher" do
+  scenario "Scheduling downtime for a transaction on Publisher", skip: true do
     given_there_is_a_published_transaction_artefact
     when_i_schedule_downtime_for_now_on_the_transaction
     and_i_visit_the_transaction_on_gov_uk


### PR DESCRIPTION
This test has failed twice on changes unrelated to this code.

From the stack trace poltergeist can't find the link at the click_link
step within and_i_visit_the_transaction_on_gov_uk

From the screenshot it looks like the capybara session has already
clicked the link.

Failing builds:
https://ci.integration.publishing.service.gov.uk/job/publishing-e2e-tests/job/test-against/2101/
https://ci.integration.publishing.service.gov.uk/job/publishing-e2e-tests/job/test-against/2109/

Stack trace:

```
  1) Updating published content from Publisher Scheduling downtime for a transaction on Publisher
     Failure/Error: click_link("/" + slug)

     Capybara::Poltergeist::TimeoutError:
       Timed out waiting for response to {"id":"afc4b878-a4df-4c00-9354-2e247feb2757","name":"click","args":[8,2]}. It's possible that this happened because something took a very long time (for example a page load was slow). If so, setting the Poltergeist :timeout option to a higher value will help (see the docs for details). If increasing the timeout does not help, this is probably a bug in Poltergeist - please report it to the issue tracker.
     # /usr/local/bundle/gems/poltergeist-1.8.1/lib/capybara/poltergeist/web_socket_server.rb:98:in `rescue in send'
     # /usr/local/bundle/gems/poltergeist-1.8.1/lib/capybara/poltergeist/web_socket_server.rb:94:in `send'
     # /usr/local/bundle/gems/poltergeist-1.8.1/lib/capybara/poltergeist/server.rb:33:in `send'
     # /usr/local/bundle/gems/poltergeist-1.8.1/lib/capybara/poltergeist/browser.rb:340:in `command'
     # /usr/local/bundle/gems/poltergeist-1.8.1/lib/capybara/poltergeist/browser.rb:180:in `click'
     # /usr/local/bundle/gems/poltergeist-1.8.1/lib/capybara/poltergeist/node.rb:17:in `command'
     # /usr/local/bundle/gems/poltergeist-1.8.1/lib/capybara/poltergeist/node.rb:131:in `click'
     # /usr/local/bundle/gems/capybara-2.7.1/lib/capybara/node/element.rb:135:in `block in click'
     # /usr/local/bundle/gems/capybara-2.7.1/lib/capybara/node/base.rb:85:in `synchronize'
     # /usr/local/bundle/gems/capybara-2.7.1/lib/capybara/node/element.rb:135:in `click'
     # /usr/local/bundle/gems/capybara-2.7.1/lib/capybara/node/actions.rb:27:in `click_link'
     # /usr/local/bundle/gems/capybara-2.7.1/lib/capybara/session.rb:699:in `block (2 levels) in <class:Session>'
     # /usr/local/bundle/gems/capybara-2.7.1/lib/capybara/dsl.rb:52:in `block (2 levels) in <module:DSL>'
     # ./spec/publisher/updating_published_content_spec.rb:41:in `and_i_visit_the_transaction_on_gov_uk'
     # ./spec/publisher/updating_published_content_spec.rb:10:in `block (2 levels) in <top (required)>'
     # ------------------
     # --- Caused by: ---
     # Errno::EAGAIN:
     #   Resource temporarily unavailable
     #   /usr/local/bundle/gems/poltergeist-1.8.1/lib/capybara/poltergeist/web_socket_server.rb:78:in `receive'
```