### PR TITLE
Drop the commit link from Slack message

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -253,7 +253,7 @@ node("publishing-e2e-tests") {
       echo("Did this fail due to a flaky test? See: https://github.com/alphagov/publishing-e2e-tests/blob/master/CONTRIBUTING.md")
       // Send a slack message just when tests fail within docker context
       def message = "Publishing end-to-end tests <${BUILD_URL}|failed>"
-      message += (params.ORIGIN_REPO && params.ORIGIN_COMMIT) ? " for <https://github.com/alphagov/${params.ORIGIN_REPO}/commit/${params.ORIGIN_COMMIT}|${params.ORIGIN_REPO}>" : ""
+      message += (params.ORIGIN_REPO) ? " for ${params.ORIGIN_REPO}" : ""
       slackSend(color: "#d40100", channel: "#end-to-end-tests", message: message)
 
       throw e


### PR DESCRIPTION
This seems to fail to link intermittently and I've no idea why. It
doesn't really offer a huge amount of value having a link to a commit
anyway so this seems a reasonable quick fix (well retreat).