### PR TITLE
Update Dockerfile and Makefile to run tests in rails production env

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -29,7 +29,7 @@ kill:
 	$(DOCKER_COMPOSE_CMD) rm -f
 
 build: kill
-	$(DOCKER_COMPOSE_CMD) build
+	COMPILE_ASSETS=true $(DOCKER_COMPOSE_CMD) build
 
 setup:
 	$(DOCKER_COMPOSE_CMD) run publishing-e2e-tests bash -c 'find /app/tmp -name .keep -prune -o -type f -exec rm {} \;'
@@ -42,7 +42,7 @@ setup:
 	$(DOCKER_COMPOSE_CMD) run -e RUMMAGER_INDEX=all rummager bundle exec rake rummager:create_all_indices
 	$(DOCKER_COMPOSE_CMD) run publishing-api-worker rails runner 'Sidekiq::Queue.new.clear'
 	# $(DOCKER_COMPOSE_CMD) run publishing-api-worker bundle exec rails runner 'channel = Bunny.new.start.create_channel;Bunny::Exchange.new(channel, :topic, "published_documents")'
-	$(DOCKER_COMPOSE_CMD) run specialist-publisher bundle exec rake db:seed
+	$(DOCKER_COMPOSE_CMD) run -e RUN_SEEDS_IN_PRODUCTION=true specialist-publisher bundle exec rake db:seed
 	$(DOCKER_COMPOSE_CMD) run specialist-publisher bundle exec rake publishing_api:publish_finders
 	$(DOCKER_COMPOSE_CMD) run travel-advice-publisher bundle exec rake db:seed
 	$(DOCKER_COMPOSE_CMD) run manuals-publisher bundle exec rake db:seed

--- a/docker-compose.development.yml
+++ b/docker-compose.development.yml
@@ -1,4 +1,4 @@
-version: '3'
+version: '3.4'
 
 # In development we want to expose the ports to the host machine on a predictable port.
 # This allows for easier manual testing of the services

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -110,7 +110,6 @@ services:
     environment:
       GOVUK_APP_NAME: draft-router
       PLEK_HOSTNAME_PREFIX: draft-
-      PLEK_SERVICE_ERRBIT_URI: http://error-handler.dev.gov.uk
       ROUTER_BACKEND_HEADER_TIMEOUT: 60s
       ROUTER_PUBADDR: ":3154"
       ROUTER_APIADDR: ":3155"
@@ -200,12 +199,10 @@ services:
     environment:
       << : *x-production
       MONGO_WRITE_CONCERN: 1
-      ERRBIT_ENVIRONMENT_NAME: draft-content-store
       GOVUK_APP_NAME: draft-content-store
       LOG_PATH: log/draft.log
       MONGODB_URI: mongodb://mongo/draft-content-store
       PLEK_HOSTNAME_PREFIX: draft-
-      PLEK_SERVICE_ERRBIT_URI: http://error-handler.dev.gov.uk
       PORT: 3100
       SENTRY_CURRENT_ENV: draft-content-store
       SENTRY_DSN: http://user:password@error-handler.dev.gov.uk/123
@@ -587,7 +584,6 @@ services:
       PLEK_HOSTNAME_PREFIX: draft-
       LOG_PATH: log/draft.log
       SENTRY_CURRENT_ENV: draft-manuals-frontend
-      PLEK_SERVICE_ERRBIT_URI: http://error-handler.dev.gov.uk
       SENTRY_DSN: http://user:password@error-handler.dev.gov.uk/123
       VIRTUAL_HOST: draft-manuals-frontend.dev.gov.uk
       PORT: 3172
@@ -669,8 +665,6 @@ services:
       - nginx-proxy:error-handler.dev.gov.uk
     environment:
       << : *x-production
-      ERRBIT_API_KEY: 1
-      ERRBIT_ENVIRONMENT_NAME: asset-manager
       REDIS_HOST: redis
       SENTRY_CURRENT_ENV: asset-manager
       SENTRY_DSN: http://user:password@error-handler.dev.gov.uk/123
@@ -691,8 +685,6 @@ services:
       - diet-error-handler
     environment:
       << : *x-production
-      ERRBIT_API_KEY: 1
-      ERRBIT_ENVIRONMENT_NAME: asset-manager-worker
       REDIS_HOST: redis
       SENTRY_CURRENT_ENV: asset-manager-worker
       SENTRY_DSN: http://user:password@error-handler.dev.gov.uk/123
@@ -709,8 +701,6 @@ services:
       - diet-error-handler
     environment:
       << : *x-production
-      ERRBIT_API_KEY: 1
-      ERRBIT_ENVIRONMENT_NAME: static
       LOG_PATH: log/live.log
       SENTRY_CURRENT_ENV: static
       SENTRY_DSN: http://user:password@error-handler.dev.gov.uk/123
@@ -727,12 +717,9 @@ services:
     command: bundle exec unicorn -p 3113
     environment:
       << : *x-production
-      ERRBIT_API_KEY: 1
-      ERRBIT_ENVIRONMENT_NAME: draft-static
       GOVUK_APP_NAME: draft-static
       LOG_PATH: log/draft.log
       PLEK_HOSTNAME_PREFIX: draft-
-      PLEK_SERVICE_ERRBIT_URI: http://error-handler.dev.gov.uk
       PORT: 3113
       REDIS_URL: redis://redis/1
       SENTRY_CURRENT_ENV: draft-static
@@ -756,8 +743,6 @@ services:
     environment:
       << : *x-production
       MEMCACHE_SERVERS: memcached
-      ERRBIT_API_KEY: 1
-      ERRBIT_ENVIRONMENT_NAME: government-frontend
       LOG_PATH: log/live.log
       SENTRY_CURRENT_ENV: government-frontend
       SENTRY_DSN: http://user:password@error-handler.dev.gov.uk/123
@@ -783,12 +768,9 @@ services:
     environment:
       << : *x-production
       MEMCACHE_SERVERS: memcached
-      ERRBIT_API_KEY: 1
-      ERRBIT_ENVIRONMENT_NAME: draft-government-frontend
       GOVUK_APP_NAME: draft-government-frontend
       LOG_PATH: log/draft.log
       PLEK_HOSTNAME_PREFIX: draft-
-      PLEK_SERVICE_ERRBIT_URI: http://error-handler.dev.gov.uk
       PORT: 3190
       SENTRY_CURRENT_ENV: draft-government-frontend
       SENTRY_DSN: http://user:password@error-handler.dev.gov.uk/123

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,6 +15,9 @@ services:
     healthcheck:
       test: "psql --username 'postgres' -c 'SELECT 1'"
 
+  memcached:
+    image: memcached:alpine
+
   mysql:
     image: mysql:5.5.58
     environment:
@@ -51,6 +54,7 @@ services:
     depends_on:
       - diet-error-handler
     environment:
+      RAILS_ENV: production
       GOVUK_APP_NAME: rummager
       LOG_PATH: log/live.log
       SENTRY_CURRENT_ENV: rummager
@@ -118,6 +122,8 @@ services:
     depends_on:
       - diet-error-handler
     environment:
+      RAILS_ENV: production
+      SECRET_KEY_BASE: 875c6bf4c48da9bb41f4cfd25d09bf5e2a62d88b39efc4bd9c498e6c8f61e4df740af87386f97269525e01b5f74402512eb6a4723882579f10aa95f6e2971fc2
       LOG_PATH: log/live.log
       SENTRY_CURRENT_ENV: router-api
       SENTRY_DSN: http://user:password@error-handler.dev.gov.uk/123
@@ -135,6 +141,8 @@ services:
     << : *router-api
     command: bundle exec unicorn -p 3156
     environment:
+      RAILS_ENV: production
+      SECRET_KEY_BASE: 875c6bf4c48da9bb41f4cfd25d09bf5e2a62d88b39efc4bd9c498e6c8f61e4df740af87386f97269525e01b5f74402512eb6a4723882579f10aa95f6e2971fc2
       GOVUK_APP_NAME: draft-router-api
       LOG_PATH: log/draft.log
       MONGODB_URI: mongodb://mongo/draft-router
@@ -159,6 +167,11 @@ services:
       - router-api
       - diet-error-handler
     environment:
+      RAILS_ENV: production
+      GOVUK_APP_DOMAIN: dev.gov.uk
+      GOVUK_WEBSITE_ROOT: http://www.dev.gov.uk
+      SECRET_KEY_BASE: 875c6bf4c48da9bb41f4cfd25d09bf5e2a62d88b39efc4bd9c498e6c8f61e4df740af87386f97269525e01b5f74402512eb6a4723882579f10aa95f6e2971fc2
+      MONGO_WRITE_CONCERN: 1
       LOG_PATH: log/live.log
       SENTRY_CURRENT_ENV: content-store
       SENTRY_DSN: http://user:password@error-handler.dev.gov.uk/123
@@ -180,6 +193,11 @@ services:
       - draft-router-api
       - diet-error-handler
     environment:
+      RAILS_ENV: production
+      GOVUK_APP_DOMAIN: dev.gov.uk
+      GOVUK_WEBSITE_ROOT: http://www.dev.gov.uk
+      SECRET_KEY_BASE: 875c6bf4c48da9bb41f4cfd25d09bf5e2a62d88b39efc4bd9c498e6c8f61e4df740af87386f97269525e01b5f74402512eb6a4723882579f10aa95f6e2971fc2
+      MONGO_WRITE_CONCERN: 1
       ERRBIT_ENVIRONMENT_NAME: draft-content-store
       GOVUK_APP_NAME: draft-content-store
       LOG_PATH: log/draft.log
@@ -204,10 +222,16 @@ services:
       - publishing-api-worker
       - diet-error-handler
     environment:
+      RAILS_ENV: production
+      GOVUK_APP_DOMAIN: dev.gov.uk
+      GOVUK_WEBSITE_ROOT: http://www.dev.gov.uk
+      SECRET_KEY_BASE: 875c6bf4c48da9bb41f4cfd25d09bf5e2a62d88b39efc4bd9c498e6c8f61e4df740af87386f97269525e01b5f74402512eb6a4723882579f10aa95f6e2971fc2
+      DISABLE_DATABASE_ENVIRONMENT_CHECK: 1
       DISABLE_QUEUE_PUBLISHER: 1
       SENTRY_CURRENT_ENV: publishing-api
       SENTRY_DSN: http://user:password@error-handler.dev.gov.uk/123
       VIRTUAL_HOST: publishing-api.dev.gov.uk
+      GDS_SSO_STRATEGY: mock
     links:
       - postgres
       - redis
@@ -227,6 +251,9 @@ services:
       - draft-content-store
       - diet-error-handler
     environment:
+      RAILS_ENV: production
+      GOVUK_APP_DOMAIN: dev.gov.uk
+      GOVUK_WEBSITE_ROOT: http://www.dev.gov.uk
       DISABLE_QUEUE_PUBLISHER: 1
       SENTRY_CURRENT_ENV: publishing-api-worker
       SENTRY_DSN: http://user:password@error-handler.dev.gov.uk/123
@@ -245,13 +272,24 @@ services:
       - ./apps/publishing-api/log:/app/log
 
   specialist-publisher:
-    build: apps/specialist-publisher
+    build:
+      context: apps/specialist-publisher
+      args:
+        - COMPILE_ASSETS
     command: bundle exec unicorn -p 3064
     depends_on:
       - publishing-api
       - asset-manager
       - diet-error-handler
     environment:
+      RAILS_ENV: production
+      GOVUK_APP_DOMAIN: dev.gov.uk
+      GOVUK_WEBSITE_ROOT: http://www.dev.gov.uk
+      GOVUK_ASSET_ROOT: http://assets-origin.dev.gov.uk
+      SECRET_TOKEN: 875c6bf4c48da9bb41f4cfd25d09bf5e2a62d88b39efc4bd9c498e6c8f61e4df740af87386f97269525e01b5f74402512eb6a4723882579f10aa95f6e2971fc2
+      MONGO_WRITE_CONCERN: 1
+      RAILS_SERVE_STATIC_FILES: "true"
+      GDS_SSO_STRATEGY: mock
       SENTRY_CURRENT_ENV: specialist-publisher
       SENTRY_DSN: http://user:password@error-handler.dev.gov.uk/123
       VIRTUAL_HOST: specialist-publisher.dev.gov.uk
@@ -267,7 +305,10 @@ services:
       - ./apps/specialist-publisher/log:/app/log
 
   travel-advice-publisher: &travel-advice-publisher
-    build: apps/travel-advice-publisher
+    build:
+      context: apps/travel-advice-publisher
+      args:
+        - COMPILE_ASSETS
     command: bundle exec unicorn -p 3035
     depends_on:
       - publishing-api
@@ -277,6 +318,13 @@ services:
       - travel-advice-publisher-worker
       - diet-error-handler
     environment:
+      RAILS_ENV: production
+      GOVUK_APP_DOMAIN: dev.gov.uk
+      GOVUK_WEBSITE_ROOT: http://www.dev.gov.uk
+      GOVUK_ASSET_ROOT: http://assets-origin.dev.gov.uk
+      SECRET_KEY_BASE: 875c6bf4c48da9bb41f4cfd25d09bf5e2a62d88b39efc4bd9c498e6c8f61e4df740af87386f97269525e01b5f74402512eb6a4723882579f10aa95f6e2971fc2
+      RAILS_SERVE_STATIC_FILES: "true"
+      GDS_SSO_STRATEGY: mock
       SENTRY_CURRENT_ENV: travel-advice-publisher
       SENTRY_DSN: http://user:password@error-handler.dev.gov.uk/123
       VIRTUAL_HOST: travel-advice-publisher.dev.gov.uk
@@ -302,12 +350,19 @@ services:
     healthcheck:
       disable: true
     environment:
+      RAILS_ENV: production
+      GOVUK_APP_DOMAIN: dev.gov.uk
+      GOVUK_WEBSITE_ROOT: http://www.dev.gov.uk
+      GOVUK_ASSET_ROOT: http://assets-origin.dev.gov.uk
       SENTRY_CURRENT_ENV: travel-advice-publisher-worker
       SENTRY_DSN: http://user:password@error-handler.dev.gov.uk/123
     ports: []
 
   collections-publisher: &collections-publisher
-    build: apps/collections-publisher
+    build:
+      context: apps/collections-publisher
+      args:
+        - COMPILE_ASSETS
     command: bundle exec unicorn -p 3071
     depends_on:
       - publishing-api
@@ -316,6 +371,14 @@ services:
       - collections-publisher-worker
       - diet-error-handler
     environment:
+      RAILS_ENV: production
+      GOVUK_APP_DOMAIN: dev.gov.uk
+      GOVUK_WEBSITE_ROOT: http://www.dev.gov.uk
+      GOVUK_ASSET_ROOT: http://assets-origin.dev.gov.uk
+      SECRET_KEY_BASE: 875c6bf4c48da9bb41f4cfd25d09bf5e2a62d88b39efc4bd9c498e6c8f61e4df740af87386f97269525e01b5f74402512eb6a4723882579f10aa95f6e2971fc2
+      DISABLE_DATABASE_ENVIRONMENT_CHECK: 1
+      RAILS_SERVE_STATIC_FILES: "true"
+      GDS_SSO_STRATEGY: mock
       SENTRY_CURRENT_ENV: collections-publisher
       SENTRY_DSN: http://user:password@error-handler.dev.gov.uk/123
       VIRTUAL_HOST: collections-publisher.dev.gov.uk
@@ -336,6 +399,8 @@ services:
       - publishing-api
       - diet-error-handler
     environment:
+      RAILS_ENV: production
+      GOVUK_APP_DOMAIN: dev.gov.uk
       SENTRY_CURRENT_ENV: collections-publisher-worker
       SENTRY_DSN: http://user:password@error-handler.dev.gov.uk/123
     healthcheck:
@@ -343,7 +408,10 @@ services:
     ports: []
 
   collections: &collections
-    build: apps/collections
+    build:
+      context: apps/collections
+      args:
+        - COMPILE_ASSETS
     command: bundle exec unicorn -p 3070
     depends_on:
       - content-store
@@ -351,6 +419,12 @@ services:
       - rummager
       - diet-error-handler
     environment:
+      RAILS_ENV: production
+      GOVUK_APP_DOMAIN: dev.gov.uk
+      GOVUK_WEBSITE_ROOT: http://www.dev.gov.uk
+      GOVUK_ASSET_ROOT: http://assets-origin.dev.gov.uk
+      SECRET_TOKEN: 875c6bf4c48da9bb41f4cfd25d09bf5e2a62d88b39efc4bd9c498e6c8f61e4df740af87386f97269525e01b5f74402512eb6a4723882579f10aa95f6e2971fc2
+      RAILS_SERVE_STATIC_FILES: "true"
       PLEK_SERVICE_SEARCH_URI: http://rummager.dev.gov.uk
       SENTRY_CURRENT_ENV: collections
       SENTRY_DSN: http://user:password@error-handler.dev.gov.uk/123
@@ -366,7 +440,10 @@ services:
       - ./apps/collections/log:/app/log
 
   publisher: &publisher
-    build: apps/publisher
+    build:
+      context: apps/publisher
+      args:
+        - COMPILE_ASSETS
     command: bundle exec unicorn -p 3000
     depends_on:
       - publishing-api
@@ -374,7 +451,17 @@ services:
       - diet-error-handler
       - calendars
     environment:
+      RAILS_ENV: production
+      GOVUK_APP_DOMAIN: dev.gov.uk
+      GOVUK_WEBSITE_ROOT: http://www.dev.gov.uk
+      GOVUK_ASSET_ROOT: http://assets-origin.dev.gov.uk
+      SECRET_KEY_BASE: 875c6bf4c48da9bb41f4cfd25d09bf5e2a62d88b39efc4bd9c498e6c8f61e4df740af87386f97269525e01b5f74402512eb6a4723882579f10aa95f6e2971fc2
+      RAILS_SERVE_STATIC_FILES: "true"
+      DISABLE_SECURE_COOKIES: "true"
+      DISABLE_EMAIL: "true"
+      JWT_AUTH_SECRET: bobajob
       SENTRY_CURRENT_ENV: publisher
+      GDS_SSO_STRATEGY: mock
       SENTRY_DSN: http://user:password@error-handler.dev.gov.uk/123
       VIRTUAL_HOST: publisher.dev.gov.uk
       GOVUK_CONTENT_SCHEMAS_PATH: /govuk-content-schemas/
@@ -398,6 +485,10 @@ services:
       - publishing-api
       - diet-error-handler
     environment:
+      RAILS_ENV: production
+      GOVUK_ASSET_ROOT: http://assets-origin.dev.gov.uk
+      GOVUK_APP_DOMAIN: dev.gov.uk
+      GOVUK_WEBSITE_ROOT: http://www.dev.gov.uk
       SENTRY_CURRENT_ENV: publisher-worker
       SENTRY_DSN: http://user:password@error-handler.dev.gov.uk/123
     healthcheck:
@@ -405,7 +496,10 @@ services:
     ports: []
 
   frontend: &frontend
-    build: apps/frontend
+    build:
+      context: apps/frontend
+      args:
+        - COMPILE_ASSETS
     command: bundle exec unicorn -p 3005
     depends_on:
       - content-store
@@ -414,6 +508,12 @@ services:
       - diet-error-handler
       - publishing-api
     environment:
+      RAILS_ENV: production
+      GOVUK_APP_DOMAIN: dev.gov.uk
+      GOVUK_WEBSITE_ROOT: http://www.dev.gov.uk
+      GOVUK_ASSET_ROOT: http://assets-origin.dev.gov.uk
+      SECRET_KEY_BASE: 875c6bf4c48da9bb41f4cfd25d09bf5e2a62d88b39efc4bd9c498e6c8f61e4df740af87386f97269525e01b5f74402512eb6a4723882579f10aa95f6e2971fc2
+      RAILS_SERVE_STATIC_FILES: "true"
       PLEK_SERVICE_SEARCH_URI: http://rummager.dev.gov.uk
       SENTRY_CURRENT_ENV: frontend
       SENTRY_DSN: http://user:password@error-handler.dev.gov.uk/123
@@ -438,6 +538,12 @@ services:
       - rummager
       - diet-error-handler
     environment:
+      RAILS_ENV: production
+      GOVUK_APP_DOMAIN: dev.gov.uk
+      GOVUK_WEBSITE_ROOT: http://www.dev.gov.uk
+      GOVUK_ASSET_ROOT: http://assets-origin.dev.gov.uk
+      SECRET_KEY_BASE: 875c6bf4c48da9bb41f4cfd25d09bf5e2a62d88b39efc4bd9c498e6c8f61e4df740af87386f97269525e01b5f74402512eb6a4723882579f10aa95f6e2971fc2
+      RAILS_SERVE_STATIC_FILES: "true"
       PORT: 3105
       PLEK_HOSTNAME_PREFIX: draft-
       PLEK_SERVICE_SEARCH_URI: http://rummager.dev.gov.uk
@@ -453,7 +559,10 @@ services:
       - "3105"
 
   manuals-publisher: &manuals-publisher
-    build: apps/manuals-publisher
+    build:
+      context: apps/manuals-publisher
+      args:
+        - COMPILE_ASSETS
     command: bundle exec unicorn -p 3205
     depends_on:
       - publishing-api
@@ -464,6 +573,13 @@ services:
       - diet-error-handler
       - whitehall
     environment:
+      RAILS_ENV: production
+      GOVUK_APP_DOMAIN: dev.gov.uk
+      GOVUK_WEBSITE_ROOT: http://www.dev.gov.uk
+      GOVUK_ASSET_ROOT: http://assets-origin.dev.gov.uk
+      SECRET_TOKEN: 875c6bf4c48da9bb41f4cfd25d09bf5e2a62d88b39efc4bd9c498e6c8f61e4df740af87386f97269525e01b5f74402512eb6a4723882579f10aa95f6e2971fc2
+      RAILS_SERVE_STATIC_FILES: "true"
+      GDS_SSO_STRATEGY: mock
       SENTRY_CURRENT_ENV: manuals-publisher
       SENTRY_DSN: http://user:password@error-handler.dev.gov.uk/123
       VIRTUAL_HOST: manuals-publisher.dev.gov.uk
@@ -486,6 +602,10 @@ services:
       - publishing-api
       - diet-error-handler
     environment:
+      RAILS_ENV: production
+      GOVUK_APP_DOMAIN: dev.gov.uk
+      GOVUK_WEBSITE_ROOT: http://www.dev.gov.uk
+      GOVUK_ASSET_ROOT: http://assets-origin.dev.gov.uk
       SENTRY_CURRENT_ENV: manuals-publisher-worker
       SENTRY_DSN: http://user:password@error-handler.dev.gov.uk/123
     healthcheck:
@@ -493,13 +613,22 @@ services:
     ports: []
 
   manuals-frontend: &manuals-frontend
-    build: apps/manuals-frontend
+    build:
+      context: apps/manuals-frontend
+      args:
+        - COMPILE_ASSETS
     command: bundle exec unicorn -p 3072
     depends_on:
       - content-store
       - static
       - diet-error-handler
     environment:
+      RAILS_ENV: production
+      GOVUK_APP_DOMAIN: dev.gov.uk
+      GOVUK_WEBSITE_ROOT: http://www.dev.gov.uk
+      GOVUK_ASSET_ROOT: http://assets-origin.dev.gov.uk
+      SECRET_KEY_BASE: 875c6bf4c48da9bb41f4cfd25d09bf5e2a62d88b39efc4bd9c498e6c8f61e4df740af87386f97269525e01b5f74402512eb6a4723882579f10aa95f6e2971fc2
+      RAILS_SERVE_STATIC_FILES: "true"
       SENTRY_CURRENT_ENV: manuals-frontend
       SENTRY_DSN: http://user:password@error-handler.dev.gov.uk/123
       VIRTUAL_HOST: manuals-frontend.dev.gov.uk
@@ -520,6 +649,11 @@ services:
       - draft-static
       - diet-error-handler
     environment:
+      RAILS_ENV: production
+      GOVUK_APP_DOMAIN: dev.gov.uk
+      GOVUK_WEBSITE_ROOT: http://www.dev.gov.uk
+      SECRET_KEY_BASE: 875c6bf4c48da9bb41f4cfd25d09bf5e2a62d88b39efc4bd9c498e6c8f61e4df740af87386f97269525e01b5f74402512eb6a4723882579f10aa95f6e2971fc2
+      RAILS_SERVE_STATIC_FILES: "true"
       PLEK_HOSTNAME_PREFIX: draft-
       LOG_PATH: log/draft.log
       SENTRY_CURRENT_ENV: draft-manuals-frontend
@@ -535,7 +669,10 @@ services:
       - "3172"
 
   calendars: &calendars
-    build: apps/calendars
+    build:
+      context: apps/calendars
+      args:
+        - COMPILE_ASSETS
     command: bundle exec unicorn -p 3011
     depends_on:
       - rummager
@@ -544,6 +681,12 @@ services:
       - publishing-api
       - diet-error-handler
     environment:
+      RAILS_ENV: production
+      GOVUK_APP_DOMAIN: dev.gov.uk
+      GOVUK_WEBSITE_ROOT: http://www.dev.gov.uk
+      GOVUK_ASSET_ROOT: http://assets-origin.dev.gov.uk
+      SECRET_KEY_BASE: 875c6bf4c48da9bb41f4cfd25d09bf5e2a62d88b39efc4bd9c498e6c8f61e4df740af87386f97269525e01b5f74402512eb6a4723882579f10aa95f6e2971fc2
+      RAILS_SERVE_STATIC_FILES: "true"
       SENTRY_CURRENT_ENV: calendars
       SENTRY_DSN: http://user:password@error-handler.dev.gov.uk/123
       VIRTUAL_HOST: calendars.dev.gov.uk
@@ -559,7 +702,10 @@ services:
       - ./apps/calendars/log:/app/log
 
   whitehall: &whitehall
-    build: apps/whitehall
+    build:
+      context: apps/whitehall
+      args:
+        - COMPILE_ASSETS
     command: bundle exec unicorn -p 3020
     depends_on:
       - publishing-api
@@ -568,7 +714,15 @@ services:
       - asset-manager
       - diet-error-handler
     environment:
+      RAILS_ENV: production
+      GOVUK_APP_DOMAIN: dev.gov.uk
+      GOVUK_WEBSITE_ROOT: http://www.dev.gov.uk
+      GOVUK_ASSET_ROOT: http://assets-origin.dev.gov.uk
+      GOVUK_ASSET_HOST: http://static.dev.gov.uk
+      SECRET_KEY_BASE: 875c6bf4c48da9bb41f4cfd25d09bf5e2a62d88b39efc4bd9c498e6c8f61e4df740af87386f97269525e01b5f74402512eb6a4723882579f10aa95f6e2971fc2
+      RAILS_SERVE_STATIC_FILES: "true"
       SENTRY_CURRENT_ENV: whitehall
+      DISABLE_DATABASE_ENVIRONMENT_CHECK: 1
       SENTRY_DSN: http://user:password@error-handler.dev.gov.uk/123
       VIRTUAL_HOST: whitehall-admin.dev.gov.uk
     links:
@@ -597,12 +751,17 @@ services:
       - nginx-proxy:error-handler.dev.gov.uk
     environment:
       FAKE_S3_HOST: http://127.0.0.1
+      RAILS_ENV: production
+      GOVUK_APP_DOMAIN: dev.gov.uk
+      SECRET_KEY_BASE: 875c6bf4c48da9bb41f4cfd25d09bf5e2a62d88b39efc4bd9c498e6c8f61e4df740af87386f97269525e01b5f74402512eb6a4723882579f10aa95f6e2971fc2
       ERRBIT_API_KEY: 1
       ERRBIT_ENVIRONMENT_NAME: asset-manager
       REDIS_HOST: redis
       SENTRY_CURRENT_ENV: asset-manager
       SENTRY_DSN: http://user:password@error-handler.dev.gov.uk/123
       VIRTUAL_HOST: asset-manager.dev.gov.uk
+      GDS_SSO_STRATEGY: mock
+      ALLOW_FAKE_S3_IN_PRODUCTION_FOR_PUBLISHING_E2E_TESTS: "true"
     ports:
       - "3037"
     volumes:
@@ -617,11 +776,14 @@ services:
       - diet-error-handler
     environment:
       FAKE_S3_HOST: http://127.0.0.1
+      RAILS_ENV: production
+      GOVUK_APP_DOMAIN: dev.gov.uk
       ERRBIT_API_KEY: 1
       ERRBIT_ENVIRONMENT_NAME: asset-manager-worker
       REDIS_HOST: redis
       SENTRY_CURRENT_ENV: asset-manager-worker
       SENTRY_DSN: http://user:password@error-handler.dev.gov.uk/123
+      ALLOW_FAKE_S3_IN_PRODUCTION_FOR_PUBLISHING_E2E_TESTS: "true"
     healthcheck:
       disable: true
     ports: []
@@ -632,6 +794,10 @@ services:
     depends_on:
       - diet-error-handler
     environment:
+      RAILS_ENV: production
+      SECRET_KEY_BASE: 875c6bf4c48da9bb41f4cfd25d09bf5e2a62d88b39efc4bd9c498e6c8f61e4df740af87386f97269525e01b5f74402512eb6a4723882579f10aa95f6e2971fc2
+      GOVUK_APP_DOMAIN: dev.gov.uk
+      GOVUK_WEBSITE_ROOT: http://www.dev.gov.uk
       ERRBIT_API_KEY: 1
       ERRBIT_ENVIRONMENT_NAME: static
       LOG_PATH: log/live.log
@@ -649,6 +815,10 @@ services:
     << : *static
     command: bundle exec unicorn -p 3113
     environment:
+      RAILS_ENV: production
+      SECRET_KEY_BASE: 875c6bf4c48da9bb41f4cfd25d09bf5e2a62d88b39efc4bd9c498e6c8f61e4df740af87386f97269525e01b5f74402512eb6a4723882579f10aa95f6e2971fc2
+      GOVUK_APP_DOMAIN: dev.gov.uk
+      GOVUK_WEBSITE_ROOT: http://www.dev.gov.uk
       ERRBIT_API_KEY: 1
       ERRBIT_ENVIRONMENT_NAME: draft-static
       GOVUK_APP_NAME: draft-static
@@ -674,7 +844,12 @@ services:
       - content-store
       - static
       - diet-error-handler
+      - memcached
     environment:
+      MEMCACHE_SERVERS: memcached
+      RAILS_ENV: production
+      GOVUK_APP_DOMAIN: dev.gov.uk
+      SECRET_KEY_BASE: 875c6bf4c48da9bb41f4cfd25d09bf5e2a62d88b39efc4bd9c498e6c8f61e4df740af87386f97269525e01b5f74402512eb6a4723882579f10aa95f6e2971fc2
       ERRBIT_API_KEY: 1
       ERRBIT_ENVIRONMENT_NAME: government-frontend
       LOG_PATH: log/live.log
@@ -698,7 +873,12 @@ services:
       - draft-content-store
       - draft-static
       - diet-error-handler
+      - memcached
     environment:
+      MEMCACHE_SERVERS: memcached
+      RAILS_ENV: production
+      GOVUK_APP_DOMAIN: dev.gov.uk
+      SECRET_KEY_BASE: 875c6bf4c48da9bb41f4cfd25d09bf5e2a62d88b39efc4bd9c498e6c8f61e4df740af87386f97269525e01b5f74402512eb6a4723882579f10aa95f6e2971fc2
       ERRBIT_API_KEY: 1
       ERRBIT_ENVIRONMENT_NAME: draft-government-frontend
       GOVUK_APP_NAME: draft-government-frontend

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,17 @@
-version: '3'
+version: '3.4'
+
+x-production: &x-production
+  RAILS_ENV: production
+  GOVUK_APP_DOMAIN: dev.gov.uk
+  GOVUK_WEBSITE_ROOT: http://www.dev.gov.uk
+  GOVUK_ASSET_ROOT: http://assets-origin.dev.gov.uk
+  SECRET_KEY_BASE: 875c6bf4c48da9bb41f4cfd25d09bf5e2a62d88b39efc4bd9c498e6c8f61e4df740af87386f97269525e01b5f74402512eb6a4723882579f10aa95f6e2971fc2
+  SECRET_TOKEN: 875c6bf4c48da9bb41f4cfd25d09bf5e2a62d88b39efc4bd9c498e6c8f61e4df740af87386f97269525e01b5f74402512eb6a4723882579f10aa95f6e2971fc2
+  DISABLE_DATABASE_ENVIRONMENT_CHECK: 1
+  RAILS_SERVE_STATIC_FILES: "true"
+  GDS_SSO_STRATEGY: mock
 
 services:
-
   nginx-proxy:
     image: jwilder/nginx-proxy:latest
     ports:
@@ -54,7 +64,7 @@ services:
     depends_on:
       - diet-error-handler
     environment:
-      RAILS_ENV: production
+      << : *x-production
       GOVUK_APP_NAME: rummager
       LOG_PATH: log/live.log
       SENTRY_CURRENT_ENV: rummager
@@ -122,8 +132,7 @@ services:
     depends_on:
       - diet-error-handler
     environment:
-      RAILS_ENV: production
-      SECRET_KEY_BASE: 875c6bf4c48da9bb41f4cfd25d09bf5e2a62d88b39efc4bd9c498e6c8f61e4df740af87386f97269525e01b5f74402512eb6a4723882579f10aa95f6e2971fc2
+      << : *x-production
       LOG_PATH: log/live.log
       SENTRY_CURRENT_ENV: router-api
       SENTRY_DSN: http://user:password@error-handler.dev.gov.uk/123
@@ -141,8 +150,7 @@ services:
     << : *router-api
     command: bundle exec unicorn -p 3156
     environment:
-      RAILS_ENV: production
-      SECRET_KEY_BASE: 875c6bf4c48da9bb41f4cfd25d09bf5e2a62d88b39efc4bd9c498e6c8f61e4df740af87386f97269525e01b5f74402512eb6a4723882579f10aa95f6e2971fc2
+      << : *x-production
       GOVUK_APP_NAME: draft-router-api
       LOG_PATH: log/draft.log
       MONGODB_URI: mongodb://mongo/draft-router
@@ -167,10 +175,7 @@ services:
       - router-api
       - diet-error-handler
     environment:
-      RAILS_ENV: production
-      GOVUK_APP_DOMAIN: dev.gov.uk
-      GOVUK_WEBSITE_ROOT: http://www.dev.gov.uk
-      SECRET_KEY_BASE: 875c6bf4c48da9bb41f4cfd25d09bf5e2a62d88b39efc4bd9c498e6c8f61e4df740af87386f97269525e01b5f74402512eb6a4723882579f10aa95f6e2971fc2
+      << : *x-production
       MONGO_WRITE_CONCERN: 1
       LOG_PATH: log/live.log
       SENTRY_CURRENT_ENV: content-store
@@ -193,10 +198,7 @@ services:
       - draft-router-api
       - diet-error-handler
     environment:
-      RAILS_ENV: production
-      GOVUK_APP_DOMAIN: dev.gov.uk
-      GOVUK_WEBSITE_ROOT: http://www.dev.gov.uk
-      SECRET_KEY_BASE: 875c6bf4c48da9bb41f4cfd25d09bf5e2a62d88b39efc4bd9c498e6c8f61e4df740af87386f97269525e01b5f74402512eb6a4723882579f10aa95f6e2971fc2
+      << : *x-production
       MONGO_WRITE_CONCERN: 1
       ERRBIT_ENVIRONMENT_NAME: draft-content-store
       GOVUK_APP_NAME: draft-content-store
@@ -222,16 +224,11 @@ services:
       - publishing-api-worker
       - diet-error-handler
     environment:
-      RAILS_ENV: production
-      GOVUK_APP_DOMAIN: dev.gov.uk
-      GOVUK_WEBSITE_ROOT: http://www.dev.gov.uk
-      SECRET_KEY_BASE: 875c6bf4c48da9bb41f4cfd25d09bf5e2a62d88b39efc4bd9c498e6c8f61e4df740af87386f97269525e01b5f74402512eb6a4723882579f10aa95f6e2971fc2
-      DISABLE_DATABASE_ENVIRONMENT_CHECK: 1
+      << : *x-production
       DISABLE_QUEUE_PUBLISHER: 1
       SENTRY_CURRENT_ENV: publishing-api
       SENTRY_DSN: http://user:password@error-handler.dev.gov.uk/123
       VIRTUAL_HOST: publishing-api.dev.gov.uk
-      GDS_SSO_STRATEGY: mock
     links:
       - postgres
       - redis
@@ -251,9 +248,7 @@ services:
       - draft-content-store
       - diet-error-handler
     environment:
-      RAILS_ENV: production
-      GOVUK_APP_DOMAIN: dev.gov.uk
-      GOVUK_WEBSITE_ROOT: http://www.dev.gov.uk
+      << : *x-production
       DISABLE_QUEUE_PUBLISHER: 1
       SENTRY_CURRENT_ENV: publishing-api-worker
       SENTRY_DSN: http://user:password@error-handler.dev.gov.uk/123
@@ -282,14 +277,8 @@ services:
       - asset-manager
       - diet-error-handler
     environment:
-      RAILS_ENV: production
-      GOVUK_APP_DOMAIN: dev.gov.uk
-      GOVUK_WEBSITE_ROOT: http://www.dev.gov.uk
-      GOVUK_ASSET_ROOT: http://assets-origin.dev.gov.uk
-      SECRET_TOKEN: 875c6bf4c48da9bb41f4cfd25d09bf5e2a62d88b39efc4bd9c498e6c8f61e4df740af87386f97269525e01b5f74402512eb6a4723882579f10aa95f6e2971fc2
+      << : *x-production
       MONGO_WRITE_CONCERN: 1
-      RAILS_SERVE_STATIC_FILES: "true"
-      GDS_SSO_STRATEGY: mock
       SENTRY_CURRENT_ENV: specialist-publisher
       SENTRY_DSN: http://user:password@error-handler.dev.gov.uk/123
       VIRTUAL_HOST: specialist-publisher.dev.gov.uk
@@ -318,13 +307,7 @@ services:
       - travel-advice-publisher-worker
       - diet-error-handler
     environment:
-      RAILS_ENV: production
-      GOVUK_APP_DOMAIN: dev.gov.uk
-      GOVUK_WEBSITE_ROOT: http://www.dev.gov.uk
-      GOVUK_ASSET_ROOT: http://assets-origin.dev.gov.uk
-      SECRET_KEY_BASE: 875c6bf4c48da9bb41f4cfd25d09bf5e2a62d88b39efc4bd9c498e6c8f61e4df740af87386f97269525e01b5f74402512eb6a4723882579f10aa95f6e2971fc2
-      RAILS_SERVE_STATIC_FILES: "true"
-      GDS_SSO_STRATEGY: mock
+      << : *x-production
       SENTRY_CURRENT_ENV: travel-advice-publisher
       SENTRY_DSN: http://user:password@error-handler.dev.gov.uk/123
       VIRTUAL_HOST: travel-advice-publisher.dev.gov.uk
@@ -350,10 +333,7 @@ services:
     healthcheck:
       disable: true
     environment:
-      RAILS_ENV: production
-      GOVUK_APP_DOMAIN: dev.gov.uk
-      GOVUK_WEBSITE_ROOT: http://www.dev.gov.uk
-      GOVUK_ASSET_ROOT: http://assets-origin.dev.gov.uk
+      << : *x-production
       SENTRY_CURRENT_ENV: travel-advice-publisher-worker
       SENTRY_DSN: http://user:password@error-handler.dev.gov.uk/123
     ports: []
@@ -371,14 +351,7 @@ services:
       - collections-publisher-worker
       - diet-error-handler
     environment:
-      RAILS_ENV: production
-      GOVUK_APP_DOMAIN: dev.gov.uk
-      GOVUK_WEBSITE_ROOT: http://www.dev.gov.uk
-      GOVUK_ASSET_ROOT: http://assets-origin.dev.gov.uk
-      SECRET_KEY_BASE: 875c6bf4c48da9bb41f4cfd25d09bf5e2a62d88b39efc4bd9c498e6c8f61e4df740af87386f97269525e01b5f74402512eb6a4723882579f10aa95f6e2971fc2
-      DISABLE_DATABASE_ENVIRONMENT_CHECK: 1
-      RAILS_SERVE_STATIC_FILES: "true"
-      GDS_SSO_STRATEGY: mock
+      << : *x-production
       SENTRY_CURRENT_ENV: collections-publisher
       SENTRY_DSN: http://user:password@error-handler.dev.gov.uk/123
       VIRTUAL_HOST: collections-publisher.dev.gov.uk
@@ -399,8 +372,7 @@ services:
       - publishing-api
       - diet-error-handler
     environment:
-      RAILS_ENV: production
-      GOVUK_APP_DOMAIN: dev.gov.uk
+      << : *x-production
       SENTRY_CURRENT_ENV: collections-publisher-worker
       SENTRY_DSN: http://user:password@error-handler.dev.gov.uk/123
     healthcheck:
@@ -419,12 +391,7 @@ services:
       - rummager
       - diet-error-handler
     environment:
-      RAILS_ENV: production
-      GOVUK_APP_DOMAIN: dev.gov.uk
-      GOVUK_WEBSITE_ROOT: http://www.dev.gov.uk
-      GOVUK_ASSET_ROOT: http://assets-origin.dev.gov.uk
-      SECRET_TOKEN: 875c6bf4c48da9bb41f4cfd25d09bf5e2a62d88b39efc4bd9c498e6c8f61e4df740af87386f97269525e01b5f74402512eb6a4723882579f10aa95f6e2971fc2
-      RAILS_SERVE_STATIC_FILES: "true"
+      << : *x-production
       PLEK_SERVICE_SEARCH_URI: http://rummager.dev.gov.uk
       SENTRY_CURRENT_ENV: collections
       SENTRY_DSN: http://user:password@error-handler.dev.gov.uk/123
@@ -451,17 +418,11 @@ services:
       - diet-error-handler
       - calendars
     environment:
-      RAILS_ENV: production
-      GOVUK_APP_DOMAIN: dev.gov.uk
-      GOVUK_WEBSITE_ROOT: http://www.dev.gov.uk
-      GOVUK_ASSET_ROOT: http://assets-origin.dev.gov.uk
-      SECRET_KEY_BASE: 875c6bf4c48da9bb41f4cfd25d09bf5e2a62d88b39efc4bd9c498e6c8f61e4df740af87386f97269525e01b5f74402512eb6a4723882579f10aa95f6e2971fc2
-      RAILS_SERVE_STATIC_FILES: "true"
+      << : *x-production
       DISABLE_SECURE_COOKIES: "true"
       DISABLE_EMAIL: "true"
-      JWT_AUTH_SECRET: bobajob
+      JWT_AUTH_SECRET: fakejwtsecret
       SENTRY_CURRENT_ENV: publisher
-      GDS_SSO_STRATEGY: mock
       SENTRY_DSN: http://user:password@error-handler.dev.gov.uk/123
       VIRTUAL_HOST: publisher.dev.gov.uk
       GOVUK_CONTENT_SCHEMAS_PATH: /govuk-content-schemas/
@@ -485,10 +446,7 @@ services:
       - publishing-api
       - diet-error-handler
     environment:
-      RAILS_ENV: production
-      GOVUK_ASSET_ROOT: http://assets-origin.dev.gov.uk
-      GOVUK_APP_DOMAIN: dev.gov.uk
-      GOVUK_WEBSITE_ROOT: http://www.dev.gov.uk
+      << : *x-production
       SENTRY_CURRENT_ENV: publisher-worker
       SENTRY_DSN: http://user:password@error-handler.dev.gov.uk/123
     healthcheck:
@@ -508,12 +466,7 @@ services:
       - diet-error-handler
       - publishing-api
     environment:
-      RAILS_ENV: production
-      GOVUK_APP_DOMAIN: dev.gov.uk
-      GOVUK_WEBSITE_ROOT: http://www.dev.gov.uk
-      GOVUK_ASSET_ROOT: http://assets-origin.dev.gov.uk
-      SECRET_KEY_BASE: 875c6bf4c48da9bb41f4cfd25d09bf5e2a62d88b39efc4bd9c498e6c8f61e4df740af87386f97269525e01b5f74402512eb6a4723882579f10aa95f6e2971fc2
-      RAILS_SERVE_STATIC_FILES: "true"
+      << : *x-production
       PLEK_SERVICE_SEARCH_URI: http://rummager.dev.gov.uk
       SENTRY_CURRENT_ENV: frontend
       SENTRY_DSN: http://user:password@error-handler.dev.gov.uk/123
@@ -538,12 +491,7 @@ services:
       - rummager
       - diet-error-handler
     environment:
-      RAILS_ENV: production
-      GOVUK_APP_DOMAIN: dev.gov.uk
-      GOVUK_WEBSITE_ROOT: http://www.dev.gov.uk
-      GOVUK_ASSET_ROOT: http://assets-origin.dev.gov.uk
-      SECRET_KEY_BASE: 875c6bf4c48da9bb41f4cfd25d09bf5e2a62d88b39efc4bd9c498e6c8f61e4df740af87386f97269525e01b5f74402512eb6a4723882579f10aa95f6e2971fc2
-      RAILS_SERVE_STATIC_FILES: "true"
+      << : *x-production
       PORT: 3105
       PLEK_HOSTNAME_PREFIX: draft-
       PLEK_SERVICE_SEARCH_URI: http://rummager.dev.gov.uk
@@ -573,13 +521,7 @@ services:
       - diet-error-handler
       - whitehall
     environment:
-      RAILS_ENV: production
-      GOVUK_APP_DOMAIN: dev.gov.uk
-      GOVUK_WEBSITE_ROOT: http://www.dev.gov.uk
-      GOVUK_ASSET_ROOT: http://assets-origin.dev.gov.uk
-      SECRET_TOKEN: 875c6bf4c48da9bb41f4cfd25d09bf5e2a62d88b39efc4bd9c498e6c8f61e4df740af87386f97269525e01b5f74402512eb6a4723882579f10aa95f6e2971fc2
-      RAILS_SERVE_STATIC_FILES: "true"
-      GDS_SSO_STRATEGY: mock
+      << : *x-production
       SENTRY_CURRENT_ENV: manuals-publisher
       SENTRY_DSN: http://user:password@error-handler.dev.gov.uk/123
       VIRTUAL_HOST: manuals-publisher.dev.gov.uk
@@ -602,10 +544,7 @@ services:
       - publishing-api
       - diet-error-handler
     environment:
-      RAILS_ENV: production
-      GOVUK_APP_DOMAIN: dev.gov.uk
-      GOVUK_WEBSITE_ROOT: http://www.dev.gov.uk
-      GOVUK_ASSET_ROOT: http://assets-origin.dev.gov.uk
+      << : *x-production
       SENTRY_CURRENT_ENV: manuals-publisher-worker
       SENTRY_DSN: http://user:password@error-handler.dev.gov.uk/123
     healthcheck:
@@ -623,12 +562,7 @@ services:
       - static
       - diet-error-handler
     environment:
-      RAILS_ENV: production
-      GOVUK_APP_DOMAIN: dev.gov.uk
-      GOVUK_WEBSITE_ROOT: http://www.dev.gov.uk
-      GOVUK_ASSET_ROOT: http://assets-origin.dev.gov.uk
-      SECRET_KEY_BASE: 875c6bf4c48da9bb41f4cfd25d09bf5e2a62d88b39efc4bd9c498e6c8f61e4df740af87386f97269525e01b5f74402512eb6a4723882579f10aa95f6e2971fc2
-      RAILS_SERVE_STATIC_FILES: "true"
+      << : *x-production
       SENTRY_CURRENT_ENV: manuals-frontend
       SENTRY_DSN: http://user:password@error-handler.dev.gov.uk/123
       VIRTUAL_HOST: manuals-frontend.dev.gov.uk
@@ -649,11 +583,7 @@ services:
       - draft-static
       - diet-error-handler
     environment:
-      RAILS_ENV: production
-      GOVUK_APP_DOMAIN: dev.gov.uk
-      GOVUK_WEBSITE_ROOT: http://www.dev.gov.uk
-      SECRET_KEY_BASE: 875c6bf4c48da9bb41f4cfd25d09bf5e2a62d88b39efc4bd9c498e6c8f61e4df740af87386f97269525e01b5f74402512eb6a4723882579f10aa95f6e2971fc2
-      RAILS_SERVE_STATIC_FILES: "true"
+      << : *x-production
       PLEK_HOSTNAME_PREFIX: draft-
       LOG_PATH: log/draft.log
       SENTRY_CURRENT_ENV: draft-manuals-frontend
@@ -681,12 +611,7 @@ services:
       - publishing-api
       - diet-error-handler
     environment:
-      RAILS_ENV: production
-      GOVUK_APP_DOMAIN: dev.gov.uk
-      GOVUK_WEBSITE_ROOT: http://www.dev.gov.uk
-      GOVUK_ASSET_ROOT: http://assets-origin.dev.gov.uk
-      SECRET_KEY_BASE: 875c6bf4c48da9bb41f4cfd25d09bf5e2a62d88b39efc4bd9c498e6c8f61e4df740af87386f97269525e01b5f74402512eb6a4723882579f10aa95f6e2971fc2
-      RAILS_SERVE_STATIC_FILES: "true"
+      << : *x-production
       SENTRY_CURRENT_ENV: calendars
       SENTRY_DSN: http://user:password@error-handler.dev.gov.uk/123
       VIRTUAL_HOST: calendars.dev.gov.uk
@@ -714,15 +639,8 @@ services:
       - asset-manager
       - diet-error-handler
     environment:
-      RAILS_ENV: production
-      GOVUK_APP_DOMAIN: dev.gov.uk
-      GOVUK_WEBSITE_ROOT: http://www.dev.gov.uk
-      GOVUK_ASSET_ROOT: http://assets-origin.dev.gov.uk
-      GOVUK_ASSET_HOST: http://static.dev.gov.uk
-      SECRET_KEY_BASE: 875c6bf4c48da9bb41f4cfd25d09bf5e2a62d88b39efc4bd9c498e6c8f61e4df740af87386f97269525e01b5f74402512eb6a4723882579f10aa95f6e2971fc2
-      RAILS_SERVE_STATIC_FILES: "true"
+      << : *x-production
       SENTRY_CURRENT_ENV: whitehall
-      DISABLE_DATABASE_ENVIRONMENT_CHECK: 1
       SENTRY_DSN: http://user:password@error-handler.dev.gov.uk/123
       VIRTUAL_HOST: whitehall-admin.dev.gov.uk
     links:
@@ -750,17 +668,14 @@ services:
       - redis
       - nginx-proxy:error-handler.dev.gov.uk
     environment:
-      FAKE_S3_HOST: http://127.0.0.1
-      RAILS_ENV: production
-      GOVUK_APP_DOMAIN: dev.gov.uk
-      SECRET_KEY_BASE: 875c6bf4c48da9bb41f4cfd25d09bf5e2a62d88b39efc4bd9c498e6c8f61e4df740af87386f97269525e01b5f74402512eb6a4723882579f10aa95f6e2971fc2
+      << : *x-production
       ERRBIT_API_KEY: 1
       ERRBIT_ENVIRONMENT_NAME: asset-manager
       REDIS_HOST: redis
       SENTRY_CURRENT_ENV: asset-manager
       SENTRY_DSN: http://user:password@error-handler.dev.gov.uk/123
       VIRTUAL_HOST: asset-manager.dev.gov.uk
-      GDS_SSO_STRATEGY: mock
+      FAKE_S3_HOST: http://127.0.0.1
       ALLOW_FAKE_S3_IN_PRODUCTION_FOR_PUBLISHING_E2E_TESTS: "true"
     ports:
       - "3037"
@@ -775,14 +690,13 @@ services:
     depends_on:
       - diet-error-handler
     environment:
-      FAKE_S3_HOST: http://127.0.0.1
-      RAILS_ENV: production
-      GOVUK_APP_DOMAIN: dev.gov.uk
+      << : *x-production
       ERRBIT_API_KEY: 1
       ERRBIT_ENVIRONMENT_NAME: asset-manager-worker
       REDIS_HOST: redis
       SENTRY_CURRENT_ENV: asset-manager-worker
       SENTRY_DSN: http://user:password@error-handler.dev.gov.uk/123
+      FAKE_S3_HOST: http://127.0.0.1
       ALLOW_FAKE_S3_IN_PRODUCTION_FOR_PUBLISHING_E2E_TESTS: "true"
     healthcheck:
       disable: true
@@ -794,10 +708,7 @@ services:
     depends_on:
       - diet-error-handler
     environment:
-      RAILS_ENV: production
-      SECRET_KEY_BASE: 875c6bf4c48da9bb41f4cfd25d09bf5e2a62d88b39efc4bd9c498e6c8f61e4df740af87386f97269525e01b5f74402512eb6a4723882579f10aa95f6e2971fc2
-      GOVUK_APP_DOMAIN: dev.gov.uk
-      GOVUK_WEBSITE_ROOT: http://www.dev.gov.uk
+      << : *x-production
       ERRBIT_API_KEY: 1
       ERRBIT_ENVIRONMENT_NAME: static
       LOG_PATH: log/live.log
@@ -815,10 +726,7 @@ services:
     << : *static
     command: bundle exec unicorn -p 3113
     environment:
-      RAILS_ENV: production
-      SECRET_KEY_BASE: 875c6bf4c48da9bb41f4cfd25d09bf5e2a62d88b39efc4bd9c498e6c8f61e4df740af87386f97269525e01b5f74402512eb6a4723882579f10aa95f6e2971fc2
-      GOVUK_APP_DOMAIN: dev.gov.uk
-      GOVUK_WEBSITE_ROOT: http://www.dev.gov.uk
+      << : *x-production
       ERRBIT_API_KEY: 1
       ERRBIT_ENVIRONMENT_NAME: draft-static
       GOVUK_APP_NAME: draft-static
@@ -846,10 +754,8 @@ services:
       - diet-error-handler
       - memcached
     environment:
+      << : *x-production
       MEMCACHE_SERVERS: memcached
-      RAILS_ENV: production
-      GOVUK_APP_DOMAIN: dev.gov.uk
-      SECRET_KEY_BASE: 875c6bf4c48da9bb41f4cfd25d09bf5e2a62d88b39efc4bd9c498e6c8f61e4df740af87386f97269525e01b5f74402512eb6a4723882579f10aa95f6e2971fc2
       ERRBIT_API_KEY: 1
       ERRBIT_ENVIRONMENT_NAME: government-frontend
       LOG_PATH: log/live.log
@@ -875,10 +781,8 @@ services:
       - diet-error-handler
       - memcached
     environment:
+      << : *x-production
       MEMCACHE_SERVERS: memcached
-      RAILS_ENV: production
-      GOVUK_APP_DOMAIN: dev.gov.uk
-      SECRET_KEY_BASE: 875c6bf4c48da9bb41f4cfd25d09bf5e2a62d88b39efc4bd9c498e6c8f61e4df740af87386f97269525e01b5f74402512eb6a4723882579f10aa95f6e2971fc2
       ERRBIT_API_KEY: 1
       ERRBIT_ENVIRONMENT_NAME: draft-government-frontend
       GOVUK_APP_NAME: draft-government-frontend

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,15 +1,23 @@
 version: '3.4'
 
-x-production: &x-production
-  RAILS_ENV: production
+x-govuk-app-env: &govuk-app
+  DISABLE_DATABASE_ENVIRONMENT_CHECK: 1
+  GDS_SSO_STRATEGY: mock
   GOVUK_APP_DOMAIN: dev.gov.uk
-  GOVUK_WEBSITE_ROOT: http://www.dev.gov.uk
   GOVUK_ASSET_ROOT: http://assets-origin.dev.gov.uk
+  GOVUK_WEBSITE_ROOT: http://www.dev.gov.uk
+  LOG_PATH: log/live.log
+  PLEK_SERVICE_SEARCH_URI: http://rummager.dev.gov.uk
+  RAILS_ENV: production
+  RAILS_SERVE_STATIC_FILES: "true"
   SECRET_KEY_BASE: 875c6bf4c48da9bb41f4cfd25d09bf5e2a62d88b39efc4bd9c498e6c8f61e4df740af87386f97269525e01b5f74402512eb6a4723882579f10aa95f6e2971fc2
   SECRET_TOKEN: 875c6bf4c48da9bb41f4cfd25d09bf5e2a62d88b39efc4bd9c498e6c8f61e4df740af87386f97269525e01b5f74402512eb6a4723882579f10aa95f6e2971fc2
-  DISABLE_DATABASE_ENVIRONMENT_CHECK: 1
-  RAILS_SERVE_STATIC_FILES: "true"
-  GDS_SSO_STRATEGY: mock
+  SENTRY_DSN: http://user:password@error-handler.dev.gov.uk/123
+
+x-draft-govuk-app-env: &draft-govuk-app
+  << : *govuk-app
+  LOG_PATH: log/draft.log
+  PLEK_HOSTNAME_PREFIX: draft-
 
 services:
   nginx-proxy:
@@ -64,11 +72,9 @@ services:
     depends_on:
       - diet-error-handler
     environment:
-      << : *x-production
+      << : *govuk-app
       GOVUK_APP_NAME: rummager
-      LOG_PATH: log/live.log
       SENTRY_CURRENT_ENV: rummager
-      SENTRY_DSN: http://user:password@error-handler.dev.gov.uk/123
       VIRTUAL_HOST: rummager.dev.gov.uk
     links:
       - elasticsearch
@@ -131,10 +137,8 @@ services:
     depends_on:
       - diet-error-handler
     environment:
-      << : *x-production
-      LOG_PATH: log/live.log
+      << : *govuk-app
       SENTRY_CURRENT_ENV: router-api
-      SENTRY_DSN: http://user:password@error-handler.dev.gov.uk/123
       VIRTUAL_HOST: router-api.dev.gov.uk
     links:
       - mongo
@@ -149,15 +153,12 @@ services:
     << : *router-api
     command: bundle exec unicorn -p 3156
     environment:
-      << : *x-production
+      << : *draft-govuk-app
       GOVUK_APP_NAME: draft-router-api
-      LOG_PATH: log/draft.log
       MONGODB_URI: mongodb://mongo/draft-router
-      PLEK_HOSTNAME_PREFIX: draft-
       PORT: 3156
       ROUTER_NODES: "draft-router:3155"
       SENTRY_CURRENT_ENV: draft-router-api
-      SENTRY_DSN: http://user:password@error-handler.dev.gov.uk/123
       TEST_MONGODB_URI: mongodb://mongo/draft-router-test
       VIRTUAL_HOST: draft-router-api.dev.gov.uk
     links:
@@ -174,11 +175,9 @@ services:
       - router-api
       - diet-error-handler
     environment:
-      << : *x-production
+      << : *govuk-app
       MONGO_WRITE_CONCERN: 1
-      LOG_PATH: log/live.log
       SENTRY_CURRENT_ENV: content-store
-      SENTRY_DSN: http://user:password@error-handler.dev.gov.uk/123
       VIRTUAL_HOST: content-store.dev.gov.uk
     links:
       - mongo
@@ -197,15 +196,12 @@ services:
       - draft-router-api
       - diet-error-handler
     environment:
-      << : *x-production
+      << : *draft-govuk-app
       MONGO_WRITE_CONCERN: 1
       GOVUK_APP_NAME: draft-content-store
-      LOG_PATH: log/draft.log
       MONGODB_URI: mongodb://mongo/draft-content-store
-      PLEK_HOSTNAME_PREFIX: draft-
       PORT: 3100
       SENTRY_CURRENT_ENV: draft-content-store
-      SENTRY_DSN: http://user:password@error-handler.dev.gov.uk/123
       VIRTUAL_HOST: draft-content-store.dev.gov.uk
     links:
       - mongo
@@ -221,10 +217,9 @@ services:
       - publishing-api-worker
       - diet-error-handler
     environment:
-      << : *x-production
+      << : *govuk-app
       DISABLE_QUEUE_PUBLISHER: 1
       SENTRY_CURRENT_ENV: publishing-api
-      SENTRY_DSN: http://user:password@error-handler.dev.gov.uk/123
       VIRTUAL_HOST: publishing-api.dev.gov.uk
     links:
       - postgres
@@ -245,10 +240,9 @@ services:
       - draft-content-store
       - diet-error-handler
     environment:
-      << : *x-production
+      << : *govuk-app
       DISABLE_QUEUE_PUBLISHER: 1
       SENTRY_CURRENT_ENV: publishing-api-worker
-      SENTRY_DSN: http://user:password@error-handler.dev.gov.uk/123
     healthcheck:
       disable: true
     links:
@@ -274,10 +268,9 @@ services:
       - asset-manager
       - diet-error-handler
     environment:
-      << : *x-production
+      << : *govuk-app
       MONGO_WRITE_CONCERN: 1
       SENTRY_CURRENT_ENV: specialist-publisher
-      SENTRY_DSN: http://user:password@error-handler.dev.gov.uk/123
       VIRTUAL_HOST: specialist-publisher.dev.gov.uk
     links:
       - mongo
@@ -304,9 +297,8 @@ services:
       - travel-advice-publisher-worker
       - diet-error-handler
     environment:
-      << : *x-production
+      << : *govuk-app
       SENTRY_CURRENT_ENV: travel-advice-publisher
-      SENTRY_DSN: http://user:password@error-handler.dev.gov.uk/123
       VIRTUAL_HOST: travel-advice-publisher.dev.gov.uk
     links:
       - mongo
@@ -330,9 +322,8 @@ services:
     healthcheck:
       disable: true
     environment:
-      << : *x-production
+      << : *govuk-app
       SENTRY_CURRENT_ENV: travel-advice-publisher-worker
-      SENTRY_DSN: http://user:password@error-handler.dev.gov.uk/123
     ports: []
 
   collections-publisher: &collections-publisher
@@ -348,9 +339,8 @@ services:
       - collections-publisher-worker
       - diet-error-handler
     environment:
-      << : *x-production
+      << : *govuk-app
       SENTRY_CURRENT_ENV: collections-publisher
-      SENTRY_DSN: http://user:password@error-handler.dev.gov.uk/123
       VIRTUAL_HOST: collections-publisher.dev.gov.uk
     links:
       - mysql
@@ -369,9 +359,8 @@ services:
       - publishing-api
       - diet-error-handler
     environment:
-      << : *x-production
+      << : *govuk-app
       SENTRY_CURRENT_ENV: collections-publisher-worker
-      SENTRY_DSN: http://user:password@error-handler.dev.gov.uk/123
     healthcheck:
       disable: true
     ports: []
@@ -388,10 +377,8 @@ services:
       - rummager
       - diet-error-handler
     environment:
-      << : *x-production
-      PLEK_SERVICE_SEARCH_URI: http://rummager.dev.gov.uk
+      << : *govuk-app
       SENTRY_CURRENT_ENV: collections
-      SENTRY_DSN: http://user:password@error-handler.dev.gov.uk/123
       VIRTUAL_HOST: collections.dev.gov.uk
     links:
       - nginx-proxy:rummager.dev.gov.uk
@@ -415,12 +402,11 @@ services:
       - diet-error-handler
       - calendars
     environment:
-      << : *x-production
+      << : *govuk-app
       DISABLE_SECURE_COOKIES: "true"
       DISABLE_EMAIL: "true"
       JWT_AUTH_SECRET: fakejwtsecret
       SENTRY_CURRENT_ENV: publisher
-      SENTRY_DSN: http://user:password@error-handler.dev.gov.uk/123
       VIRTUAL_HOST: publisher.dev.gov.uk
       GOVUK_CONTENT_SCHEMAS_PATH: /govuk-content-schemas/
     volumes:
@@ -443,9 +429,8 @@ services:
       - publishing-api
       - diet-error-handler
     environment:
-      << : *x-production
+      << : *govuk-app
       SENTRY_CURRENT_ENV: publisher-worker
-      SENTRY_DSN: http://user:password@error-handler.dev.gov.uk/123
     healthcheck:
       disable: true
     ports: []
@@ -463,10 +448,8 @@ services:
       - diet-error-handler
       - publishing-api
     environment:
-      << : *x-production
-      PLEK_SERVICE_SEARCH_URI: http://rummager.dev.gov.uk
+      << : *govuk-app
       SENTRY_CURRENT_ENV: frontend
-      SENTRY_DSN: http://user:password@error-handler.dev.gov.uk/123
       VIRTUAL_HOST: frontend.dev.gov.uk
     links:
       - nginx-proxy:rummager.dev.gov.uk
@@ -488,12 +471,9 @@ services:
       - rummager
       - diet-error-handler
     environment:
-      << : *x-production
+      << : *draft-govuk-app
       PORT: 3105
-      PLEK_HOSTNAME_PREFIX: draft-
-      PLEK_SERVICE_SEARCH_URI: http://rummager.dev.gov.uk
       SENTRY_CURRENT_ENV: draft-frontend
-      SENTRY_DSN: http://user:password@error-handler.dev.gov.uk/123
       VIRTUAL_HOST: draft-frontend.dev.gov.uk
     links:
       - nginx-proxy:rummager.dev.gov.uk
@@ -518,9 +498,8 @@ services:
       - diet-error-handler
       - whitehall
     environment:
-      << : *x-production
+      << : *govuk-app
       SENTRY_CURRENT_ENV: manuals-publisher
-      SENTRY_DSN: http://user:password@error-handler.dev.gov.uk/123
       VIRTUAL_HOST: manuals-publisher.dev.gov.uk
     links:
       - mongo
@@ -541,9 +520,8 @@ services:
       - publishing-api
       - diet-error-handler
     environment:
-      << : *x-production
+      << : *govuk-app
       SENTRY_CURRENT_ENV: manuals-publisher-worker
-      SENTRY_DSN: http://user:password@error-handler.dev.gov.uk/123
     healthcheck:
       disable: true
     ports: []
@@ -559,9 +537,8 @@ services:
       - static
       - diet-error-handler
     environment:
-      << : *x-production
+      << : *govuk-app
       SENTRY_CURRENT_ENV: manuals-frontend
-      SENTRY_DSN: http://user:password@error-handler.dev.gov.uk/123
       VIRTUAL_HOST: manuals-frontend.dev.gov.uk
     links:
       - nginx-proxy:content-store.dev.gov.uk
@@ -580,11 +557,8 @@ services:
       - draft-static
       - diet-error-handler
     environment:
-      << : *x-production
-      PLEK_HOSTNAME_PREFIX: draft-
-      LOG_PATH: log/draft.log
+      << : *draft-govuk-app
       SENTRY_CURRENT_ENV: draft-manuals-frontend
-      SENTRY_DSN: http://user:password@error-handler.dev.gov.uk/123
       VIRTUAL_HOST: draft-manuals-frontend.dev.gov.uk
       PORT: 3172
     links:
@@ -607,9 +581,8 @@ services:
       - publishing-api
       - diet-error-handler
     environment:
-      << : *x-production
+      << : *govuk-app
       SENTRY_CURRENT_ENV: calendars
-      SENTRY_DSN: http://user:password@error-handler.dev.gov.uk/123
       VIRTUAL_HOST: calendars.dev.gov.uk
     links:
       - nginx-proxy:static.dev.gov.uk
@@ -635,9 +608,8 @@ services:
       - asset-manager
       - diet-error-handler
     environment:
-      << : *x-production
+      << : *govuk-app
       SENTRY_CURRENT_ENV: whitehall
-      SENTRY_DSN: http://user:password@error-handler.dev.gov.uk/123
       VIRTUAL_HOST: whitehall-admin.dev.gov.uk
     links:
       - mysql
@@ -664,10 +636,9 @@ services:
       - redis
       - nginx-proxy:error-handler.dev.gov.uk
     environment:
-      << : *x-production
+      << : *govuk-app
       REDIS_HOST: redis
       SENTRY_CURRENT_ENV: asset-manager
-      SENTRY_DSN: http://user:password@error-handler.dev.gov.uk/123
       VIRTUAL_HOST: asset-manager.dev.gov.uk
       FAKE_S3_HOST: http://127.0.0.1
       ALLOW_FAKE_S3_IN_PRODUCTION_FOR_PUBLISHING_E2E_TESTS: "true"
@@ -684,10 +655,9 @@ services:
     depends_on:
       - diet-error-handler
     environment:
-      << : *x-production
+      << : *govuk-app
       REDIS_HOST: redis
       SENTRY_CURRENT_ENV: asset-manager-worker
-      SENTRY_DSN: http://user:password@error-handler.dev.gov.uk/123
       FAKE_S3_HOST: http://127.0.0.1
       ALLOW_FAKE_S3_IN_PRODUCTION_FOR_PUBLISHING_E2E_TESTS: "true"
     healthcheck:
@@ -700,10 +670,8 @@ services:
     depends_on:
       - diet-error-handler
     environment:
-      << : *x-production
-      LOG_PATH: log/live.log
+      << : *govuk-app
       SENTRY_CURRENT_ENV: static
-      SENTRY_DSN: http://user:password@error-handler.dev.gov.uk/123
       VIRTUAL_HOST: static.dev.gov.uk
     links:
       - nginx-proxy:error-handler.dev.gov.uk
@@ -716,14 +684,11 @@ services:
     << : *static
     command: bundle exec unicorn -p 3113
     environment:
-      << : *x-production
+      << : *draft-govuk-app
       GOVUK_APP_NAME: draft-static
-      LOG_PATH: log/draft.log
-      PLEK_HOSTNAME_PREFIX: draft-
       PORT: 3113
       REDIS_URL: redis://redis/1
       SENTRY_CURRENT_ENV: draft-static
-      SENTRY_DSN: http://user:password@error-handler.dev.gov.uk/123
       VIRTUAL_HOST: draft-static.dev.gov.uk
     ports:
       - "3113"
@@ -741,11 +706,9 @@ services:
       - diet-error-handler
       - memcached
     environment:
-      << : *x-production
+      << : *govuk-app
       MEMCACHE_SERVERS: memcached
-      LOG_PATH: log/live.log
       SENTRY_CURRENT_ENV: government-frontend
-      SENTRY_DSN: http://user:password@error-handler.dev.gov.uk/123
       VIRTUAL_HOST: government-frontend.dev.gov.uk
       VIRTUAL_PORT: 3090
     links:
@@ -766,14 +729,11 @@ services:
       - diet-error-handler
       - memcached
     environment:
-      << : *x-production
+      << : *draft-govuk-app
       MEMCACHE_SERVERS: memcached
       GOVUK_APP_NAME: draft-government-frontend
-      LOG_PATH: log/draft.log
-      PLEK_HOSTNAME_PREFIX: draft-
       PORT: 3190
       SENTRY_CURRENT_ENV: draft-government-frontend
-      SENTRY_DSN: http://user:password@error-handler.dev.gov.uk/123
       VIRTUAL_HOST: draft-government-frontend.dev.gov.uk
     links:
       - nginx-proxy:draft-content-store.dev.gov.uk


### PR DESCRIPTION
We have an aim to run the test suite as close to production as possible and this is the initial step of running and setting up applications in the production environment with the caveat of no Signon or SSL currently.

To allow for running the tests in production we added ENV vars and ARGs to the underlying applications. These changes reflect those variables and allow us to orchestrate the applications in rails production env.