### PR TITLE
Use kill and rm commands to stop Docker containers

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,11 +18,11 @@ $(APPS):
 
 clone: $(APPS)
 
-down:
+kill:
 	$(DOCKER_COMPOSE_CMD) kill
 	$(DOCKER_COMPOSE_CMD) rm -f
 
-build: down
+build: kill
 	$(DOCKER_COMPOSE_CMD) build
 
 setup:
@@ -72,9 +72,9 @@ test-manuals-publisher:
 test-frontend:
 	$(TEST_CMD) --tag frontend
 
-stop: down
+stop: kill
 
-.PHONY: all $(APPS) clone down build setup start up test stop \
+.PHONY: all $(APPS) clone kill build setup start up test stop \
 	test-specialist-publisher test-travel-advice-publisher \
 	test-collections-publisher test-publisher test-manuals-publisher \
 	test-frontend

--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,8 @@ $(APPS):
 clone: $(APPS)
 
 down:
-	$(DOCKER_COMPOSE_CMD) down
+	$(DOCKER_COMPOSE_CMD) kill
+	$(DOCKER_COMPOSE_CMD) rm -f
 
 build: down
 	$(DOCKER_COMPOSE_CMD) build


### PR DESCRIPTION
This allows us to bring this step of running the tests down from 1min10s+ on Jenkins to 7 seconds. We want to keep the pipeline run under 10 minutes so this is a valuable saving.