### PR TITLE
Remove container name for nginx proxy

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,7 +4,6 @@ services:
 
   nginx-proxy:
     image: jwilder/nginx-proxy:latest
-    container_name: nginx-proxy
     ports:
       - "80:80"
     volumes:


### PR DESCRIPTION
I think this was left over from a copy+paste configuration and doesn't actually
affect the build. I had a nagging concern that this might be needed for
the routing to work, but this doesn't seem to be the case.