### PR TITLE
Let docker assign random ports to the containers when running on CI

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,12 @@ APPS = asset-manager content-store govuk-content-schemas government-frontend \
 	collections frontend publisher calendars \
 	manuals-publisher manuals-frontend whitehall
 
-TEST_CMD = docker-compose run publishing-e2e-tests bundle exec rspec
+DOCKER_COMPOSE_CMD = docker-compose -f docker-compose.yml
+
+ifndef JENKINS_URL
+  DOCKER_COMPOSE_CMD += -f docker-compose.development.yml
+endif
+TEST_CMD = $(DOCKER_COMPOSE_CMD) run publishing-e2e-tests bundle exec rspec
 
 all: clone build start test stop
 
@@ -14,34 +19,34 @@ $(APPS):
 clone: $(APPS)
 
 down:
-	docker-compose down
+	$(DOCKER_COMPOSE_CMD) down
 
 build: down
-	docker-compose build
+	$(DOCKER_COMPOSE_CMD) build
 
 setup:
-	docker-compose run publishing-e2e-tests bash -c 'find /app/tmp -name .keep -prune -o -type f -exec rm {} \;'
-	docker-compose run router-api bundle exec rake db:purge
-	docker-compose run draft-router-api bundle exec rake db:purge
-	docker-compose run content-store bundle exec rake db:purge
-	docker-compose run draft-content-store bundle exec rake db:purge
-	docker-compose run asset-manager bundle exec rake db:purge
-	docker-compose run publishing-api bundle exec rake db:setup
-	docker-compose run -e RUMMAGER_INDEX=all rummager bundle exec rake rummager:create_all_indices
-	docker-compose run publishing-api-worker rails runner 'Sidekiq::Queue.new.clear'
-	# docker-compose run publishing-api-worker bundle exec rails runner 'channel = Bunny.new.start.create_channel;Bunny::Exchange.new(channel, :topic, "published_documents")'
-	docker-compose run specialist-publisher bundle exec rake db:seed
-	docker-compose run specialist-publisher bundle exec rake publishing_api:publish_finders
-	docker-compose run travel-advice-publisher bundle exec rake db:seed
-	docker-compose run manuals-publisher bundle exec rake db:seed
-	docker-compose run collections-publisher bundle exec rake db:setup
-	docker-compose run publisher bundle exec rake db:setup
-	docker-compose run frontend bundle exec rake publishing_api:publish_special_routes
-	docker-compose run whitehall bundle exec rake db:create db:purge db:setup
-	docker-compose run publishing-e2e-tests bundle exec rake wait_for_router
+	$(DOCKER_COMPOSE_CMD) run publishing-e2e-tests bash -c 'find /app/tmp -name .keep -prune -o -type f -exec rm {} \;'
+	$(DOCKER_COMPOSE_CMD) run router-api bundle exec rake db:purge
+	$(DOCKER_COMPOSE_CMD) run draft-router-api bundle exec rake db:purge
+	$(DOCKER_COMPOSE_CMD) run content-store bundle exec rake db:purge
+	$(DOCKER_COMPOSE_CMD) run draft-content-store bundle exec rake db:purge
+	$(DOCKER_COMPOSE_CMD) run asset-manager bundle exec rake db:purge
+	$(DOCKER_COMPOSE_CMD) run publishing-api bundle exec rake db:setup
+	$(DOCKER_COMPOSE_CMD) run -e RUMMAGER_INDEX=all rummager bundle exec rake rummager:create_all_indices
+	$(DOCKER_COMPOSE_CMD) run publishing-api-worker rails runner 'Sidekiq::Queue.new.clear'
+	# $(DOCKER_COMPOSE_CMD) run publishing-api-worker bundle exec rails runner 'channel = Bunny.new.start.create_channel;Bunny::Exchange.new(channel, :topic, "published_documents")'
+	$(DOCKER_COMPOSE_CMD) run specialist-publisher bundle exec rake db:seed
+	$(DOCKER_COMPOSE_CMD) run specialist-publisher bundle exec rake publishing_api:publish_finders
+	$(DOCKER_COMPOSE_CMD) run travel-advice-publisher bundle exec rake db:seed
+	$(DOCKER_COMPOSE_CMD) run manuals-publisher bundle exec rake db:seed
+	$(DOCKER_COMPOSE_CMD) run collections-publisher bundle exec rake db:setup
+	$(DOCKER_COMPOSE_CMD) run publisher bundle exec rake db:setup
+	$(DOCKER_COMPOSE_CMD) run frontend bundle exec rake publishing_api:publish_special_routes
+	$(DOCKER_COMPOSE_CMD) run whitehall bundle exec rake db:create db:purge db:setup
+	$(DOCKER_COMPOSE_CMD) run publishing-e2e-tests bundle exec rake wait_for_router
 
 up:
-	docker-compose up -d
+	$(DOCKER_COMPOSE_CMD) up -d
 
 start: setup up
 

--- a/docker-compose.development.yml
+++ b/docker-compose.development.yml
@@ -1,0 +1,118 @@
+version: '3'
+
+# In development we want to expose the ports to the host machine on a predictable port.
+# This allows for easier manual testing of the services
+
+# On CI this is unnecessary and can cause conflicts between two builds wanting to use the same port.
+
+services:
+  nginx-proxy:
+    ports:
+      - "80:80"
+
+  rummager:
+    ports:
+      - "33009:3009"
+
+  diet-error-handler:
+    ports:
+      - "33129:3129"
+
+  router:
+    ports:
+      - "33054:3054"
+      - "33055:3055"
+
+  draft-router:
+    ports:
+      - "33154:3154"
+      - "33155:3155"
+
+  router-api:
+    ports:
+      - "33056:3056"
+
+  draft-router-api:
+    ports:
+      - "33156:3156"
+
+  content-store:
+    ports:
+      - "33068:3068"
+
+  draft-content-store:
+    ports:
+      - "33100:3100"
+
+  publishing-api:
+    ports:
+      - "33093:3093"
+
+  specialist-publisher:
+    ports:
+      - "33064:3064"
+
+  travel-advice-publisher:
+    ports:
+      - "33035:3035"
+
+  collections-publisher:
+    ports:
+      - "33071:3071"
+
+  collections:
+    ports:
+      - "33070:3070"
+
+  publisher:
+    ports:
+      - "33000:3000"
+
+  frontend:
+    ports:
+      - "33005:3005"
+
+  draft-frontend:
+    ports:
+      - "33105:3105"
+
+  manuals-publisher:
+    ports:
+      - "33205:3205"
+
+  manuals-frontend:
+    ports:
+      - "33072:3072"
+
+  draft-manuals-frontend:
+    ports:
+      - "33172:3172"
+
+  calendars:
+    ports:
+      - "33011:3011"
+
+  whitehall:
+    ports:
+      - "33020:3020"
+
+  asset-manager:
+    ports:
+      - "33037:3037"
+
+  static:
+    ports:
+      - "33013:3013"
+
+  draft-static:
+    ports:
+      - "33113:3113"
+
+  government-frontend:
+    ports:
+      - "33090:3090"
+
+  draft-government-frontend:
+    ports:
+      - "33190:3190"
+

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,7 +5,7 @@ services:
   nginx-proxy:
     image: jwilder/nginx-proxy:latest
     ports:
-      - "80:80"
+      - "80"
     volumes:
       - /var/run/docker.sock:/tmp/docker.sock
       - ./docker/nginx.tmpl:/app/nginx.tmpl
@@ -60,7 +60,7 @@ services:
       - redis
       - nginx-proxy:error-handler.dev.gov.uk
     ports:
-      - "33009:3009"
+      - "3009"
     volumes:
       - ./apps/rummager/log:/app/log
 
@@ -69,7 +69,7 @@ services:
     environment:
       VIRTUAL_HOST: error-handler.dev.gov.uk
     ports:
-      - "33129:3129"
+      - "3129"
     volumes:
       - ./tmp:/app/tmp
 
@@ -87,8 +87,8 @@ services:
       - nginx-proxy:calendars.dev.gov.uk
       - nginx-proxy:manuals-frontend.dev.gov.uk
     ports:
-      - "33054:3054"
-      - "33055:3055"
+      - "3054"
+      - "3055"
 
   draft-router:
     << : *router
@@ -108,8 +108,8 @@ services:
       - nginx-proxy:draft-frontend.dev.gov.uk
       - nginx-proxy:draft-manuals-frontend.dev.gov.uk
     ports:
-      - "33154:3154"
-      - "33155:3155"
+      - "3154"
+      - "3155"
 
   router-api: &router-api
     build: apps/router-api
@@ -125,7 +125,7 @@ services:
       - router
       - nginx-proxy:error-handler.dev.gov.uk
     ports:
-      - "33056:3056"
+      - "3056"
     volumes:
       - ./apps/router-api/log:/app/log
 
@@ -147,7 +147,7 @@ services:
       - draft-router
       - nginx-proxy:error-handler.dev.gov.uk
     ports:
-      - "33156:3156"
+      - "3156"
 
   content-store: &content-store
     build: apps/content-store
@@ -164,7 +164,7 @@ services:
       - nginx-proxy:router-api.dev.gov.uk
       - nginx-proxy:error-handler.dev.gov.uk
     ports:
-      - "33068:3068"
+      - "3068"
     volumes:
       - ./apps/content-store/log:/app/log
       - ./apps/govuk-content-schemas:/govuk-content-schemas
@@ -190,7 +190,7 @@ services:
       - nginx-proxy:draft-router-api.dev.gov.uk
       - nginx-proxy:error-handler.dev.gov.uk
     ports:
-      - "33100:3100"
+      - "3100"
 
   publishing-api:
     build: apps/publishing-api
@@ -208,7 +208,7 @@ services:
       # - rabbitmq
       - nginx-proxy:error-handler.dev.gov.uk
     ports:
-      - "33093:3093"
+      - "3093"
     volumes:
       - ./apps/govuk-content-schemas:/govuk-content-schemas
       - ./apps/publishing-api/log:/app/log
@@ -254,7 +254,7 @@ services:
       - nginx-proxy:asset-manager.dev.gov.uk
       - nginx-proxy:error-handler.dev.gov.uk
     ports:
-      - "33064:3064"
+      - "3064"
     volumes:
       - ./apps/specialist-publisher/log:/app/log
 
@@ -282,7 +282,7 @@ services:
       - nginx-proxy:static.dev.gov.uk
       - nginx-proxy:error-handler.dev.gov.uk
     ports:
-      - "33035:3035"
+      - "3035"
     volumes:
       - ./apps/travel-advice-publisher/log:/app/log
 
@@ -317,7 +317,7 @@ services:
       - nginx-proxy:publishing-api.dev.gov.uk
       - nginx-proxy:error-handler.dev.gov.uk
     ports:
-      - "33071:3071"
+      - "3071"
     volumes:
       - ./apps/collections-publisher/log:/app/log
 
@@ -352,7 +352,7 @@ services:
       - nginx-proxy:static.dev.gov.uk
       - nginx-proxy:error-handler.dev.gov.uk
     ports:
-      - "33070:3070"
+      - "3070"
     volumes:
       - ./apps/collections/log:/app/log
 
@@ -379,7 +379,7 @@ services:
       - nginx-proxy:error-handler.dev.gov.uk
       - nginx-proxy:calendars.dev.gov.uk
     ports:
-      - "33000:3000"
+      - "3000"
     volumes:
       - ./apps/publisher/log:/app/log
 
@@ -416,7 +416,7 @@ services:
       - nginx-proxy:error-handler.dev.gov.uk
       - nginx-proxy:publishing-api.dev.gov.uk
     ports:
-      - "33005:3005"
+      - "3005"
     volumes:
       - ./apps/frontend/log:/app/log
 
@@ -442,7 +442,7 @@ services:
       - nginx-proxy:draft-static.dev.gov.uk
       - nginx-proxy:error-handler.dev.gov.uk
     ports:
-      - "33105:3105"
+      - "3105"
 
   manuals-publisher: &manuals-publisher
     build: apps/manuals-publisher
@@ -466,7 +466,7 @@ services:
       - nginx-proxy:asset-manager.dev.gov.uk
       - nginx-proxy:whitehall-admin.dev.gov.uk
     ports:
-      - "33205:3205"
+      - "3205"
     volumes:
       - ./apps/manuals-publisher/log:/app/log
 
@@ -496,7 +496,7 @@ services:
       - nginx-proxy:static.dev.gov.uk
       - nginx-proxy:error-handler.dev.gov.uk
     ports:
-      - "33072:3072"
+      - "3072"
     volumes:
       - ./apps/manuals-frontend/log:/app/log
 
@@ -519,7 +519,7 @@ services:
       - nginx-proxy:draft-static.dev.gov.uk
       - nginx-proxy:error-handler.dev.gov.uk
     ports:
-      - "33172:3172"
+      - "3172"
 
   calendars: &calendars
     build: apps/calendars
@@ -540,7 +540,7 @@ services:
       - nginx-proxy:publishing-api.dev.gov.uk
       - nginx-proxy:error-handler.dev.gov.uk
     ports:
-      - "33011:3011"
+      - "3011"
     volumes:
       - ./apps/calendars/log:/app/log
 
@@ -564,7 +564,7 @@ services:
       - nginx-proxy:asset-manager.dev.gov.uk
       - nginx-proxy:static.dev.gov.uk
     ports:
-      - "33020:3020"
+      - "3020"
     volumes:
       - ./apps/whitehall/log:/app/log
 
@@ -592,7 +592,7 @@ services:
     healthcheck:
       test: ["CMD", "curl --silent --fail localhost:3037 || exit 1"]
     ports:
-      - "33037:3037"
+      - "3037"
     volumes:
       - ./apps/asset-manager/log:/app/log
       - ./tmp/uploads:/app/uploads
@@ -628,7 +628,7 @@ services:
     links:
       - nginx-proxy:error-handler.dev.gov.uk
     ports:
-      - "33013:3013"
+      - "3013"
     volumes:
       - ./apps/static/log:/app/log
 
@@ -647,7 +647,7 @@ services:
       SENTRY_DSN: http://user:password@error-handler.dev.gov.uk/123
       VIRTUAL_HOST: draft-static.dev.gov.uk
     ports:
-      - "33113:3113"
+      - "3113"
 
   # I think we might need these finder apps running to publish finders
   # finder-frontend:
@@ -674,7 +674,7 @@ services:
       - nginx-proxy:static.dev.gov.uk
       - nginx-proxy:error-handler.dev.gov.uk
     ports:
-      - "33090:3090"
+      - "3090"
     volumes:
       - ./apps/government-frontend/log:/app/log
 
@@ -702,7 +702,7 @@ services:
       - nginx-proxy:draft-static.dev.gov.uk
       - nginx-proxy:error-handler.dev.gov.uk
     ports:
-      - "33190:3190"
+      - "3190"
 
   publishing-e2e-tests:
     build: .


### PR DESCRIPTION
When in development we want to expose the services to the host on a predictable port.  This allows for easier manual testing.

On CI this is unnecessary and can cause conflicts between two separate builds.