### PR TITLE
Remove redundant Asset Manager environment variables

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -580,8 +580,6 @@ services:
       - redis
       - nginx-proxy:error-handler.dev.gov.uk
     environment:
-      PROXY_PERCENTAGE_OF_ASSET_REQUESTS_TO_S3_VIA_NGINX: 100
-      PROXY_PERCENTAGE_OF_WHITEHALL_ASSET_REQUESTS_TO_S3_VIA_NGINX: 100
       FAKE_S3_HOST: http://127.0.0.1
       ERRBIT_API_KEY: 1
       ERRBIT_ENVIRONMENT_NAME: asset-manager
@@ -604,8 +602,6 @@ services:
     depends_on:
       - diet-error-handler
     environment:
-      PROXY_PERCENTAGE_OF_ASSET_REQUESTS_TO_S3_VIA_NGINX: 100
-      PROXY_PERCENTAGE_OF_WHITEHALL_ASSET_REQUESTS_TO_S3_VIA_NGINX: 100
       FAKE_S3_HOST: http://127.0.0.1
       ERRBIT_API_KEY: 1
       ERRBIT_ENVIRONMENT_NAME: asset-manager-worker


### PR DESCRIPTION
These variables were added in #93, but were made redundant by alphagov/asset-manager#328 in which proxying asset requests to S3 via Nginx became the default for both Mainstream & Whitehall assets. The latter PR was deployed to production earlier today.

Note that alphagov/govuk-puppet#6952 & alphagov/govuk-puppet#6955 contain the same changes for all other environments.