### PR TITLE
Hard code the manual section title and slug

### DIFF
--- a/spec/manuals_publisher/removing_content_spec.rb
+++ b/spec/manuals_publisher/removing_content_spec.rb
@@ -2,8 +2,8 @@ feature "Removing content on Manuals Publisher", manuals_publisher: true do
   include ManualsPublisherHelpers
 
   let(:title) { title_with_timestamp }
-  let(:section_title) { title_with_timestamp }
-  let(:section_slug) { section_title.downcase.tr(" ", "-").gsub(/[^\w-]/, '') }
+  let(:section_title) { "How to eat an orange" }
+  let(:section_slug) { "how-to-eat-an-orange" }
 
   scenario "Remove a section from a published manual" do
     given_there_is_a_published_manual_with_sections


### PR DESCRIPTION
The code to slugify the title wasn't working in all cases, such as when there was a ç in the title.

Given that the section title doesn't need to be globally unique, we can hardcode the title and slug to be known values and avoid the aforementioned problem altogether.