### PR TITLE
Add TEST_ARGS environment variable to allow overriding of rspec args

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -31,6 +31,11 @@ node("publishing-e2e-tests") {
         name: "TEST_COMMAND"
       ),
       stringParam(
+        defaultValue: "",
+        description: "Allows for overriding the default arguments following rspec such as the path to spec or spec directory used to focus on the test(s), useful for flaky tests.",
+        name: "TEST_ARGS"
+      ),
+      stringParam(
         defaultValue: DEFAULT_COMMITISH,
         description: "Which commit/branch/tag of asset-manager to clone",
         name: "ASSET_MANAGER_COMMITISH"
@@ -122,6 +127,7 @@ node("publishing-e2e-tests") {
     "ORIGIN_REPO": "",
     "ORIGIN_COMMIT": "",
     "TEST_COMMAND": "test",
+    "TEST_ARGS": "",
     "ASSET_MANAGER_COMMITISH": DEFAULT_COMMITISH,
     "CONTENT_STORE_COMMITISH": DEFAULT_COMMITISH,
     "GOVERNMENT_FRONTEND_COMMITISH": DEFAULT_COMMITISH,

--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,12 @@ DOCKER_COMPOSE_CMD = docker-compose -f docker-compose.yml
 ifndef JENKINS_URL
   DOCKER_COMPOSE_CMD += -f docker-compose.development.yml
 endif
-TEST_CMD = $(DOCKER_COMPOSE_CMD) run publishing-e2e-tests bundle exec rspec
+
+ifndef TEST_ARGS
+  TEST_ARGS = --tag ~flaky
+endif
+
+TEST_CMD = $(DOCKER_COMPOSE_CMD) run publishing-e2e-tests bundle exec rspec $(TEST_ARGS)
 
 all: clone build start test stop
 

--- a/spec/publisher/updating_published_content_spec.rb
+++ b/spec/publisher/updating_published_content_spec.rb
@@ -4,7 +4,7 @@ feature "Updating published content from Publisher", publisher: true, frontend: 
   let(:title) { title_with_timestamp }
   let(:slug) { slug_with_timestamp }
 
-  scenario "Scheduling downtime for a transaction on Publisher", skip: true do
+  scenario "Scheduling downtime for a transaction on Publisher", flaky: true do
     given_there_is_a_published_transaction_artefact
     when_i_schedule_downtime_for_now_on_the_transaction
     and_i_visit_the_transaction_on_gov_uk


### PR DESCRIPTION
This allows us to focus in on flaky tests on Jenkins more easily. A lot of the time we find a flaky test occurs when the test runs first highlighting a race condition, by adding this ability to run these tests in isolation we can more confidently say these tests are fixed.