### PR TITLE
Add new tag for tests which run through government frontend

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -77,6 +77,9 @@ test-manuals-publisher:
 test-frontend:
 	$(TEST_CMD) --tag frontend
 
+test-government-frontend:
+	$(TEST_CMD) --tag government_frontend
+
 stop: kill
 
 .PHONY: all $(APPS) clone kill build setup start up test stop \

--- a/spec/publisher/publishing_content_to_government_frontend_spec.rb
+++ b/spec/publisher/publishing_content_to_government_frontend_spec.rb
@@ -1,4 +1,4 @@
-feature "Publishing content from Publisher to Government Frontend", publisher: true do
+feature "Publishing content from Publisher to Government Frontend", publisher: true, government_frontend: true do
   include PublisherHelpers
 
   let(:title) { title_with_timestamp }

--- a/spec/publisher/removing_content_without_redirect_spec.rb
+++ b/spec/publisher/removing_content_without_redirect_spec.rb
@@ -1,4 +1,4 @@
-feature "Removing content without a redirect from Publisher", publisher: true do
+feature "Removing content without a redirect from Publisher", publisher: true, government_frontend: true do
   include PublisherHelpers
 
   let(:title) { title_with_timestamp }

--- a/spec/specialist_publisher/change_note_spec.rb
+++ b/spec/specialist_publisher/change_note_spec.rb
@@ -1,4 +1,4 @@
-feature "Change notes on Specialist Publisher", specialist_publisher: true do
+feature "Change notes on Specialist Publisher", specialist_publisher: true, government_frontend: true do
   include SpecialistPublisherHelpers
 
   let(:title) { title_with_timestamp }

--- a/spec/specialist_publisher/creating_spec.rb
+++ b/spec/specialist_publisher/creating_spec.rb
@@ -1,4 +1,4 @@
-feature "Creating a draft on Specialist Publisher", specialist_publisher: true do
+feature "Creating a draft on Specialist Publisher", specialist_publisher: true, government_frontend: true do
   include SpecialistPublisherHelpers
 
   let(:title) { title_with_timestamp }

--- a/spec/specialist_publisher/discarding_draft_spec.rb
+++ b/spec/specialist_publisher/discarding_draft_spec.rb
@@ -1,4 +1,4 @@
-feature "Discarding a draft on Specialist Publisher", specialist_publisher: true do
+feature "Discarding a draft on Specialist Publisher", specialist_publisher: true, government_frontend: true do
   include SpecialistPublisherHelpers
 
   let(:title) { title_with_timestamp }

--- a/spec/specialist_publisher/editing_spec.rb
+++ b/spec/specialist_publisher/editing_spec.rb
@@ -1,4 +1,4 @@
-feature "Editing with Specialist Publisher", specialist_publisher: true do
+feature "Editing with Specialist Publisher", specialist_publisher: true, government_frontend: true do
   include SpecialistPublisherHelpers
 
   let(:old_title) { title_with_timestamp }

--- a/spec/specialist_publisher/publishing_spec.rb
+++ b/spec/specialist_publisher/publishing_spec.rb
@@ -1,4 +1,4 @@
-feature "Publishing with Specialist Publisher", specialist_publisher: true do
+feature "Publishing with Specialist Publisher", specialist_publisher: true, government_frontend: true do
   include SpecialistPublisherHelpers
 
   let(:title) { title_with_timestamp }

--- a/spec/specialist_publisher/unpublishing_spec.rb
+++ b/spec/specialist_publisher/unpublishing_spec.rb
@@ -1,4 +1,4 @@
-feature "Unpublishing with Specialist Publisher", specialist_publisher: true do
+feature "Unpublishing with Specialist Publisher", specialist_publisher: true, government_frontend: true do
   include SpecialistPublisherHelpers
 
   let(:title) { "#{Faker::Book.title} #{Time.now.to_i}" }

--- a/spec/specialist_publisher/upload_attachment_spec.rb
+++ b/spec/specialist_publisher/upload_attachment_spec.rb
@@ -1,6 +1,6 @@
 require "httparty"
 
-feature "Uploading an attachment on Specialist Publisher", specialist_publisher: true do
+feature "Uploading an attachment on Specialist Publisher", specialist_publisher: true, government_frontend: true do
   include SpecialistPublisherHelpers
 
   let(:title) { title_with_timestamp }

--- a/spec/travel_advice_publisher/creating_draft_spec.rb
+++ b/spec/travel_advice_publisher/creating_draft_spec.rb
@@ -1,4 +1,4 @@
-feature "Creating a draft on Travel Advice Publisher", feature: true, travel_advice_publisher: true do
+feature "Creating a draft on Travel Advice Publisher", feature: true, travel_advice_publisher: true, government_frontend: true do
   include TravelAdvicePublisherHelpers
 
   let(:country) { "Chad" }

--- a/spec/travel_advice_publisher/creating_live_spec.rb
+++ b/spec/travel_advice_publisher/creating_live_spec.rb
@@ -1,4 +1,4 @@
-feature "Creating a live edition on Travel Advice Publisher", feature: true, travel_advice_publisher: true do
+feature "Creating a live edition on Travel Advice Publisher", feature: true, travel_advice_publisher: true, government_frontend: true do
   include TravelAdvicePublisherHelpers
 
   let(:country) { "Malta" }

--- a/spec/travel_advice_publisher/upload_attachments_spec.rb
+++ b/spec/travel_advice_publisher/upload_attachments_spec.rb
@@ -1,4 +1,4 @@
-feature "Upload attachments on Travel Advice Publisher", feature: true, travel_advice_publisher: true do
+feature "Upload attachments on Travel Advice Publisher", feature: true, travel_advice_publisher: true, government_frontend: true do
   include TravelAdvicePublisherHelpers
 
   let(:country) { "Congo" }


### PR DESCRIPTION
This tag can be used by the government-frontend repository to reduce the number of E2E tests it runs.  Currently it runs the whole suite of tests.