### PR TITLE
Reenable the updating publisher content test

### DIFF
--- a/spec/publisher/updating_published_content_spec.rb
+++ b/spec/publisher/updating_published_content_spec.rb
@@ -4,7 +4,7 @@ feature "Updating published content from Publisher", publisher: true, frontend: 
   let(:title) { title_with_timestamp }
   let(:slug) { slug_with_timestamp }
 
-  scenario "Scheduling downtime for a transaction on Publisher", flaky: true do
+  scenario "Scheduling downtime for a transaction on Publisher" do
     given_there_is_a_published_transaction_artefact
     when_i_schedule_downtime_for_now_on_the_transaction
     and_i_visit_the_transaction_on_gov_uk


### PR DESCRIPTION
Having run this test with the flaky tag for the past 2 days it has run 300+ times and not failed once.

We've updated the version of poltergiest since this was first marked as flaky.