### PR TITLE
Wait for the draft document to be accessible before discarding

### DIFF
--- a/spec/specialist_publisher/discarding_draft_spec.rb
+++ b/spec/specialist_publisher/discarding_draft_spec.rb
@@ -20,6 +20,7 @@ feature "Discarding a draft on Specialist Publisher", specialist_publisher: true
 
   def when_i_discard_it
     @url = find_link("Preview draft")[:href]
+    expect_status_code_eventually(@url, 200, keep_retrying_while: 404)
 
     page.accept_confirm do
       click_button("Discard draft")


### PR DESCRIPTION
We found a race condition where the draft document was being discarded before it had been saved.  This was causing a race condition where the draft should have been discarded, but was accessible.