### PR TITLE
Update to fix incorrect flag being used for loading tags

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -62,25 +62,25 @@ test:
 	$(TEST_CMD)
 
 test-specialist-publisher:
-	$(TEST_CMD) --o '-tag specialist_publisher --tag ~flaky --tag ~new'
+	$(TEST_CMD) -o '--tag specialist_publisher --tag ~flaky --tag ~new'
 
 test-travel-advice-publisher:
-	$(TEST_CMD) --o '--tag travel_advice_publisher --tag ~flaky --tag ~new'
+	$(TEST_CMD) -o '--tag travel_advice_publisher --tag ~flaky --tag ~new'
 
 test-collections-publisher:
-	$(TEST_CMD) --o '--tag collections_publisher --tag ~flaky --tag ~new'
+	$(TEST_CMD) -o '--tag collections_publisher --tag ~flaky --tag ~new'
 
 test-publisher:
-	$(TEST_CMD) --o '--tag publisher --tag ~flaky --tag ~new'
+	$(TEST_CMD) -o '--tag publisher --tag ~flaky --tag ~new'
 
 test-manuals-publisher:
-	$(TEST_CMD) --o '--tag manuals_publisher --tag ~flaky --tag ~new'
+	$(TEST_CMD) -o '--tag manuals_publisher --tag ~flaky --tag ~new'
 
 test-frontend:
-	$(TEST_CMD) --o '--tag frontend --tag ~flaky --tag ~new'
+	$(TEST_CMD) -o '--tag frontend --tag ~flaky --tag ~new'
 
 test-government-frontend:
-	$(TEST_CMD) --o '--tag government_frontend --tag ~flaky --tag ~new'
+	$(TEST_CMD) -o '--tag government_frontend --tag ~flaky --tag ~new'
 
 stop: kill
 


### PR DESCRIPTION
This resolves the issue we've seen with manuals-publisher and others running the whole suite versus the specific tags we want to run