### PR TITLE
Signon support improvements

### DIFF
--- a/spec/support/collections_publisher_helpers.rb
+++ b/spec/support/collections_publisher_helpers.rb
@@ -10,4 +10,18 @@ module CollectionsPublisherHelpers
     fill_in "Title", with: title
     fill_in "Description", with: sentence
   end
+
+  def self.included(base)
+    return unless SignonHelpers::use_signon?
+
+    default_permissions = ['GDS Editor']
+
+    base.before(:each) do |example|
+      @user = get_next_user(
+        "Collections Publisher" =>
+        example.metadata.fetch(:permissions, default_permissions)
+      )
+      signin_with_user(@user)
+    end
+  end
 end

--- a/spec/support/manuals_publisher_helpers.rb
+++ b/spec/support/manuals_publisher_helpers.rb
@@ -27,4 +27,18 @@ module ManualsPublisherHelpers
     reload_url_until_match(current_url, :has_text?, "View on website")
     visit current_url
   end
+
+  def self.included(base)
+    return unless SignonHelpers::use_signon?
+
+    default_permissions = %w[editor gds_editor]
+
+    base.before(:each) do |example|
+      @user = get_next_user(
+        "Manuals Publisher" =>
+        example.metadata.fetch(:permissions, default_permissions)
+      )
+      signin_with_user(@user)
+    end
+  end
 end

--- a/spec/support/publisher_helpers.rb
+++ b/spec/support/publisher_helpers.rb
@@ -77,4 +77,18 @@ module PublisherHelpers
   def wait_for_artefact_to_be_viewable(url)
     reload_url_until_status_code(url, 200)
   end
+
+  def self.included(base)
+    return unless SignonHelpers::use_signon?
+
+    default_permissions = %w[skip_review]
+
+    base.before(:each) do |example|
+      @user = get_next_user(
+        "Publisher" =>
+        example.metadata.fetch(:permissions, default_permissions)
+      )
+      signin_with_user(@user)
+    end
+  end
 end

--- a/spec/support/signon_helpers.rb
+++ b/spec/support/signon_helpers.rb
@@ -122,12 +122,16 @@ module SignonHelpers
 
           options = all('option', visible: :all)
 
+          if permissions.include? 'signin'
+            raise "The 'signin' permission is implicit, so it doesn't need to be included"
+          end
+
           supported_permissions = options.map { |o| o.text(:all) }
           unsupported_permissions =
             permissions - supported_permissions
 
           unless unsupported_permissions.empty?
-            raise "#{app} does not support the #{unsupported_permissions} permissions"
+            raise "#{app} does not support the #{unsupported_permissions} permissions, only #{supported_permissions}"
           end
 
           options.each do |option|

--- a/spec/support/signon_helpers.rb
+++ b/spec/support/signon_helpers.rb
@@ -5,7 +5,6 @@ require 'rotp'
 module SignonHelpers
   class User
     attr_reader :email, :passphrase, :number
-    attr_accessor :two_step_verification_secret
 
     @next_user_number = 1
 
@@ -21,7 +20,23 @@ module SignonHelpers
     end
 
     def two_step_verification_code
-      ROTP::TOTP.new(@two_step_verification_secret).now
+      ROTP::TOTP.new(two_step_verification_secret).now
+    end
+
+    # Save the secret, so that the tests can be rerun
+    def two_step_verification_secret_file_name
+      "tmp/user_#{number}_two_step_verification_secret"
+    end
+
+    def two_step_verification_secret=(secret)
+      File.open(two_step_verification_secret_file_name, 'w') do |f|
+        f.puts secret
+      end
+    end
+
+    def two_step_verification_secret
+      @_two_step_verification_secret ||=
+        File.open(two_step_verification_secret_file_name, &:readline).strip
     end
 
     def self.get_next_user_number

--- a/spec/support/signon_helpers.rb
+++ b/spec/support/signon_helpers.rb
@@ -117,7 +117,7 @@ module SignonHelpers
 
     within_table('editable-permissions') do
       app_permissions.each do |app, permissions|
-        within('tr', text: app) do
+        within(:xpath, "//tr[td//text()[normalize-space(.) ='#{app}']]") do
           find("input[type='checkbox']").set(!permissions.nil?)
 
           options = all('option', visible: :all)

--- a/spec/support/specialist_publisher_helpers.rb
+++ b/spec/support/specialist_publisher_helpers.rb
@@ -155,17 +155,17 @@ module SpecialistPublisherHelpers
   end
 
   def self.included(base)
-    if SignonHelpers::use_signon?
-      default_permissions = %w[editor gds_editor]
+    return unless SignonHelpers::use_signon?
 
-      base.before(:each) do |example|
-        @user = get_next_user(
-          'Specialist Publisher' =>
-          example.metadata.fetch(:permissions, default_permissions),
-          'Content Preview' => %w[]
-        )
-        signin_with_user(@user)
-      end
+    default_permissions = %w[editor gds_editor]
+
+    base.before(:each) do |example|
+      @user = get_next_user(
+        "Specialist Publisher" =>
+        example.metadata.fetch(:permissions, default_permissions),
+        "Content Preview" => %w[]
+      )
+      signin_with_user(@user)
     end
   end
 end

--- a/spec/support/specialist_publisher_helpers.rb
+++ b/spec/support/specialist_publisher_helpers.rb
@@ -161,7 +161,8 @@ module SpecialistPublisherHelpers
       base.before(:each) do |example|
         @user = get_next_user(
           'Specialist Publisher' =>
-          example.metadata.fetch(:permissions, default_permissions)
+          example.metadata.fetch(:permissions, default_permissions),
+          'Content Preview' => %w[]
         )
         signin_with_user(@user)
       end

--- a/spec/support/travel_advice_publisher_helpers.rb
+++ b/spec/support/travel_advice_publisher_helpers.rb
@@ -72,16 +72,16 @@ module TravelAdvicePublisherHelpers
   end
 
   def self.included(base)
-    if SignonHelpers::use_signon?
-      default_permissions = %w[gds_editor]
+    return unless SignonHelpers::use_signon?
 
-      base.before(:each) do |example|
-        @user = get_next_user(
-          'Travel Advice Publisher' =>
-          example.metadata.fetch(:permissions, default_permissions)
-        )
-        signin_with_user(@user)
-      end
+    default_permissions = %w[gds_editor]
+
+    base.before(:each) do |example|
+      @user = get_next_user(
+        "Travel Advice Publisher" =>
+        example.metadata.fetch(:permissions, default_permissions)
+      )
+      signin_with_user(@user)
     end
   end
 end


### PR DESCRIPTION
These changes improve the support for running the Publishing E2E Tests where the applications under test use Signon for authentication. This is a continuation of the initial changes back in November [1], which implemented initial support for Signon aimed at allowing the tests to run (but not necessarily pass yet) when run in the Rails production environment.

1: https://github.com/alphagov/publishing-e2e-tests/pull/56

When running the tests with docker compose, this shouldn't have any effect, as Signon is not used. When running the tests with govuk-guix, not all of the pass, I get 11 passes, and 12 failures. The 5 Manuals Publisher tests all fail, I think due to issues with the test users Signon organisation. 6 tests fail between Specialist Publisher and Travel Advice Publisher due to 302 redirects, probably from authenticating proxy. There is also one test failure in the Publisher tests, as it doesn't expect the service to be running on a odd port.


  