### PR TITLE
Update to run JUnit last

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -296,11 +296,14 @@ timestamps {
           sh("docker-compose logs --timestamps | sort -t '|' -k 2.2,2.31 > docker.log")
 
           archiveArtifacts(artifacts: "docker.log,tmp/errors-verbose.log,tmp/screenshot*.png", fingerprint: true)
-          junit 'tmp/rspec*.xml'
         }
 
         stage("Stop Docker") {
           sh("make stop")
+        }
+
+        stage("JUnit") {
+          junit 'tmp/rspec*.xml'
         }
       }
     }


### PR DESCRIPTION
We discovered while investigating another issue that if the tests aren't run JUnit will raise an error before the docker instances are cleaned up by moving this to be the last step it can still raise an error but not cause problems for other stages.