### PR TITLE
This test has been occasionally failing

### DIFF
--- a/spec/specialist_publisher/change_note_spec.rb
+++ b/spec/specialist_publisher/change_note_spec.rb
@@ -6,7 +6,7 @@ feature "Change notes on Specialist Publisher", specialist_publisher: true, gove
   let(:new_body) { Faker::Lorem.paragraph }
   let(:change_note) { Faker::Lorem.sentence }
 
-  scenario "Change note on a Countryside Stewardship Grant" do
+  scenario "Change note on a Countryside Stewardship Grant", flakey: true do
     given_there_is_a_published_countryside_stewardship_grant
     when_i_edit_it_with_a_change_note
     and_publish_it


### PR DESCRIPTION
Failure/Error: click_link("+ full page history")

```
Capybara::ElementNotFound:
  Unable to find visible link "+ full page history"
/usr/local/bundle/gems/capybara-2.16.1/lib/capybara/node/finders.rb:314:in `block in synced_resolve'
/usr/local/bundle/gems/capybara-2.16.1/lib/capybara/node/base.rb:85:in `synchronize'
/usr/local/bundle/gems/capybara-2.16.1/lib/capybara/node/finders.rb:302:in `synced_resolve'
/usr/local/bundle/gems/capybara-2.16.1/lib/capybara/node/finders.rb:37:in `find'
```

The screenshot shows a page with the link shown.

Example builds
https://ci.integration.publishing.service.gov.uk/job/publishing-e2e-tests/job/test-against/3597/
https://ci.integration.publishing.service.gov.uk/job/publishing-e2e-tests/job/test-against/3616/