### PR TITLE
Increase number of processes used for testing to 6

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -37,7 +37,7 @@ timestamps {
           name: "TEST_ARGS"
         ),
         stringParam(
-          defaultValue: "2",
+          defaultValue: "6",
           description: "Set number of processes for parallel testing",
           name: "TEST_PROCESSES"
         ),
@@ -134,7 +134,7 @@ timestamps {
       "ORIGIN_COMMIT": "",
       "TEST_COMMAND": "test",
       "TEST_ARGS": "",
-      "TEST_PROCESSES": "2",
+      "TEST_PROCESSES": "6",
       "ASSET_MANAGER_COMMITISH": DEFAULT_COMMITISH,
       "CONTENT_STORE_COMMITISH": DEFAULT_COMMITISH,
       "GOVERNMENT_FRONTEND_COMMITISH": DEFAULT_COMMITISH,


### PR DESCRIPTION
Jenkins can reliably support a higher number of processes and we gain a speed increase of around 30 seconds by switching to 6 processes. We've also tested this with 4 processes and found the speed gain to be negligible compared to 2.  