### PR TITLE
Add content tagger to docker stack

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -53,6 +53,11 @@ timestamps {
         ),
         stringParam(
           defaultValue: DEFAULT_COMMITISH,
+          description: "Which commit/branch/tag of content-tagger to clone",
+          name: "CONTENT_TAGGER_COMMITISH"
+        ),
+        stringParam(
+          defaultValue: DEFAULT_COMMITISH,
           description: "Which commit/branch/tag of government-frontend to clone",
           name: "GOVERNMENT_FRONTEND_COMMITISH"
         ),
@@ -137,6 +142,7 @@ timestamps {
       "TEST_PROCESSES": "6",
       "ASSET_MANAGER_COMMITISH": DEFAULT_COMMITISH,
       "CONTENT_STORE_COMMITISH": DEFAULT_COMMITISH,
+      "CONTENT_TAGGER_COMMITISH": DEFAULT_COMMITISH,
       "GOVERNMENT_FRONTEND_COMMITISH": DEFAULT_COMMITISH,
       "PUBLISHING_API_COMMITISH": DEFAULT_COMMITISH,
       "ROUTER_API_COMMITISH": DEFAULT_COMMITISH,
@@ -209,6 +215,7 @@ timestamps {
           withEnv([
             "ASSET_MANAGER_COMMITISH=${params.ASSET_MANAGER_COMMITISH}",
             "CONTENT_STORE_COMMITISH=${params.CONTENT_STORE_COMMITISH}",
+            "CONTENT_TAGGER_COMMITISH=${params.CONTENT_TAGGER_COMMITISH}",
             "GOVERNMENT_FRONTEND_COMMITISH=${params.GOVERNMENT_FRONTEND_COMMITISH}",
             "PUBLISHING_API_COMMITISH=${params.PUBLISHING_API_COMMITISH}",
             "ROUTER_API_COMMITISH=${params.ROUTER_API_COMMITISH}",

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ APPS = asset-manager content-store govuk-content-schemas government-frontend \
 	publishing-api router router-api rummager \
 	specialist-publisher static travel-advice-publisher collections-publisher \
 	collections frontend publisher calendars \
-	manuals-publisher manuals-frontend whitehall
+	manuals-publisher manuals-frontend whitehall content-tagger
 
 DOCKER_COMPOSE_CMD = docker-compose -f docker-compose.yml
 TEST_PROCESSES := 1
@@ -50,6 +50,7 @@ setup:
 	$(DOCKER_COMPOSE_CMD) run publisher bundle exec rake db:setup
 	$(DOCKER_COMPOSE_CMD) run frontend bundle exec rake publishing_api:publish_special_routes
 	$(DOCKER_COMPOSE_CMD) run whitehall bundle exec rake db:create db:purge db:setup
+	$(DOCKER_COMPOSE_CMD) run content-tagger bundle exec rake db:setup
 	$(DOCKER_COMPOSE_CMD) run publishing-e2e-tests bundle exec rake wait_for_router
 
 up:

--- a/docker-compose.development.yml
+++ b/docker-compose.development.yml
@@ -64,6 +64,10 @@ services:
     ports:
       - "33070:3070"
 
+  draft-collections:
+    ports:
+      - "33170:3170"
+
   publisher:
     ports:
       - "33000:3000"

--- a/docker-compose.development.yml
+++ b/docker-compose.development.yml
@@ -96,6 +96,10 @@ services:
     ports:
       - "33020:3020"
 
+  content-tagger:
+    ports:
+      - "33116:3116"
+
   asset-manager:
     ports:
       - "33037:3037"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -625,6 +625,38 @@ services:
 
   # TODO: When adding E2E specs for Whitehall, it is likely we'll need to create a service for the Whitehall workers.
 
+  content-tagger: &content-tagger
+    build: apps/content-tagger
+    depends_on:
+      - content-tagger-worker
+      - diet-error-handler
+      - publishing-api
+    environment:
+      << : *govuk-app
+      SENTRY_CURRENT_ENV: content-tagger
+      VIRTUAL_HOST: content-tagger.dev.gov.uk
+    links:
+      - nginx-proxy:error-handler.dev.gov.uk
+      - nginx-proxy:publishing-api.dev.gov.uk
+      - postgres
+      - redis
+    ports:
+      - "3116"
+    volumes:
+      - ./apps/content-tagger/log:/app/log
+
+  content-tagger-worker:
+    << : *content-tagger
+    command: bundle exec sidekiq -C ./config/sidekiq.yml
+    depends_on:
+      - diet-error-handler
+    environment:
+      << : *govuk-app
+      SENTRY_CURRENT_ENV: content-tagger-worker
+    healthcheck:
+      disable: true
+    ports: []
+
   asset-manager: &asset-manager
     build: apps/asset-manager
     command: bundle exec unicorn -p 3037

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -125,6 +125,7 @@ services:
     links:
       - mongo
       - nginx-proxy:draft-government-frontend.dev.gov.uk
+      - nginx-proxy:draft-collections.dev.gov.uk
       - nginx-proxy:draft-frontend.dev.gov.uk
       - nginx-proxy:draft-manuals-frontend.dev.gov.uk
     ports:
@@ -389,6 +390,27 @@ services:
       - "3070"
     volumes:
       - ./apps/collections/log:/app/log
+
+  draft-collections:
+    << : *collections
+    command: bundle exec unicorn -p 3170
+    depends_on:
+      - draft-content-store
+      - draft-static
+      - rummager
+      - diet-error-handler
+    environment:
+      << : *draft-govuk-app
+      SENTRY_CURRENT_ENV: draft-collections
+      VIRTUAL_HOST: draft-collections.dev.gov.uk
+      PORT: 3170
+    links:
+      - nginx-proxy:rummager.dev.gov.uk
+      - nginx-proxy:draft-content-store.dev.gov.uk
+      - nginx-proxy:draft-static.dev.gov.uk
+      - nginx-proxy:error-handler.dev.gov.uk
+    ports:
+      - "3170"
 
   publisher: &publisher
     build:


### PR DESCRIPTION
Boots up content tagger stack

Dependent on https://github.com/alphagov/content-tagger/pull/605