### PR TITLE
Add end to end test for creating a draft taxon within content-tagger

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -82,6 +82,9 @@ test-frontend:
 test-government-frontend:
 	$(TEST_CMD) -o '--tag government_frontend --tag ~flaky --tag ~new'
 
+test-content-tagger:
+	$(TEST_CMD) -o '--tag content_tagger --tag ~flaky --tag ~new'
+
 stop: kill
 
 .PHONY: all $(APPS) clone kill build setup start up test stop \

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -823,5 +823,6 @@ services:
       - nginx-proxy:collections.dev.gov.uk
       - nginx-proxy:publisher.dev.gov.uk
       - nginx-proxy:manuals-publisher.dev.gov.uk
+      - nginx-proxy:content-tagger.dev.gov.uk
     volumes:
       - ./tmp:/app/tmp

--- a/spec/content_tagger/create_draft_taxon_spec.rb
+++ b/spec/content_tagger/create_draft_taxon_spec.rb
@@ -1,0 +1,28 @@
+feature "Creating a draft taxon on Content Tagger", new: true, content_tagger: true do
+  let(:title) { "Create Draft Taxon" + SecureRandom.uuid }
+  let(:slug) { "draft-taxon" + SecureRandom.uuid }
+
+  scenario "Creating a draft taxon" do
+    when_i_create_a_new_taxon
+    then_i_can_preview_it_on_draft_gov_uk
+  end
+
+  def when_i_create_a_new_taxon
+    visit(Plek.find("content-tagger") + "/taxons/new")
+    fill_in "Path", with: slug
+    fill_in "Internal taxon name", with: title
+    fill_in "External taxon name", with: title
+    fill_in "Description", with: Faker::Lorem.paragraph
+    click_button "Create taxon"
+  end
+
+  def then_i_can_preview_it_on_draft_gov_uk
+    url = find_link("/" + slug)[:href]
+    reload_url_until_status_code(url, 200)
+
+    click_link "/" + slug
+    expect(page).to have_content(title)
+    expect_url_matches_draft_gov_uk
+    expect_rendering_application("collections")
+  end
+end


### PR DESCRIPTION
This tests that the content tagger is able to communicate with the draft stack and that the collections frontend is able to render the taxon.