### PR TITLE
Add end to end test for publishing a taxon from Content Tagger

### DIFF
--- a/spec/content_tagger/create_draft_taxon_spec.rb
+++ b/spec/content_tagger/create_draft_taxon_spec.rb
@@ -1,4 +1,6 @@
 feature "Creating a draft taxon on Content Tagger", new: true, content_tagger: true do
+  include ContentTaggerHelpers
+
   let(:title) { "Create Draft Taxon" + SecureRandom.uuid }
   let(:slug) { "draft-taxon" + SecureRandom.uuid }
 
@@ -8,12 +10,7 @@ feature "Creating a draft taxon on Content Tagger", new: true, content_tagger: t
   end
 
   def when_i_create_a_new_taxon
-    visit(Plek.find("content-tagger") + "/taxons/new")
-    fill_in "Path", with: slug
-    fill_in "Internal taxon name", with: title
-    fill_in "External taxon name", with: title
-    fill_in "Description", with: Faker::Lorem.paragraph
-    click_button "Create taxon"
+    create_draft_taxon(slug: slug, title: title)
   end
 
   def then_i_can_preview_it_on_draft_gov_uk

--- a/spec/content_tagger/publishing_taxon_spec.rb
+++ b/spec/content_tagger/publishing_taxon_spec.rb
@@ -1,0 +1,31 @@
+feature "Publishing a taxon on Content Tagger", new: true, content_tagger: true do
+  include ContentTaggerHelpers
+
+  let(:title) { "Publishing a taxon" + SecureRandom.uuid }
+  let(:slug) { "publishing-taxon" + SecureRandom.uuid }
+
+  scenario "Publishing a taxon" do
+    given_there_is_a_draft_taxon
+    when_i_publish_the_taxon
+    then_i_can_view_it_on_gov_uk
+  end
+
+  def given_there_is_a_draft_taxon
+    create_draft_taxon(slug: slug, title: title)
+  end
+
+  def when_i_publish_the_taxon
+    click_link "Publish"
+    click_button "Confirm publish"
+  end
+
+  def then_i_can_view_it_on_gov_uk
+    url = find_link("/" + slug)[:href]
+    reload_url_until_status_code(url, 200)
+
+    click_link "/" + slug
+    expect(page).to have_content(title)
+    expect_url_matches_live_gov_uk
+    expect_rendering_application("collections")
+  end
+end

--- a/spec/support/content_tagger_helpers.rb
+++ b/spec/support/content_tagger_helpers.rb
@@ -1,0 +1,10 @@
+module ContentTaggerHelpers
+  def create_draft_taxon(slug:, title:)
+    visit(Plek.find("content-tagger") + "/taxons/new")
+    fill_in "Path", with: slug
+    fill_in "Internal taxon name", with: title
+    fill_in "External taxon name", with: title
+    fill_in "Description", with: Faker::Lorem.paragraph
+    click_button "Create taxon"
+  end
+end


### PR DESCRIPTION
This test provides confidence that the content tagger can communicate with the live stack.