### PR TITLE
Add test for updating published taxon on Content Tagger

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -76,6 +76,9 @@ test-publisher:
 test-manuals-publisher:
 	$(TEST_CMD) -o '--tag manuals_publisher --tag ~flaky --tag ~new'
 
+test-collections:
+	$(TEST_CMD) -o '--tag collections --tag ~flaky --tag ~new'
+
 test-frontend:
 	$(TEST_CMD) -o '--tag frontend --tag ~flaky --tag ~new'
 

--- a/spec/content_tagger/publishing_taxon_spec.rb
+++ b/spec/content_tagger/publishing_taxon_spec.rb
@@ -15,8 +15,7 @@ feature "Publishing a taxon on Content Tagger", new: true, content_tagger: true 
   end
 
   def when_i_publish_the_taxon
-    click_link "Publish"
-    click_button "Confirm publish"
+    publish_taxon
   end
 
   def then_i_can_view_it_on_gov_uk

--- a/spec/content_tagger/updating_taxon_spec.rb
+++ b/spec/content_tagger/updating_taxon_spec.rb
@@ -1,0 +1,40 @@
+feature "Updating a published taxon on Content Tagger", new: true, collections: true, content_tagger: true do
+  include ContentTaggerHelpers
+
+  let(:title) { "Updating a taxon" + SecureRandom.uuid }
+  let(:slug) { "updating-taxon" + SecureRandom.uuid }
+  let(:updated_content) { "Updated content" + SecureRandom.uuid }
+
+  scenario "Updating a taxon" do
+    given_there_is_a_published_taxon
+    when_i_update_the_taxon
+    then_i_can_view_it_on_gov_uk
+  end
+
+  private
+
+  def given_there_is_a_published_taxon
+    create_draft_taxon(slug: slug, title: title)
+    publish_taxon
+
+    url = find_link("/" + slug)[:href]
+    reload_url_until_status_code(url, 200)
+  end
+
+  def when_i_update_the_taxon
+    click_link "Edit taxon"
+    fill_in "Description", with: updated_content
+    click_button "Save & publish"
+  end
+
+  def then_i_can_view_it_on_gov_uk
+    url = find_link("/" + slug)[:href]
+    reload_url_until_match(url, :has_text?, updated_content)
+
+    click_link "/" + slug
+    expect(page).to have_content(title)
+    expect(page).to have_content(updated_content)
+    expect_url_matches_live_gov_uk
+    expect_rendering_application("collections")
+  end
+end

--- a/spec/support/content_tagger_helpers.rb
+++ b/spec/support/content_tagger_helpers.rb
@@ -7,4 +7,9 @@ module ContentTaggerHelpers
     fill_in "Description", with: Faker::Lorem.paragraph
     click_button "Create taxon"
   end
+
+  def publish_taxon
+    click_link "Publish"
+    click_button "Confirm publish"
+  end
 end


### PR DESCRIPTION
This test provides confidence that the Content Tagger app is able to overwrite existing content on the live stack, and the new content is displayed on the collections frontend.