### PR TITLE
Use a new session for each retry

### DIFF
--- a/spec/support/retry_helpers.rb
+++ b/spec/support/retry_helpers.rb
@@ -27,9 +27,8 @@ module RetryHelpers
       raise "#{url} returned a status code of #{code}"
     end
 
-    session = Capybara::Session.new(Capybara.default_driver)
-
     retry_while_false(reload_options) do
+      session = Capybara::Session.new(Capybara.default_driver)
       session.visit(url)
       if within_selector
         session.witin(within_selector, wait: capybara_options[:wait]) do


### PR DESCRIPTION
Previously Capybara was visiting the same URL in a loop which was acting as a NOOP.  By using a new Capybara session we ensure that Capybara is making a new request each time.