### PR TITLE
Update to use test name in title/slug

### DIFF
--- a/spec/collections_publisher/archiving_child_topic_spec.rb
+++ b/spec/collections_publisher/archiving_child_topic_spec.rb
@@ -2,10 +2,10 @@ feature "Archiving a child topic on Collections Publisher", collections_publishe
   include CollectionsPublisherHelpers
 
   let(:parent_title) { title_with_timestamp }
-  let(:parent_slug) { slug_with_timestamp }
+  let(:parent_slug) { "archiving-collections-publisher-parent-#{SecureRandom.uuid}" }
 
-  let(:child_slug) { slug_with_timestamp }
   let(:child_title) { title_with_timestamp }
+  let(:child_slug) { "archiving-collections-publisher-child-#{SecureRandom.uuid}" }
   let(:link) { ["/topic", parent_slug, child_slug].join("/") }
 
   scenario "Archiving a child topic" do

--- a/spec/collections_publisher/publishing_parent_and_child_topic_spec.rb
+++ b/spec/collections_publisher/publishing_parent_and_child_topic_spec.rb
@@ -2,11 +2,11 @@ feature "Publishing a parent and child topic on Collections Publisher", collecti
   include CollectionsPublisherHelpers
 
   let(:parent_title) { title_with_timestamp }
-  let(:parent_slug) { slug_with_timestamp }
+  let(:parent_slug) { "publishing-collections-publisher-parent-#{SecureRandom.uuid}" }
   let(:link) { "/topic/" + parent_slug }
 
-  let(:child_slug) { slug_with_timestamp }
   let(:child_title) { title_with_timestamp }
+  let(:child_slug) { "publishing-collections-publisher-child-#{SecureRandom.uuid}" }
 
   scenario "Publishing a parent and child topic" do
     given_i_have_a_published_topic

--- a/spec/content_tagger/create_draft_taxon_spec.rb
+++ b/spec/content_tagger/create_draft_taxon_spec.rb
@@ -1,8 +1,8 @@
 feature "Creating a draft taxon on Content Tagger", new: true, content_tagger: true do
   include ContentTaggerHelpers
 
-  let(:title) { "Create Draft Taxon" + SecureRandom.uuid }
-  let(:slug) { "draft-taxon" + SecureRandom.uuid }
+  let(:title) { "Create Draft Taxon #{SecureRandom.uuid}" }
+  let(:slug) { "draft-taxon-#{SecureRandom.uuid}" }
 
   scenario "Creating a draft taxon" do
     when_i_create_a_new_taxon

--- a/spec/content_tagger/publishing_taxon_spec.rb
+++ b/spec/content_tagger/publishing_taxon_spec.rb
@@ -1,8 +1,8 @@
 feature "Publishing a taxon on Content Tagger", new: true, content_tagger: true do
   include ContentTaggerHelpers
 
-  let(:title) { "Publishing a taxon" + SecureRandom.uuid }
-  let(:slug) { "publishing-taxon" + SecureRandom.uuid }
+  let(:title) { "Publishing a taxon #{SecureRandom.uuid}" }
+  let(:slug) { "publishing-taxon-#{SecureRandom.uuid}" }
 
   scenario "Publishing a taxon" do
     given_there_is_a_draft_taxon

--- a/spec/manuals_publisher/creating_draft_spec.rb
+++ b/spec/manuals_publisher/creating_draft_spec.rb
@@ -1,7 +1,7 @@
 feature "Creating a draft on Manuals Publisher", manuals_publisher: true do
   include ManualsPublisherHelpers
 
-  let(:title) { title_with_timestamp }
+  let(:title) { "Creating a draft manual #{SecureRandom.uuid}" }
 
   scenario "Creating a draft manual" do
     when_i_create_a_new_manual

--- a/spec/manuals_publisher/publish_live_spec.rb
+++ b/spec/manuals_publisher/publish_live_spec.rb
@@ -1,7 +1,7 @@
 feature "Publishing content on Manuals Publisher", manuals_publisher: true do
   include ManualsPublisherHelpers
 
-  let(:title) { title_with_timestamp }
+  let(:title) { "Publishing a manual #{SecureRandom.uuid}" }
 
   scenario "Publishing a manual" do
     given_there_is_a_draft_manual_with_a_section

--- a/spec/manuals_publisher/removing_content_spec.rb
+++ b/spec/manuals_publisher/removing_content_spec.rb
@@ -1,7 +1,7 @@
 feature "Removing content on Manuals Publisher", manuals_publisher: true do
   include ManualsPublisherHelpers
 
-  let(:title) { title_with_timestamp }
+  let(:title) { "Removing a section from a manual #{SecureRandom.uuid}" }
   let(:section_title) { "How to eat an orange" }
   let(:section_slug) { "how-to-eat-an-orange" }
 

--- a/spec/manuals_publisher/update_published_content_spec.rb
+++ b/spec/manuals_publisher/update_published_content_spec.rb
@@ -1,7 +1,7 @@
 feature "Updating content on Manuals Publisher", manuals_publisher: true do
   include ManualsPublisherHelpers
 
-  let(:title) { title_with_timestamp }
+  let(:title) { "Updating a manual #{SecureRandom.uuid}" }
   let(:section_title) { title_with_timestamp }
   let(:change_note) { sentence }
 

--- a/spec/manuals_publisher/upload_attachment_spec.rb
+++ b/spec/manuals_publisher/upload_attachment_spec.rb
@@ -1,9 +1,9 @@
 feature "Uploading an attachment on Manuals Publisher", manuals_publisher: true do
   include ManualsPublisherHelpers
 
-  let(:title) { title_with_timestamp }
+  let(:title) { "Uploading atttachent to manual #{SecureRandom.uuid}" }
   let(:section_title) { title_with_timestamp }
-  let(:attachment_title) { title_with_timestamp }
+  let(:attachment_title) { "Uploading atttachent to manual attachment #{SecureRandom.uuid}" }
   let(:file) { File.expand_path("../fixtures/manuals_publisher/manuals.png", __dir__) }
 
   scenario "Uploading an attachment to a manual" do

--- a/spec/publisher/creating_draft_content_spec.rb
+++ b/spec/publisher/creating_draft_content_spec.rb
@@ -2,7 +2,7 @@ feature "Creating draft content on Publisher", publisher: true, frontend: true d
   include PublisherHelpers
 
   let(:title) { title_with_timestamp }
-  let(:slug) { slug_with_timestamp }
+  let(:slug) { "creating-draft-publisher-content-#{SecureRandom.uuid}" }
 
   scenario "Creating a draft artefact" do
     when_i_create_a_new_artefact

--- a/spec/publisher/publishing_content_to_frontend_spec.rb
+++ b/spec/publisher/publishing_content_to_frontend_spec.rb
@@ -2,7 +2,7 @@ feature "Publishing content from Publisher to Frontend", flaky: true, publisher:
   include PublisherHelpers
 
   let(:title) { title_with_timestamp }
-  let(:slug) { slug_with_timestamp }
+  let(:slug) { "publishing-content-publisher-to-frontend-#{SecureRandom.uuid}" }
   let(:subpart_title) { title_with_timestamp }
 
   scenario "Publishing an artefact" do

--- a/spec/publisher/publishing_content_to_government_frontend_spec.rb
+++ b/spec/publisher/publishing_content_to_government_frontend_spec.rb
@@ -2,7 +2,7 @@ feature "Publishing content from Publisher to Government Frontend", publisher: t
   include PublisherHelpers
 
   let(:title) { title_with_timestamp }
-  let(:slug) { "help/" + slug_with_timestamp }
+  let(:slug) { "help/publishing-content-publisher-to-government-frontend-#{SecureRandom.uuid}" }
 
   scenario "Publishing a Help guide" do
     given_there_is_a_draft_help_guide

--- a/spec/publisher/removing_content_with_redirect_spec.rb
+++ b/spec/publisher/removing_content_with_redirect_spec.rb
@@ -2,7 +2,7 @@ feature "Removing content by redirecting it from Publisher", publisher: true do
   include PublisherHelpers
 
   let(:title) { title_with_timestamp }
-  let(:slug) { slug_with_timestamp }
+  let(:slug) { "removing-content-with-redirect-publisher-#{SecureRandom.uuid}" }
   let(:redirect_url) { "https://www.gov.uk/help" }
 
   scenario "Unpublishing an artefact" do

--- a/spec/publisher/removing_content_without_redirect_spec.rb
+++ b/spec/publisher/removing_content_without_redirect_spec.rb
@@ -2,7 +2,7 @@ feature "Removing content without a redirect from Publisher", publisher: true, g
   include PublisherHelpers
 
   let(:title) { title_with_timestamp }
-  let(:slug) { slug_with_timestamp }
+  let(:slug) { "removing-content-without-redirect-publisher-#{SecureRandom.uuid}" }
 
   scenario "Unpublishing an artefact" do
     given_a_published_artefact_with_subpages

--- a/spec/publisher/updating_published_content_spec.rb
+++ b/spec/publisher/updating_published_content_spec.rb
@@ -2,7 +2,7 @@ feature "Updating published content from Publisher", publisher: true, frontend: 
   include PublisherHelpers
 
   let(:title) { title_with_timestamp }
-  let(:slug) { slug_with_timestamp }
+  let(:slug) { "updating-published-content-publisher-#{SecureRandom.uuid}" }
 
   scenario "Scheduling downtime for a transaction on Publisher" do
     given_there_is_a_published_transaction_artefact

--- a/spec/specialist_publisher/change_note_spec.rb
+++ b/spec/specialist_publisher/change_note_spec.rb
@@ -1,7 +1,7 @@
 feature "Change notes on Specialist Publisher", specialist_publisher: true, government_frontend: true do
   include SpecialistPublisherHelpers
 
-  let(:title) { title_with_timestamp }
+  let(:title) { "Change note Specialist Publisher #{SecureRandom.uuid}" }
   let(:old_body) { Faker::Lorem.paragraph }
   let(:new_body) { Faker::Lorem.paragraph }
   let(:change_note) { Faker::Lorem.sentence }

--- a/spec/specialist_publisher/creating_spec.rb
+++ b/spec/specialist_publisher/creating_spec.rb
@@ -1,7 +1,7 @@
 feature "Creating a draft on Specialist Publisher", specialist_publisher: true, government_frontend: true do
   include SpecialistPublisherHelpers
 
-  let(:title) { title_with_timestamp }
+  let(:title) { "Creating a draft Specialist Publisher #{SecureRandom.uuid}" }
 
   scenario "Creating a Business Finance Support Scheme" do
     when_i_create_a_business_finance_support_scheme

--- a/spec/specialist_publisher/discarding_draft_spec.rb
+++ b/spec/specialist_publisher/discarding_draft_spec.rb
@@ -1,7 +1,7 @@
 feature "Discarding a draft on Specialist Publisher", specialist_publisher: true, government_frontend: true do
   include SpecialistPublisherHelpers
 
-  let(:title) { title_with_timestamp }
+  let(:title) { "Discarding a draft Specialist Publisher #{SecureRandom.uuid}" }
 
   scenario "Discarding a draft CMA case" do
     given_there_is_a_draft_cma_case

--- a/spec/specialist_publisher/editing_spec.rb
+++ b/spec/specialist_publisher/editing_spec.rb
@@ -1,8 +1,8 @@
 feature "Editing with Specialist Publisher", specialist_publisher: true, government_frontend: true do
   include SpecialistPublisherHelpers
 
-  let(:old_title) { title_with_timestamp }
-  let(:new_title) { title_with_timestamp }
+  let(:old_title) { "Editing Specialist Publisher Old title #{SecureRandom.uuid}" }
+  let(:new_title) { "Editing Specialist Publisher New title #{SecureRandom.uuid}" }
 
   scenario "Editing an Asylum Support Decision" do
     given_there_is_an_asylum_support_decision

--- a/spec/specialist_publisher/publishing_spec.rb
+++ b/spec/specialist_publisher/publishing_spec.rb
@@ -1,7 +1,7 @@
 feature "Publishing with Specialist Publisher", specialist_publisher: true, government_frontend: true do
   include SpecialistPublisherHelpers
 
-  let(:title) { title_with_timestamp }
+  let(:title) { "Publishing Specialist Publisher #{SecureRandom.uuid}" }
 
   scenario "Publishing an AAIB Report" do
     given_there_is_a_draft_aaib_report

--- a/spec/specialist_publisher/unpublishing_spec.rb
+++ b/spec/specialist_publisher/unpublishing_spec.rb
@@ -1,7 +1,7 @@
 feature "Unpublishing with Specialist Publisher", specialist_publisher: true, government_frontend: true do
   include SpecialistPublisherHelpers
 
-  let(:title) { "#{Faker::Book.title} #{Time.now.to_i}" }
+  let(:title) { "Unpublishing Specialist Publisher #{SecureRandom.uuid}" }
 
   scenario "Unpublishing a DFID research output" do
     given_there_is_a_published_dfid_research_output

--- a/spec/specialist_publisher/upload_attachment_spec.rb
+++ b/spec/specialist_publisher/upload_attachment_spec.rb
@@ -3,8 +3,8 @@ require "httparty"
 feature "Uploading an attachment on Specialist Publisher", specialist_publisher: true, government_frontend: true do
   include SpecialistPublisherHelpers
 
-  let(:title) { title_with_timestamp }
-  let(:attachment_title) { title_with_timestamp }
+  let(:title) { "Uploading an attachment to a EAT decision #{SecureRandom.uuid}" }
+  let(:attachment_title) { "Uploading an attachment to a EAT decision attachment #{SecureRandom.uuid}" }
   let(:file) { File.expand_path("../fixtures/specialist_publisher/tax_returns.pdf", __dir__) }
 
   scenario "Uploading an attachment to a EAT decision" do


### PR DESCRIPTION
When investigating issues it is currently difficult to find where an error occured within the `docker.log`.
By using the test name along with a random UUID it is much simpler to determine which requests belong to a given test.