### PR TITLE
Add flag to disable the GDS API cache

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,6 +3,7 @@ version: '3.4'
 x-govuk-app-env: &govuk-app
   DISABLE_DATABASE_ENVIRONMENT_CHECK: 1
   GDS_SSO_STRATEGY: mock
+  GDS_API_DISABLE_CACHE: "true"
   GOVUK_APP_DOMAIN: dev.gov.uk
   GOVUK_ASSET_ROOT: http://assets-origin.dev.gov.uk
   GOVUK_WEBSITE_ROOT: http://www.dev.gov.uk


### PR DESCRIPTION
Caching at the GDS API layer meant that responses to content-store requests weren't being reissued after the content had been updated.

By setting this flag we prevent the aforementioned caching from causing updates not to appear on frontends.  This was affecting collections frontend from the content-tagger publishing tests.