### PR TITLE
Setup RabbitMQ between publishing-api and rummager

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,3 +14,5 @@ WORKDIR $APP_HOME
 ADD Gemfile* $APP_HOME/
 RUN bundle install
 ADD . $APP_HOME
+
+ENV RABBITMQ_URL amqp://guest:guest@rabbitmq:5672

--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,6 @@
 source "https://rubygems.org"
 
+gem "bunny"
 gem "byebug"
 gem "capybara"
 gem "capybara-screenshot"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -3,7 +3,10 @@ GEM
   specs:
     addressable (2.5.2)
       public_suffix (>= 2.0.2, < 4.0)
+    amq-protocol (2.3.0)
     ast (2.3.0)
+    bunny (2.9.1)
+      amq-protocol (~> 2.3.0)
     byebug (9.1.0)
     capybara (2.17.0)
       addressable
@@ -105,6 +108,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  bunny
   byebug
   capybara
   capybara-screenshot

--- a/Makefile
+++ b/Makefile
@@ -41,7 +41,7 @@ setup:
 	$(DOCKER_COMPOSE_CMD) run publishing-api bundle exec rake db:setup
 	$(DOCKER_COMPOSE_CMD) run -e RUMMAGER_INDEX=all rummager bundle exec rake rummager:create_all_indices
 	$(DOCKER_COMPOSE_CMD) run publishing-api-worker rails runner 'Sidekiq::Queue.new.clear'
-	# $(DOCKER_COMPOSE_CMD) run publishing-api-worker bundle exec rails runner 'channel = Bunny.new.start.create_channel;Bunny::Exchange.new(channel, :topic, "published_documents")'
+	$(DOCKER_COMPOSE_CMD) run publishing-e2e-tests bundle exec rake setup_rabbitmq_rummager
 	$(DOCKER_COMPOSE_CMD) run -e RUN_SEEDS_IN_PRODUCTION=true specialist-publisher bundle exec rake db:seed
 	$(DOCKER_COMPOSE_CMD) run specialist-publisher bundle exec rake publishing_api:publish_finders
 	$(DOCKER_COMPOSE_CMD) run travel-advice-publisher bundle exec rake db:seed

--- a/Rakefile
+++ b/Rakefile
@@ -1,3 +1,4 @@
+require "bunny"
 require "httparty"
 require "plek"
 require_relative "lib/retry_while_false"
@@ -10,4 +11,13 @@ task :wait_for_router do
   end
 
   abort "Router has no routes after 60 seconds" unless outcome
+end
+
+task :setup_rabbitmq_rummager do
+  bunny = Bunny.new(ENV["RABBITMQ_URL"])
+  channel = bunny.start.create_channel
+  exch = Bunny::Exchange.new(channel, :topic, "published_documents")
+  channel.queue("rummager_to_be_indexed").bind(exch, routing_key: "*.links")
+  channel.queue("rummager_bulk_reindex").bind(exch, routing_key: "*.bulk.reindex")
+  channel.queue("rummager_govuk_index").bind(exch, routing_key: "*.*")
 end

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -53,9 +53,8 @@ services:
     healthcheck:
       test: "redis-cli ping"
 
-  # commented out as not used currently
-  # rabbitmq:
-  #   image: rabbitmq
+  rabbitmq:
+    image: rabbitmq
 
   elasticsearch:
     image: elasticsearch:1.7.6
@@ -66,11 +65,15 @@ services:
     healthcheck:
       test: "curl --silent --fail localhost:9200/_cluster/health || exit 1"
 
-  rummager:
+  rummager: &rummager
     build: apps/rummager
     command: bundle exec unicorn -p 3009
     depends_on:
       - diet-error-handler
+      - rummager-worker
+      - rummager-listener-publishing-queue
+      - rummager-listener-insert-data
+      - rummager-listener-bulk-insert-data
     environment:
       << : *govuk-app
       GOVUK_APP_NAME: rummager
@@ -84,6 +87,58 @@ services:
       - "3009"
     volumes:
       - ./apps/rummager/log:/app/log
+
+  rummager-worker:
+    << : *rummager
+    command: bundle exec sidekiq -C ./config/sidekiq.yml
+    depends_on:
+      - diet-error-handler
+      - rabbitmq
+    environment: &rummager-worker-env
+      << : *govuk-app
+      RABBITMQ_HOSTS: rabbitmq
+      RABBITMQ_VHOST: /
+      RABBITMQ_USER: guest
+      RABBITMQ_PASSWORD: guest
+      GOVUK_APP_NAME: rummager-worker
+      SENTRY_CURRENT_ENV: rummager-worker
+    ports: []
+
+  rummager-listener-publishing-queue:
+    << : *rummager
+    command: bundle exec rake message_queue:listen_to_publishing_queue
+    depends_on:
+      - diet-error-handler
+      - rabbitmq
+    environment:
+      << : *rummager-worker-env
+      GOVUK_APP_NAME: rummager-listener-publishing-queue
+      SENTRY_CURRENT_ENV: rummager-listener-publishing-queue
+    ports: []
+
+  rummager-listener-insert-data:
+    << : *rummager
+    command: bundle exec rake message_queue:insert_data_into_govuk
+    depends_on:
+      - diet-error-handler
+      - rabbitmq
+    environment:
+      << : *rummager-worker-env
+      GOVUK_APP_NAME: rummager-listener-insert-data
+      SENTRY_CURRENT_ENV: rummager-listener-insert-data
+    ports: []
+
+  rummager-listener-bulk-insert-data:
+    << : *rummager
+    command: bundle exec rake message_queue:bulk_insert_data_into_govuk
+    depends_on:
+      - diet-error-handler
+      - rabbitmq
+    environment:
+      << : *rummager-worker-env
+      GOVUK_APP_NAME: rummager-listener-bulk-insert-data
+      SENTRY_CURRENT_ENV: rummager-listener-bulk-insert-data
+    ports: []
 
   diet-error-handler:
     build: diet-error-handler
@@ -218,6 +273,7 @@ services:
       - publishing-api-worker
       - diet-error-handler
       - memcached
+      - rabbitmq
     environment:
       << : *govuk-app
       DISABLE_QUEUE_PUBLISHER: 1
@@ -227,7 +283,6 @@ services:
     links:
       - postgres
       - redis
-      # - rabbitmq
       - nginx-proxy:error-handler.dev.gov.uk
     ports:
       - "3093"
@@ -243,6 +298,7 @@ services:
       - draft-content-store
       - diet-error-handler
       - memcached
+      - rabbitmq
     environment:
       << : *govuk-app
       DISABLE_QUEUE_PUBLISHER: 1
@@ -253,7 +309,6 @@ services:
     links:
       - postgres
       - redis
-      # - rabbitmq
       - nginx-proxy:content-store.dev.gov.uk
       - nginx-proxy:draft-content-store.dev.gov.uk
       - nginx-proxy:error-handler.dev.gov.uk


### PR DESCRIPTION
To progress with testing on content tagger we need rummager to be
populated with publishing content.  This is done via messages posted to
RabbitMQ from publishing-api.