### PR TITLE
Fix scenario where attachment doesn't appear in section

### DIFF
--- a/spec/manuals_publisher/upload_attachment_spec.rb
+++ b/spec/manuals_publisher/upload_attachment_spec.rb
@@ -16,6 +16,9 @@ feature "Uploading an attachment on Manuals Publisher", manuals_publisher: true 
   def given_there_is_a_draft_manual_with_a_section
     create_draft_manual(title: title)
     create_manual_section(title: section_title)
+
+    url = find_link("Preview draft")[:href]
+    reload_url_until_match(url, :has_text?, section_title)
   end
 
   def when_i_upload_an_attachment
@@ -38,10 +41,6 @@ feature "Uploading an attachment on Manuals Publisher", manuals_publisher: true 
   end
 
   def then_i_can_access_the_attachment_through_the_draft
-    url = find_link("Preview draft")[:href]
-
-    reload_url_until_status_code(url, 200)
-
     click_link("Preview draft")
 
     section_url = find_link(section_title)[:href]


### PR DESCRIPTION
We've had a few instances where this error happens:

```
After 60 seconds,

http://draft-origin.dev.gov.uk/guidance/uploading-atttachent-to-manual-a518a3ae
  -9133-4a90-a3cb-037ca7741829/whats-become-of-waring-1516019030

didn't match

Uploading atttachent to manual attachment 0959f5e5-53e7-4194-9e4a-cf67d83591a7

for has_text?
```

By moving this reload_url_until_match to before the attachment gets added we
can ensure that the request to the publishing-api to create the new section
and the request to the publishing-api to add the attachment link happen in
the correct order.

The logs don't provide enough information to confirm this theory, but in my
opinion is the only possible cause of this flakyness.