### PR TITLE
Add test covering content tagger linking content

### DIFF
--- a/spec/content_tagger/adding_taxon_to_external_content_spec.rb
+++ b/spec/content_tagger/adding_taxon_to_external_content_spec.rb
@@ -28,9 +28,7 @@ feature "Adding a taxon to external content", new: true, collections: true, cont
   end
 
   def when_i_tag_the_guide_with_the_taxon
-    visit(Plek.find("content-tagger") + "/taggings/lookup")
-    fill_in "content_lookup_form_base_path", with: "/" + guide_slug
-    click_button "Edit page"
+    visit_tag_external_content_page(slug: guide_slug)
     select2(taxon_title, css: "#s2id_tagging_tagging_update_form_taxons")
     click_button "Update tagging"
   end

--- a/spec/content_tagger/linking_related_content_spec.rb
+++ b/spec/content_tagger/linking_related_content_spec.rb
@@ -1,0 +1,48 @@
+feature "Adding related content to Publisher content", new: true, content_tagger: true, frontend: true, publisher: true do
+  include ContentTaggerHelpers
+  include PublisherHelpers
+
+  let(:guide_title) { "Transaction with related content " + SecureRandom.uuid }
+  let(:guide_slug) { "transaction-with-related-content-" + SecureRandom.uuid }
+  let(:related_content_title) { "Related transaction " + SecureRandom.uuid }
+  let(:related_content_slug) { "related-transaction-" + SecureRandom.uuid }
+
+  scenario "Adding related content to a Publisher guide" do
+    given_there_is_a_published_guide
+    when_i_add_related_content_to_the_guide
+    then_the_related_content_is_linked_to_from_the_guide
+  end
+
+  def given_there_is_a_published_guide
+    @guide_url = create_and_publish_guide(slug: guide_slug, title: guide_title)
+  end
+
+  def when_i_add_related_content_to_the_guide
+    @related_content_url = create_and_publish_guide(slug: related_content_slug, title: related_content_title)
+    visit_tag_external_content_page(slug: guide_slug)
+
+    find("input.new-base-path").set("/" + related_content_slug)
+    click_button "Add related item"
+    expect(page).to have_text(related_content_slug)
+    click_button "Update tagging"
+    expect(page).to have_text("Tags have been updated!")
+  end
+
+  def then_the_related_content_is_linked_to_from_the_guide
+    reload_url_until_status_code(@guide_url, 200)
+    reload_url_until_match(@guide_url, :has_text?, related_content_title)
+    visit(@guide_url)
+
+    related_content_link = find_link(related_content_title)[:href]
+
+    expect(related_content_link).to eq(@related_content_url)
+    expect_url_matches_live_gov_uk
+    expect_rendering_application("frontend")
+  end
+
+  def create_and_publish_guide(slug:, title:)
+    create_publisher_artefact(slug: slug, title: title)
+    publish_artefact
+    find_link("View this on the GOV.UK website")[:href]
+  end
+end

--- a/spec/support/content_tagger_helpers.rb
+++ b/spec/support/content_tagger_helpers.rb
@@ -12,4 +12,10 @@ module ContentTaggerHelpers
     click_link "Publish"
     click_button "Confirm publish"
   end
+
+  def visit_tag_external_content_page(slug:)
+    visit(Plek.find("content-tagger") + "/taggings/lookup")
+    fill_in "content_lookup_form_base_path", with: "/" + slug
+    click_button "Edit page"
+  end
 end


### PR DESCRIPTION
This test gives confidence that related content associated via content
tagger is properly displayed on frontend.