### PR TITLE
Remove `new` tag from first two content tagger tests

### DIFF
--- a/spec/content_tagger/create_draft_taxon_spec.rb
+++ b/spec/content_tagger/create_draft_taxon_spec.rb
@@ -1,4 +1,4 @@
-feature "Creating a draft taxon on Content Tagger", new: true, collections: true, content_tagger: true do
+feature "Creating a draft taxon on Content Tagger", collections: true, content_tagger: true do
   include ContentTaggerHelpers
 
   let(:title) { "Create Draft Taxon #{SecureRandom.uuid}" }

--- a/spec/content_tagger/publishing_taxon_spec.rb
+++ b/spec/content_tagger/publishing_taxon_spec.rb
@@ -1,4 +1,4 @@
-feature "Publishing a taxon on Content Tagger", new: true, collections: true, content_tagger: true do
+feature "Publishing a taxon on Content Tagger", collections: true, content_tagger: true do
   include ContentTaggerHelpers
 
   let(:title) { "Publishing a taxon #{SecureRandom.uuid}" }


### PR DESCRIPTION
These have now been running for a week without any issues so we should
graduate them out into the main suite. By enabling these tests we can
trigger E2E tests from content tagger.