### PR TITLE
Enable deeper phantom debugging on flaky test

### DIFF
--- a/spec/publisher/publishing_content_to_frontend_spec.rb
+++ b/spec/publisher/publishing_content_to_frontend_spec.rb
@@ -1,6 +1,12 @@
 feature "Publishing content from Publisher to Frontend", flaky: true, publisher: true, frontend: true do
   include PublisherHelpers
 
+  around do |spec|
+    Capybara.current_driver = :poltergeist_logging
+    spec.run
+    Capybara.use_default_driver
+  end
+
   let(:title) { title_with_timestamp }
   let(:slug) { "publishing-content-publisher-to-frontend-#{SecureRandom.uuid}" }
   let(:subpart_title) { title_with_timestamp }

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -115,6 +115,13 @@ RSpec.configure do |config|
   config.add_setting :reload_page_wait_time, default: 60
 end
 
+Capybara.register_driver :poltergeist_logging do |app|
+  driver_options = {
+    phantomjs_options: ["--debug=true"],
+  }
+  Capybara::Poltergeist::Driver.new(app, driver_options)
+end
+
 Capybara.configure do |config|
   config.run_server = false
   config.default_driver = :poltergeist


### PR DESCRIPTION
We've been unable to diagnose the issue with the flaky test from the
docker log. We're hoping that with Phantom logging enabled for only this
test we'll be able to find a root cause.