### PR TITLE
Update link selector to match new wording

### DIFF
--- a/spec/specialist_publisher/change_note_spec.rb
+++ b/spec/specialist_publisher/change_note_spec.rb
@@ -54,7 +54,7 @@ feature "Change notes on Specialist Publisher", specialist_publisher: true, gove
 
     click_link("View on website")
     expect_url_matches_live_gov_uk
-    click_link("+ full page history")
+    click_link("show all updates")
     within("#full-history") do
       expect(page).to have_content(ignore_quotes_regex(change_note))
     end


### PR DESCRIPTION
@steventux This is the fix for the test broken by the incoming component update in government-frontend.