### PR TITLE
Re-enable images & some clean-up

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -162,7 +162,12 @@ timestamps {
           sh("make pull")
           sh("make build")
         }
+      } catch(e) {
+        failBuild()
+        throw e
+      }
 
+      try {
         stage("Start docker apps") {
           try {
             sh("make start")

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -190,127 +190,128 @@ timestamps {
     }
 
     lock("publishing-e2e-tests-$NODE_NAME") {
-      try {
-        originBuildStatus("Running publishing end-to-end tests on Jenkins", "PENDING")
+      withEnv([
+        "ASSET_MANAGER_COMMITISH=${params.ASSET_MANAGER_COMMITISH}",
+        "CONTENT_STORE_COMMITISH=${params.CONTENT_STORE_COMMITISH}",
+        "CONTENT_TAGGER_COMMITISH=${params.CONTENT_TAGGER_COMMITISH}",
+        "GOVERNMENT_FRONTEND_COMMITISH=${params.GOVERNMENT_FRONTEND_COMMITISH}",
+        "PUBLISHING_API_COMMITISH=${params.PUBLISHING_API_COMMITISH}",
+        "ROUTER_API_COMMITISH=${params.ROUTER_API_COMMITISH}",
+        "RUMMAGER_COMMITISH=${params.RUMMAGER_COMMITISH}",
+        "SPECIALIST_PUBLISHER_COMMITISH=${params.SPECIALIST_PUBLISHER_COMMITISH}",
+        "STATIC_COMMITISH=${params.STATIC_COMMITISH}",
+        "TRAVEL_ADVICE_PUBLISHER_COMMITISH=${params.TRAVEL_ADVICE_PUBLISHER_COMMITISH}",
+        "COLLECTIONS_PUBLISHER_COMMITISH=${params.COLLECTIONS_PUBLISHER_COMMITISH}",
+        "COLLECTIONS_COMMITISH=${params.COLLECTIONS_COMMITISH}",
+        "PUBLISHER_COMMITISH=${params.PUBLISHER_COMMITISH}",
+        "FRONTEND_COMMITISH=${params.FRONTEND_COMMITISH}",
+        "CALENDARS_COMMITISH=${params.CALENDARS_COMMITISH}",
+        "MANUALS_PUBLISHER_COMMITISH=${params.MANUALS_PUBLISHER_COMMITISH}",
+        "MANUALS_FRONTEND_COMMITISH=${params.MANUALS_FRONTEND_COMMITISH}",
+        "WHITEHALL_COMMITISH=${params.WHITEHALL_COMMITISH}",
+      ]) {
+        try {
+          originBuildStatus("Running publishing end-to-end tests on Jenkins", "PENDING")
 
-        stage("Checkout") {
-          checkout(scm)
+          stage("Checkout") {
+            checkout(scm)
+          }
+
+          stage("Bundle Gems") {
+            govuk.bundleApp()
+          }
+
+          stage("Ruby Lint") {
+            govuk.rubyLinter("spec lib")
+          }
+
+        } catch(e) {
+          failBuild()
+          throw e
         }
 
-        stage("Bundle Gems") {
-          govuk.bundleApp()
-        }
-
-        stage("Ruby Lint") {
-          govuk.rubyLinter("spec lib")
-        }
-
-      } catch(e) {
-        failBuild()
-        throw e
-      }
-
-      try {
-        stage("Clone applications") {
-          withEnv([
-            "ASSET_MANAGER_COMMITISH=${params.ASSET_MANAGER_COMMITISH}",
-            "CONTENT_STORE_COMMITISH=${params.CONTENT_STORE_COMMITISH}",
-            "CONTENT_TAGGER_COMMITISH=${params.CONTENT_TAGGER_COMMITISH}",
-            "GOVERNMENT_FRONTEND_COMMITISH=${params.GOVERNMENT_FRONTEND_COMMITISH}",
-            "PUBLISHING_API_COMMITISH=${params.PUBLISHING_API_COMMITISH}",
-            "ROUTER_API_COMMITISH=${params.ROUTER_API_COMMITISH}",
-            "RUMMAGER_COMMITISH=${params.RUMMAGER_COMMITISH}",
-            "SPECIALIST_PUBLISHER_COMMITISH=${params.SPECIALIST_PUBLISHER_COMMITISH}",
-            "STATIC_COMMITISH=${params.STATIC_COMMITISH}",
-            "TRAVEL_ADVICE_PUBLISHER_COMMITISH=${params.TRAVEL_ADVICE_PUBLISHER_COMMITISH}",
-            "COLLECTIONS_PUBLISHER_COMMITISH=${params.COLLECTIONS_PUBLISHER_COMMITISH}",
-            "COLLECTIONS_COMMITISH=${params.COLLECTIONS_COMMITISH}",
-            "PUBLISHER_COMMITISH=${params.PUBLISHER_COMMITISH}",
-            "FRONTEND_COMMITISH=${params.FRONTEND_COMMITISH}",
-            "CALENDARS_COMMITISH=${params.CALENDARS_COMMITISH}",
-            "MANUALS_PUBLISHER_COMMITISH=${params.MANUALS_PUBLISHER_COMMITISH}",
-            "MANUALS_FRONTEND_COMMITISH=${params.MANUALS_FRONTEND_COMMITISH}",
-            "WHITEHALL_COMMITISH=${params.WHITEHALL_COMMITISH}",
-          ]) {
+        try {
+          stage("Clone applications") {
             sh("make clone -j4")
           }
-        }
-      } catch(e) {
-        abortBuild("Publishing end-to-end tests could not clone all repositories")
-      }
-
-      try {
-        stage("Build docker environment") {
-          sh("make build")
+        } catch(e) {
+          abortBuild("Publishing end-to-end tests could not clone all repositories")
         }
 
-        stage("Start docker apps") {
-          try {
-            sh("make start")
-          } catch(e) {
-            echo("We weren't able to setup for tests, this probably means there is a bigger problem. Test aborting")
-            throw e
-          }
-        }
-
-        stage("Run flaky/new tests") {
-          echo "Running flaky/new tests that aren't in main build with `make test TEST_ARGS='--tag flaky --tag new'`"
-          try {
-            sh("make test TEST_PROCESSES=${params.TEST_PROCESSES} TEST_ARGS=\"spec -o '--tag flaky --tag new'\"")
-          } catch(err) {
-            // Send a slack message just when tests fail within docker context
-            def message = "Publishing end-to-end flaky/new tests <${BUILD_URL}|failed>"
-            message += (params.ORIGIN_REPO) ? " for ${params.ORIGIN_REPO}" : ""
-            slackSend(color: "#ffff94", channel: "#end-to-end-tests", message: message)
-          }
-        }
-
-        stage("Run tests") {
-          echo "Running tests with `make ${params.TEST_COMMAND}`"
-          sh("make ${params.TEST_COMMAND} TEST_PROCESSES=${params.TEST_PROCESSES}")
-        }
-
-        if (env.BRANCH_NAME == "master") {
-          echo 'Pushing to test-against branch'
-          sshagent(['govuk-ci-ssh-key']) {
-            sh("git push git@github.com:alphagov/publishing-e2e-tests.git HEAD:refs/heads/test-against --force")
-          }
-        }
-
-        originBuildStatus("Publishing end-to-end tests succeeded on Jenkins", "SUCCESS")
-
-      } catch (e) {
-        failBuild()
-
-        echo("Did this fail due to a flaky test? See: https://github.com/alphagov/publishing-e2e-tests/blob/master/CONTRIBUTING.md")
-        // Send a slack message just when tests fail within docker context
-        def message = "Publishing end-to-end tests <${BUILD_URL}|failed>"
-        message += (params.ORIGIN_REPO) ? " for ${params.ORIGIN_REPO}" : ""
-        slackSend(color: "#d40100", channel: "#end-to-end-tests", message: message)
-
-        throw e
-      } finally {
-        stage("Make logs available") {
-          errors = sh(script: "test -s tmp/errors.log", returnStatus: true)
-          if (errors == 0) {
-            echo("The following errors were logged with sentry/errbit:")
-            sh("cat tmp/errors.log")
-          } else {
-            echo("No errors were sent to sentry/errbit")
+        try {
+          stage("Build docker environment") {
+            sh("make pull")
+            sh("make build")
           }
 
-          echo("dumping docker log")
-          sh("docker-compose logs --timestamps | sort -t '|' -k 2.2,2.31 > docker.log")
+          stage("Start docker apps") {
+            try {
+              sh("make start")
+            } catch(e) {
+              echo("We weren't able to setup for tests, this probably means there is a bigger problem. Test aborting")
+              throw e
+            }
+          }
 
-          archiveArtifacts(artifacts: "docker.log,tmp/errors-verbose.log,tmp/screenshot*.png", fingerprint: true)
-        }
+          stage("Run flaky/new tests") {
+            echo "Running flaky/new tests that aren't in main build with `make test TEST_ARGS='--tag flaky --tag new'`"
+            try {
+              sh("make test TEST_PROCESSES=${params.TEST_PROCESSES} TEST_ARGS=\"spec -o '--tag flaky --tag new'\"")
+            } catch(err) {
+              // Send a slack message just when tests fail within docker context
+              def message = "Publishing end-to-end flaky/new tests <${BUILD_URL}|failed>"
+              message += (params.ORIGIN_REPO) ? " for ${params.ORIGIN_REPO}" : ""
+              slackSend(color: "#ffff94", channel: "#end-to-end-tests", message: message)
+            }
+          }
 
-        stage("Stop Docker") {
-          sh("make stop")
-        }
+          stage("Run tests") {
+            echo "Running tests with `make ${params.TEST_COMMAND}`"
+            sh("make ${params.TEST_COMMAND} TEST_PROCESSES=${params.TEST_PROCESSES}")
+          }
 
-        stage("JUnit") {
-          junit 'tmp/rspec*.xml'
+          if (env.BRANCH_NAME == "master") {
+            echo 'Pushing to test-against branch'
+            sshagent(['govuk-ci-ssh-key']) {
+              sh("git push git@github.com:alphagov/publishing-e2e-tests.git HEAD:refs/heads/test-against --force")
+            }
+          }
+
+          originBuildStatus("Publishing end-to-end tests succeeded on Jenkins", "SUCCESS")
+
+        } catch (e) {
+          failBuild()
+
+          echo("Did this fail due to a flaky test? See: https://github.com/alphagov/publishing-e2e-tests/blob/master/CONTRIBUTING.md")
+          // Send a slack message just when tests fail within docker context
+          def message = "Publishing end-to-end tests <${BUILD_URL}|failed>"
+          message += (params.ORIGIN_REPO) ? " for ${params.ORIGIN_REPO}" : ""
+          slackSend(color: "#d40100", channel: "#end-to-end-tests", message: message)
+
+          throw e
+        } finally {
+          stage("Make logs available") {
+            errors = sh(script: "test -s tmp/errors.log", returnStatus: true)
+            if (errors == 0) {
+              echo("The following errors were logged with sentry/errbit:")
+              sh("cat tmp/errors.log")
+            } else {
+              echo("No errors were sent to sentry/errbit")
+            }
+
+            echo("dumping docker log")
+            sh("docker-compose logs --timestamps | sort -t '|' -k 2.2,2.31 > docker.log")
+
+            archiveArtifacts(artifacts: "docker.log,tmp/errors-verbose.log,tmp/screenshot*.png", fingerprint: true)
+          }
+
+          stage("Stop Docker") {
+            sh("make stop")
+          }
+
+          stage("JUnit") {
+            junit 'tmp/rspec*.xml'
+          }
         }
       }
     }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -114,12 +114,19 @@ timestamps {
        error(reason)
     }
 
+    appsToBuild = []
     apps.each { app ->
       commitishConstant = "${app.constantPrefix}_COMMITISH"
 
       commitish = params[commitishConstant].trim()
       govuk.setEnvar(commitishConstant, commitish)
+
+      if (commitish != app.defaultCommitish) {
+        appsToBuild << app.app
+      }
     }
+
+    govuk.setEnvar("APPS_TO_BUILD", appsToBuild.join(" "))
 
     lock("publishing-e2e-tests-$NODE_NAME") {
       try {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -3,10 +3,43 @@
 REPOSITORY = "publishing-e2e-tests"
 DEFAULT_COMMITISH = "deployed-to-production"
 
+def apps = [
+  [constantPrefix: "ASSET_MANAGER", app: "asset-manager", name: "Asset Manager"],
+  [constantPrefix: "CALENDARS", app: "calendars", name: "Calendars"],
+  [constantPrefix: "COLLECTIONS", app: "collections", name: "Collections"],
+  [constantPrefix: "COLLECTIONS_PUBLISHER", app: "collections-publisher", name: "Collections Publisher"],
+  [constantPrefix: "CONTENT_STORE", app: "content-store", name: "Content Store"],
+  [constantPrefix: "CONTENT_TAGGER", app: "content-tagger", name: "Content Tagger"],
+  [constantPrefix: "FRONTEND", app: "frontend", name: "Frontend"],
+  [constantPrefix: "GOVERNMENT_FRONTEND", app: "government-frontend", name: "Government Frontend"],
+  [constantPrefix: "MANUALS_FRONTEND", app: "manuals-frontend", name: "Manuals Frontend"],
+  [constantPrefix: "MANUALS_PUBLISHER", app: "manuals-publisher", name: "Manuals Publisher"],
+  [constantPrefix: "PUBLISHER", app: "publisher", name: "Publisher"],
+  [constantPrefix: "PUBLISHING_API", app: "publishing-api", name: "Publishing API"],
+  [constantPrefix: "ROUTER", app: "router", name: "Router", defaultCommitish: "master"],
+  [constantPrefix: "ROUTER_API", app: "router-api", name: "Router API"],
+  [constantPrefix: "RUMMAGER", app: "rummager", name: "Rummager"],
+  [constantPrefix: "SPECIALIST_PUBLISHER", app: "specialist-publisher", name: "Specialist Publisher"],
+  [constantPrefix: "STATIC", app: "static", name: "Static"],
+  [constantPrefix: "TRAVEL_ADVICE_PUBLISHER", app: "travel-advice-publisher", name: "Travel Advice Publisher"],
+  [constantPrefix: "WHITEHALL", app: "whitehall", name: "Whitehall"],
+].each { app -> app.defaultCommitish = app.defaultCommitish ?: DEFAULT_COMMITISH }
+
 timestamps {
   node("publishing-e2e-tests") {
 
     def govuk = load("/var/lib/jenkins/groovy_scripts/govuk_jenkinslib.groovy")
+
+    appDefaultCommits = [:]
+    appParams = apps.collect { app ->
+      appDefaultCommits["${app.constantPrefix}_COMMITISH"] = app.defaultCommitish
+
+      stringParam(
+        defaultValue: app.defaultCommitish,
+        description: "Which commit/branch/tag of ${app.name} to clone",
+        name: "${app.constantPrefix}_COMMITISH"
+      )
+    }
 
     properties([
       [$class: "BuildDiscarderProperty",
@@ -40,98 +73,8 @@ timestamps {
           defaultValue: "6",
           description: "Set number of processes for parallel testing",
           name: "TEST_PROCESSES"
-        ),
-        stringParam(
-          defaultValue: DEFAULT_COMMITISH,
-          description: "Which commit/branch/tag of asset-manager to clone",
-          name: "ASSET_MANAGER_COMMITISH"
-        ),
-        stringParam(
-          defaultValue: DEFAULT_COMMITISH,
-          description: "Which commit/branch/tag of content-store to clone",
-          name: "CONTENT_STORE_COMMITISH"
-        ),
-        stringParam(
-          defaultValue: DEFAULT_COMMITISH,
-          description: "Which commit/branch/tag of content-tagger to clone",
-          name: "CONTENT_TAGGER_COMMITISH"
-        ),
-        stringParam(
-          defaultValue: DEFAULT_COMMITISH,
-          description: "Which commit/branch/tag of government-frontend to clone",
-          name: "GOVERNMENT_FRONTEND_COMMITISH"
-        ),
-        stringParam(
-          defaultValue: DEFAULT_COMMITISH,
-          description: "Which commit/branch/tag of publishing-api to clone",
-          name: "PUBLISHING_API_COMMITISH"
-        ),
-        stringParam(
-          defaultValue: DEFAULT_COMMITISH,
-          description: "Which commit/branch/tag of router-api to clone",
-          name: "ROUTER_API_COMMITISH"
-        ),
-        stringParam(
-          defaultValue: DEFAULT_COMMITISH,
-          description: "Which commit/branch/tag of rummager to clone",
-          name: "RUMMAGER_COMMITISH"
-        ),
-        stringParam(
-          defaultValue: DEFAULT_COMMITISH,
-          description: "Which commit/branch/tag of specialist-publisher to clone",
-          name: "SPECIALIST_PUBLISHER_COMMITISH"
-        ),
-        stringParam(
-          defaultValue: DEFAULT_COMMITISH,
-          description: "Which commit/branch/tag of static to clone",
-          name: "STATIC_COMMITISH"
-        ),
-        stringParam(
-          defaultValue: DEFAULT_COMMITISH,
-          description: "Which commit/branch/tag of travel-advice-publisher to clone",
-          name: "TRAVEL_ADVICE_PUBLISHER_COMMITISH"
-        ),
-        stringParam(
-          defaultValue: DEFAULT_COMMITISH,
-          description: "Which commit/branch/tag of collections-publisher to clone",
-          name: "COLLECTIONS_PUBLISHER_COMMITISH"
-        ),
-        stringParam(
-          defaultValue: DEFAULT_COMMITISH,
-          description: "Which commit/branch/tag of collections to clone",
-          name: "COLLECTIONS_COMMITISH"
-        ),
-        stringParam(
-          defaultValue: DEFAULT_COMMITISH,
-          description: "Which commit/branch/tag of publisher to clone",
-          name: "PUBLISHER_COMMITISH"
-        ),
-        stringParam(
-          defaultValue: DEFAULT_COMMITISH,
-          description: "Which commit/branch/tag of frontend to clone",
-          name: "FRONTEND_COMMITISH"
-        ),
-        stringParam(
-          defaultValue: DEFAULT_COMMITISH,
-          description: "Which commit/branch/tag of calendars to clone",
-          name: "CALENDARS_COMMITISH"
-        ),
-        stringParam(
-          defaultValue: DEFAULT_COMMITISH,
-          description: "Which commit/branch/tag of manuals-publisher to clone",
-          name: "MANUALS_PUBLISHER_COMMITISH"
-        ),
-        stringParam(
-          defaultValue: DEFAULT_COMMITISH,
-          description: "Which commit/branch/tag of manuals-frontend to clone",
-          name: "MANUALS_FRONTEND_COMMITISH"
-        ),
-        stringParam(
-          defaultValue: DEFAULT_COMMITISH,
-          description: "Which commit/branch/tag of whitehall to clone",
-          name: "WHITEHALL_COMMITISH"
-        ),
-      ])
+        )
+      ] + appParams)
     ])
 
     govuk.initializeParameters([
@@ -139,26 +82,8 @@ timestamps {
       "ORIGIN_COMMIT": "",
       "TEST_COMMAND": "test",
       "TEST_ARGS": "",
-      "TEST_PROCESSES": "6",
-      "ASSET_MANAGER_COMMITISH": DEFAULT_COMMITISH,
-      "CONTENT_STORE_COMMITISH": DEFAULT_COMMITISH,
-      "CONTENT_TAGGER_COMMITISH": DEFAULT_COMMITISH,
-      "GOVERNMENT_FRONTEND_COMMITISH": DEFAULT_COMMITISH,
-      "PUBLISHING_API_COMMITISH": DEFAULT_COMMITISH,
-      "ROUTER_API_COMMITISH": DEFAULT_COMMITISH,
-      "RUMMAGER_COMMITISH": DEFAULT_COMMITISH,
-      "SPECIALIST_PUBLISHER_COMMITISH": DEFAULT_COMMITISH,
-      "STATIC_COMMITISH": DEFAULT_COMMITISH,
-      "TRAVEL_ADVICE_PUBLISHER_COMMITISH": DEFAULT_COMMITISH,
-      "COLLECTIONS_PUBLISHER_COMMITISH": DEFAULT_COMMITISH,
-      "COLLECTIONS_COMMITISH": DEFAULT_COMMITISH,
-      "PUBLISHER_COMMITISH": DEFAULT_COMMITISH,
-      "FRONTEND_COMMITISH": DEFAULT_COMMITISH,
-      "CALENDARS_COMMITISH": DEFAULT_COMMITISH,
-      "MANUALS_PUBLISHER_COMMITISH": DEFAULT_COMMITISH,
-      "MANUALS_FRONTEND_COMMITISH": DEFAULT_COMMITISH,
-      "WHITEHALL_COMMITISH": DEFAULT_COMMITISH,
-    ])
+      "TEST_PROCESSES": "6"] + appDefaultCommits
+    )
 
     def originBuildStatus = { message, status ->
       if (params.ORIGIN_REPO && params.ORIGIN_COMMIT) {
@@ -189,129 +114,115 @@ timestamps {
        error(reason)
     }
 
+    apps.each { app ->
+      commitishConstant = "${app.constantPrefix}_COMMITISH"
+
+      commitish = params[commitishConstant].trim()
+      govuk.setEnvar(commitishConstant, commitish)
+    }
+
     lock("publishing-e2e-tests-$NODE_NAME") {
-      withEnv([
-        "ASSET_MANAGER_COMMITISH=${params.ASSET_MANAGER_COMMITISH}",
-        "CONTENT_STORE_COMMITISH=${params.CONTENT_STORE_COMMITISH}",
-        "CONTENT_TAGGER_COMMITISH=${params.CONTENT_TAGGER_COMMITISH}",
-        "GOVERNMENT_FRONTEND_COMMITISH=${params.GOVERNMENT_FRONTEND_COMMITISH}",
-        "PUBLISHING_API_COMMITISH=${params.PUBLISHING_API_COMMITISH}",
-        "ROUTER_API_COMMITISH=${params.ROUTER_API_COMMITISH}",
-        "RUMMAGER_COMMITISH=${params.RUMMAGER_COMMITISH}",
-        "SPECIALIST_PUBLISHER_COMMITISH=${params.SPECIALIST_PUBLISHER_COMMITISH}",
-        "STATIC_COMMITISH=${params.STATIC_COMMITISH}",
-        "TRAVEL_ADVICE_PUBLISHER_COMMITISH=${params.TRAVEL_ADVICE_PUBLISHER_COMMITISH}",
-        "COLLECTIONS_PUBLISHER_COMMITISH=${params.COLLECTIONS_PUBLISHER_COMMITISH}",
-        "COLLECTIONS_COMMITISH=${params.COLLECTIONS_COMMITISH}",
-        "PUBLISHER_COMMITISH=${params.PUBLISHER_COMMITISH}",
-        "FRONTEND_COMMITISH=${params.FRONTEND_COMMITISH}",
-        "CALENDARS_COMMITISH=${params.CALENDARS_COMMITISH}",
-        "MANUALS_PUBLISHER_COMMITISH=${params.MANUALS_PUBLISHER_COMMITISH}",
-        "MANUALS_FRONTEND_COMMITISH=${params.MANUALS_FRONTEND_COMMITISH}",
-        "WHITEHALL_COMMITISH=${params.WHITEHALL_COMMITISH}",
-      ]) {
-        try {
-          originBuildStatus("Running publishing end-to-end tests on Jenkins", "PENDING")
+      try {
+        originBuildStatus("Running publishing end-to-end tests on Jenkins", "PENDING")
 
-          stage("Checkout") {
-            checkout(scm)
-          }
-
-          stage("Bundle Gems") {
-            govuk.bundleApp()
-          }
-
-          stage("Ruby Lint") {
-            govuk.rubyLinter("spec lib")
-          }
-
-        } catch(e) {
-          failBuild()
-          throw e
+        stage("Checkout") {
+          checkout(scm)
         }
 
-        try {
-          stage("Clone applications") {
-            sh("make clone -j4")
-          }
-        } catch(e) {
-          abortBuild("Publishing end-to-end tests could not clone all repositories")
+        stage("Bundle Gems") {
+          govuk.bundleApp()
         }
 
-        try {
-          stage("Build docker environment") {
-            sh("make pull")
-            sh("make build")
+        stage("Ruby Lint") {
+          govuk.rubyLinter("spec lib")
+        }
+
+      } catch(e) {
+        failBuild()
+        throw e
+      }
+
+      try {
+        stage("Clone applications") {
+          sh("make clone -j4")
+        }
+      } catch(e) {
+        abortBuild("Publishing end-to-end tests could not clone all repositories")
+      }
+
+      try {
+        stage("Build docker environment") {
+          sh("make pull")
+          sh("make build")
+        }
+
+        stage("Start docker apps") {
+          try {
+            sh("make start")
+          } catch(e) {
+            echo("We weren't able to setup for tests, this probably means there is a bigger problem. Test aborting")
+            throw e
+          }
+        }
+
+        stage("Run flaky/new tests") {
+          echo "Running flaky/new tests that aren't in main build with `make test TEST_ARGS='--tag flaky --tag new'`"
+          try {
+            sh("make test TEST_PROCESSES=${params.TEST_PROCESSES} TEST_ARGS=\"spec -o '--tag flaky --tag new'\"")
+          } catch(err) {
+            // Send a slack message just when tests fail within docker context
+            def message = "Publishing end-to-end flaky/new tests <${BUILD_URL}|failed>"
+            message += (params.ORIGIN_REPO) ? " for ${params.ORIGIN_REPO}" : ""
+            slackSend(color: "#ffff94", channel: "#end-to-end-tests", message: message)
+          }
+        }
+
+        stage("Run tests") {
+          echo "Running tests with `make ${params.TEST_COMMAND}`"
+          sh("make ${params.TEST_COMMAND} TEST_PROCESSES=${params.TEST_PROCESSES}")
+        }
+
+        if (env.BRANCH_NAME == "master") {
+          echo 'Pushing to test-against branch'
+          sshagent(['govuk-ci-ssh-key']) {
+            sh("git push git@github.com:alphagov/publishing-e2e-tests.git HEAD:refs/heads/test-against --force")
+          }
+        }
+
+        originBuildStatus("Publishing end-to-end tests succeeded on Jenkins", "SUCCESS")
+
+      } catch (e) {
+        failBuild()
+
+        echo("Did this fail due to a flaky test? See: https://github.com/alphagov/publishing-e2e-tests/blob/master/CONTRIBUTING.md")
+        // Send a slack message just when tests fail within docker context
+        def message = "Publishing end-to-end tests <${BUILD_URL}|failed>"
+        message += (params.ORIGIN_REPO) ? " for ${params.ORIGIN_REPO}" : ""
+        slackSend(color: "#d40100", channel: "#end-to-end-tests", message: message)
+
+        throw e
+      } finally {
+        stage("Make logs available") {
+          errors = sh(script: "test -s tmp/errors.log", returnStatus: true)
+          if (errors == 0) {
+            echo("The following errors were logged with sentry/errbit:")
+            sh("cat tmp/errors.log")
+          } else {
+            echo("No errors were sent to sentry/errbit")
           }
 
-          stage("Start docker apps") {
-            try {
-              sh("make start")
-            } catch(e) {
-              echo("We weren't able to setup for tests, this probably means there is a bigger problem. Test aborting")
-              throw e
-            }
-          }
+          echo("dumping docker log")
+          sh("docker-compose logs --timestamps | sort -t '|' -k 2.2,2.31 > docker.log")
 
-          stage("Run flaky/new tests") {
-            echo "Running flaky/new tests that aren't in main build with `make test TEST_ARGS='--tag flaky --tag new'`"
-            try {
-              sh("make test TEST_PROCESSES=${params.TEST_PROCESSES} TEST_ARGS=\"spec -o '--tag flaky --tag new'\"")
-            } catch(err) {
-              // Send a slack message just when tests fail within docker context
-              def message = "Publishing end-to-end flaky/new tests <${BUILD_URL}|failed>"
-              message += (params.ORIGIN_REPO) ? " for ${params.ORIGIN_REPO}" : ""
-              slackSend(color: "#ffff94", channel: "#end-to-end-tests", message: message)
-            }
-          }
+          archiveArtifacts(artifacts: "docker.log,tmp/errors-verbose.log,tmp/screenshot*.png", fingerprint: true)
+        }
 
-          stage("Run tests") {
-            echo "Running tests with `make ${params.TEST_COMMAND}`"
-            sh("make ${params.TEST_COMMAND} TEST_PROCESSES=${params.TEST_PROCESSES}")
-          }
+        stage("Stop Docker") {
+          sh("make stop")
+        }
 
-          if (env.BRANCH_NAME == "master") {
-            echo 'Pushing to test-against branch'
-            sshagent(['govuk-ci-ssh-key']) {
-              sh("git push git@github.com:alphagov/publishing-e2e-tests.git HEAD:refs/heads/test-against --force")
-            }
-          }
-
-          originBuildStatus("Publishing end-to-end tests succeeded on Jenkins", "SUCCESS")
-
-        } catch (e) {
-          failBuild()
-
-          echo("Did this fail due to a flaky test? See: https://github.com/alphagov/publishing-e2e-tests/blob/master/CONTRIBUTING.md")
-          // Send a slack message just when tests fail within docker context
-          def message = "Publishing end-to-end tests <${BUILD_URL}|failed>"
-          message += (params.ORIGIN_REPO) ? " for ${params.ORIGIN_REPO}" : ""
-          slackSend(color: "#d40100", channel: "#end-to-end-tests", message: message)
-
-          throw e
-        } finally {
-          stage("Make logs available") {
-            errors = sh(script: "test -s tmp/errors.log", returnStatus: true)
-            if (errors == 0) {
-              echo("The following errors were logged with sentry/errbit:")
-              sh("cat tmp/errors.log")
-            } else {
-              echo("No errors were sent to sentry/errbit")
-            }
-
-            echo("dumping docker log")
-            sh("docker-compose logs --timestamps | sort -t '|' -k 2.2,2.31 > docker.log")
-
-            archiveArtifacts(artifacts: "docker.log,tmp/errors-verbose.log,tmp/screenshot*.png", fingerprint: true)
-          }
-
-          stage("Stop Docker") {
-            sh("make stop")
-          }
-
-          stage("JUnit") {
-            junit 'tmp/rspec*.xml'
-          }
+        stage("JUnit") {
+          junit 'tmp/rspec*.xml'
         }
       }
     }

--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,7 @@ endif
 
 TEST_CMD = $(DOCKER_COMPOSE_CMD) run publishing-e2e-tests bundle exec parallel_rspec -n $(TEST_PROCESSES) $(TEST_ARGS)
 
-all: clone build start test stop
+all: clone pull build start test stop
 
 $(APPS):
 	bin/clone-app $@
@@ -29,7 +29,7 @@ kill:
 	$(DOCKER_COMPOSE_CMD) rm -f
 
 build: kill
-	COMPILE_ASSETS=true $(DOCKER_COMPOSE_CMD) build
+	$(DOCKER_COMPOSE_CMD) build diet-error-handler publishing-e2e-tests
 
 setup:
 	$(DOCKER_COMPOSE_CMD) run publishing-e2e-tests bash -c 'find /app/tmp -name .keep -prune -o -type f -exec rm {} \;'
@@ -55,6 +55,9 @@ setup:
 
 up:
 	$(DOCKER_COMPOSE_CMD) up -d
+
+pull:
+	$(DOCKER_COMPOSE_CMD) pull --parallel --ignore-pull-failures
 
 start: setup up
 
@@ -93,4 +96,4 @@ stop: kill
 .PHONY: all $(APPS) clone kill build setup start up test stop \
 	test-specialist-publisher test-travel-advice-publisher \
 	test-collections-publisher test-publisher test-manuals-publisher \
-	test-frontend
+	test-frontend pull

--- a/Makefile
+++ b/Makefile
@@ -29,7 +29,7 @@ kill:
 	$(DOCKER_COMPOSE_CMD) rm -f
 
 build: kill
-	$(DOCKER_COMPOSE_CMD) build diet-error-handler publishing-e2e-tests
+	$(DOCKER_COMPOSE_CMD) build diet-error-handler publishing-e2e-tests $(APPS_TO_BUILD)
 
 setup:
 	$(DOCKER_COMPOSE_CMD) run publishing-e2e-tests bash -c 'find /app/tmp -name .keep -prune -o -type f -exec rm {} \;'

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ $ make
 ```
 
 Running this command executes the following targets in order, which you can
-choose to run separately to speed up development: `clone`, `build`, `start`,
+choose to run separately to speed up development: `clone`, `pull`, `build`, `start`,
 `test` and `stop`.
 
 For example, to run only the tests for the specialist publisher, you need only
@@ -41,7 +41,31 @@ do:
 
 ```bash
 $ make -j4 clone
-$ make build start test-specialist-publisher stop
+$ make pull build start test-specialist-publisher stop
+```
+
+If you need to run the tests against a branch of an application other than
+deployed-to-production you can specify it to be built as below:
+
+```bash
+$ make -j4 clone
+$ make pull
+$ docker-compose build publisher
+$ make start test-publisher stop
+```
+
+When making changes to an application you will need to rebuild the image before
+the new version will be used.
+
+```bash
+$ docker-compose build publisher
+```
+
+When you have finished testing against your branch version and want to switch back
+to the deployed-to-production version you will need to untag the built image before you can re-pull.
+
+```bash
+$ docker rmi publisher:master
 ```
 
 See [docs/docker.md](docs/docker.md) for more information

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -271,7 +271,7 @@ services:
     ports:
       - "3100"
 
-  publishing-api:
+  publishing-api: &publishing-api
     image: govuk/publishing-api:${PUBLISHING_API_COMMITISH:-master}
     build: apps/publishing-api
     command: bundle exec unicorn -p 3093
@@ -296,8 +296,7 @@ services:
       - ./apps/publishing-api/log:/app/log
 
   publishing-api-worker:
-    image: govuk/publishing-api:${PUBLISHING_API_COMMITISH:-master}
-    build: apps/publishing-api
+    << : *publishing-api
     command: bundle exec sidekiq -C ./config/sidekiq.yml
     depends_on:
       - content-store
@@ -318,9 +317,6 @@ services:
       - nginx-proxy:draft-content-store.dev.gov.uk
       - nginx-proxy:error-handler.dev.gov.uk
     ports: []
-    volumes:
-      - ./apps/govuk-content-schemas:/govuk-content-schemas
-      - ./apps/publishing-api/log:/app/log
 
   specialist-publisher:
     image: govuk/specialist-publisher:${SPECIALIST_PUBLISHER_COMMITISH:-master}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -67,6 +67,7 @@ services:
       test: "curl --silent --fail localhost:9200/_cluster/health || exit 1"
 
   rummager: &rummager
+    image: govuk/rummager:${RUMMAGER_COMMITISH:-master}
     build: apps/rummager
     command: bundle exec unicorn -p 3009
     depends_on:
@@ -151,6 +152,7 @@ services:
       - ./tmp:/app/tmp
 
   router: &router
+    image: govuk/router:${ROUTER_COMMITISH:-master}
     build: apps/router
     environment:
       VIRTUAL_HOST: www.dev.gov.uk
@@ -189,6 +191,7 @@ services:
       - "3155"
 
   router-api: &router-api
+    image: govuk/router-api:${ROUTER_API_COMMITISH:-master}
     build: apps/router-api
     command: bundle exec unicorn -p 3056
     depends_on:
@@ -226,6 +229,7 @@ services:
       - "3156"
 
   content-store: &content-store
+    image: govuk/content-store:${CONTENT_STORE_COMMITISH:-master}
     build: apps/content-store
     command: bundle exec unicorn -p 3068
     depends_on:
@@ -268,6 +272,7 @@ services:
       - "3100"
 
   publishing-api:
+    image: govuk/publishing-api:${PUBLISHING_API_COMMITISH:-master}
     build: apps/publishing-api
     command: bundle exec unicorn -p 3093
     depends_on:
@@ -291,6 +296,7 @@ services:
       - ./apps/publishing-api/log:/app/log
 
   publishing-api-worker:
+    image: govuk/publishing-api:${PUBLISHING_API_COMMITISH:-master}
     build: apps/publishing-api
     command: bundle exec sidekiq -C ./config/sidekiq.yml
     depends_on:
@@ -317,10 +323,9 @@ services:
       - ./apps/publishing-api/log:/app/log
 
   specialist-publisher:
+    image: govuk/specialist-publisher:${SPECIALIST_PUBLISHER_COMMITISH:-master}
     build:
       context: apps/specialist-publisher
-      args:
-        - COMPILE_ASSETS
     command: bundle exec unicorn -p 3064
     depends_on:
       - publishing-api
@@ -343,10 +348,9 @@ services:
       - ./apps/specialist-publisher/log:/app/log
 
   travel-advice-publisher: &travel-advice-publisher
+    image: govuk/travel-advice-publisher:${TRAVEL_ADVICE_PUBLISHER_COMMITISH:-master}
     build:
       context: apps/travel-advice-publisher
-      args:
-        - COMPILE_ASSETS
     command: bundle exec unicorn -p 3035
     depends_on:
       - publishing-api
@@ -386,10 +390,9 @@ services:
     ports: []
 
   collections-publisher: &collections-publisher
+    image: govuk/collections-publisher:${COLLECTIONS_PUBLISHER_COMMITISH:-master}
     build:
       context: apps/collections-publisher
-      args:
-        - COMPILE_ASSETS
     command: bundle exec unicorn -p 3071
     depends_on:
       - publishing-api
@@ -425,10 +428,9 @@ services:
     ports: []
 
   collections: &collections
+    image: govuk/collections:${COLLECTIONS_COMMITISH:-master}
     build:
       context: apps/collections
-      args:
-        - COMPILE_ASSETS
     command: bundle exec unicorn -p 3070
     depends_on:
       - content-store
@@ -471,10 +473,9 @@ services:
       - "3170"
 
   publisher: &publisher
+    image: govuk/publisher:${PUBLISHER_COMMITISH:-master}
     build:
       context: apps/publisher
-      args:
-        - COMPILE_ASSETS
     command: bundle exec unicorn -p 3000
     depends_on:
       - publishing-api
@@ -516,10 +517,9 @@ services:
     ports: []
 
   frontend: &frontend
+    image: govuk/frontend:${FRONTEND_COMMITISH:-master}
     build:
       context: apps/frontend
-      args:
-        - COMPILE_ASSETS
     command: bundle exec unicorn -p 3005
     depends_on:
       - content-store
@@ -564,10 +564,9 @@ services:
       - "3105"
 
   manuals-publisher: &manuals-publisher
+    image: govuk/manuals-publisher:${MANUALS_PUBLISHER_COMMITISH:-master}
     build:
       context: apps/manuals-publisher
-      args:
-        - COMPILE_ASSETS
     command: bundle exec unicorn -p 3205
     depends_on:
       - publishing-api
@@ -607,10 +606,9 @@ services:
     ports: []
 
   manuals-frontend: &manuals-frontend
+    image: govuk/manuals-frontend:${MANUALS_FRONTEND_COMMITISH:-master}
     build:
       context: apps/manuals-frontend
-      args:
-        - COMPILE_ASSETS
     command: bundle exec unicorn -p 3072
     depends_on:
       - content-store
@@ -649,10 +647,9 @@ services:
       - "3172"
 
   calendars: &calendars
+    image: govuk/calendars:${CALENDARS_COMMITISH:-master}
     build:
       context: apps/calendars
-      args:
-        - COMPILE_ASSETS
     command: bundle exec unicorn -p 3011
     depends_on:
       - rummager
@@ -676,10 +673,9 @@ services:
       - ./apps/calendars/log:/app/log
 
   whitehall: &whitehall
+    image: govuk/whitehall:${WHITEHALL_COMMITISH:-master}
     build:
       context: apps/whitehall
-      args:
-        - COMPILE_ASSETS
     command: bundle exec unicorn -p 3020
     depends_on:
       - publishing-api
@@ -706,6 +702,7 @@ services:
   # TODO: When adding E2E specs for Whitehall, it is likely we'll need to create a service for the Whitehall workers.
 
   content-tagger: &content-tagger
+    image: govuk/content-tagger:${CONTENT_TAGGER_COMMITISH:-master}
     build: apps/content-tagger
     depends_on:
       - content-tagger-worker
@@ -738,6 +735,7 @@ services:
     ports: []
 
   asset-manager: &asset-manager
+    image: govuk/asset-manager:${ASSET_MANAGER_COMMITISH:-master}
     build: apps/asset-manager
     command: bundle exec unicorn -p 3037
     depends_on:
@@ -777,6 +775,7 @@ services:
     ports: []
 
   static: &static
+    image: govuk/static:${STATIC_COMMITISH:-master}
     build: apps/static
     command: bundle exec unicorn -p 3013
     depends_on:
@@ -810,6 +809,7 @@ services:
   # draft-finder-frontend:
 
   government-frontend: &government-frontend
+    image: govuk/government-frontend:${GOVERNMENT_FRONTEND_COMMITISH:-master}
     build: apps/government-frontend
     command: bundle exec unicorn -p 3090
     depends_on:


### PR DESCRIPTION
This started off as some cleaning up to follow https://github.com/alphagov/publishing-e2e-tests/pull/150 but since the issue was different I have instead repurposed this.

Mostly this changes the Jenkinsfile to have a collection of all the apps which can be iterated through in each of the contexts where we look through them all. 

It adds an env var that is passed to the makefile of APPS_TO_BUILD which cause building to occur in make build step rather than when the app is needed. I'm not sure if it's a great idea or not since it'll mean branches that exist as tags may be rebuilt.

Further details of all changes in respective commit messages.


