### PR TITLE
Add test for creating a contact

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -93,9 +93,12 @@ test-government-frontend:
 test-content-tagger:
 	$(TEST_CMD) -o '--tag content_tagger --tag ~flaky --tag ~new'
 
+test-contacts:
+	$(TEST_CMD) -o '--tag contacts --tag ~flaky --tag ~new'
+
 stop: kill
 
 .PHONY: all $(APPS) clone kill build setup start up test stop \
 	test-specialist-publisher test-travel-advice-publisher \
 	test-collections-publisher test-publisher test-manuals-publisher \
-	test-frontend pull
+	test-frontend test-content-tagger test-contacts pull

--- a/spec/contacts/publish_a_contact_spec.rb
+++ b/spec/contacts/publish_a_contact_spec.rb
@@ -1,0 +1,25 @@
+feature "Publishing a contact", contacts: true, new: true, government_frontend: true do
+  let(:title) { "Creating a contact #{SecureRandom.uuid}" }
+
+  scenario "Creating a contact" do
+    when_i_create_a_contact
+    then_i_can_view_it_on_gov_uk
+  end
+
+  def when_i_create_a_contact
+    visit(Plek.find("contacts-admin") + "/admin/contacts/new")
+    fill_in "contact_title", with: title
+    fill_in "Description", with: sentence
+    click_button "Create Contact"
+  end
+
+  def then_i_can_view_it_on_gov_uk
+    url = find_link(title)[:href]
+    reload_url_until_status_code(url, 200)
+
+    click_link title
+    expect(page).to have_content(title)
+    expect_url_matches_live_gov_uk
+    expect_rendering_application("government-frontend")
+  end
+end


### PR DESCRIPTION
This provides confidence that when a contact is created it is viewable on
 the live stack for government-frontend.