### PR TITLE
Update publish contact test to cover finder frontend

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -85,6 +85,9 @@ test-manuals-publisher:
 test-collections:
 	$(TEST_CMD) -o '--tag collections --tag ~flaky --tag ~new'
 
+test-finder-frontend:
+	$(TEST_CMD) -o '--tag finder-frontend --tag ~flaky --tag ~new'
+
 test-frontend:
 	$(TEST_CMD) -o '--tag frontend --tag ~flaky --tag ~new'
 
@@ -105,4 +108,5 @@ stop: kill
 .PHONY: all $(APPS) clone kill build setup start up test stop \
 	test-specialist-publisher test-travel-advice-publisher \
 	test-collections-publisher test-publisher test-manuals-publisher \
-	test-frontend test-content-tagger test-contacts pull
+	test-frontend test-content-tagger test-contacts test-finder-frontend \
+	pull

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -167,6 +167,7 @@ services:
       - nginx-proxy:calendars.dev.gov.uk
       - nginx-proxy:manuals-frontend.dev.gov.uk
       - nginx-proxy:whitehall-frontend.dev.gov.uk
+      - nginx-proxy:finder-frontend.dev.gov.uk
     ports:
       - "3054"
       - "3055"

--- a/spec/contacts/publish_a_contact_spec.rb
+++ b/spec/contacts/publish_a_contact_spec.rb
@@ -1,25 +1,35 @@
-feature "Publishing a contact", contacts: true, new: true, government_frontend: true do
+feature "Publishing a contact", contacts: true, new: true, finder_frontend: true, government_frontend: true do
+  include ContactsHelpers
+
   let(:title) { "Creating a contact #{SecureRandom.uuid}" }
 
   scenario "Creating a contact" do
     when_i_create_a_contact
     then_i_can_view_it_on_gov_uk
+    and_i_can_view_it_on_finder
   end
 
   def when_i_create_a_contact
-    visit(Plek.find("contacts-admin") + "/admin/contacts/new")
-    fill_in "contact_title", with: title
-    fill_in "Description", with: sentence
-    click_button "Create Contact"
+    publish_contact(title: title)
   end
 
   def then_i_can_view_it_on_gov_uk
     url = find_link(title)[:href]
     reload_url_until_status_code(url, 200)
+    reload_url_until_match(url, :has_text?, "Contact HMRC")
 
     click_link title
     expect(page).to have_content(title)
     expect_url_matches_live_gov_uk
     expect_rendering_application("government-frontend")
+  end
+
+  def and_i_can_view_it_on_finder
+    contact_finder_url = find_link("Contact HMRC")[:href]
+    reload_url_until_match(contact_finder_url, :has_text?, title)
+
+    click_link "Contact HMRC"
+    expect_rendering_application("finder-frontend")
+    expect(page).to have_content(title)
   end
 end

--- a/spec/support/contacts_helpers.rb
+++ b/spec/support/contacts_helpers.rb
@@ -1,0 +1,8 @@
+module ContactsHelpers
+  def publish_contact(title:)
+    visit(Plek.find("contacts-admin") + "/admin/contacts/new")
+    fill_in "contact_title", with: title
+    fill_in "Description", with: sentence
+    click_button "Create Contact"
+  end
+end


### PR DESCRIPTION
This provides confidence that published contacts are correctly rendered on
the finder frontend for their organisations.