### PR TITLE
Replace timestamp in title with uuid

### DIFF
--- a/spec/collections_publisher/archiving_child_topic_spec.rb
+++ b/spec/collections_publisher/archiving_child_topic_spec.rb
@@ -1,10 +1,10 @@
 feature "Archiving a child topic on Collections Publisher", collections: true, collections_publisher: true do
   include CollectionsPublisherHelpers
 
-  let(:parent_title) { title_with_timestamp }
+  let(:parent_title) { unique_title }
   let(:parent_slug) { "archiving-collections-publisher-parent-#{SecureRandom.uuid}" }
 
-  let(:child_title) { title_with_timestamp }
+  let(:child_title) { unique_title }
   let(:child_slug) { "archiving-collections-publisher-child-#{SecureRandom.uuid}" }
   let(:link) { ["/topic", parent_slug, child_slug].join("/") }
 

--- a/spec/collections_publisher/publishing_parent_and_child_topic_spec.rb
+++ b/spec/collections_publisher/publishing_parent_and_child_topic_spec.rb
@@ -1,11 +1,11 @@
 feature "Publishing a parent and child topic on Collections Publisher", collections: true, collections_publisher: true do
   include CollectionsPublisherHelpers
 
-  let(:parent_title) { title_with_timestamp }
+  let(:parent_title) { unique_title }
   let(:parent_slug) { "publishing-collections-publisher-parent-#{SecureRandom.uuid}" }
   let(:link) { "/topic/" + parent_slug }
 
-  let(:child_title) { title_with_timestamp }
+  let(:child_title) { unique_title }
   let(:child_slug) { "publishing-collections-publisher-child-#{SecureRandom.uuid}" }
 
   scenario "Publishing a parent and child topic" do

--- a/spec/content_tagger/adding_taxon_to_external_content_spec.rb
+++ b/spec/content_tagger/adding_taxon_to_external_content_spec.rb
@@ -16,7 +16,7 @@ feature "Adding a taxon to external content", new: true, collections: true, cont
 
   def given_there_is_a_published_guide
     create_publisher_artefact(slug: guide_slug, title: guide_title, format: "Guide")
-    add_part_to_artefact(title: title_with_timestamp)
+    add_part_to_artefact(title: unique_title)
     publish_artefact
   end
 

--- a/spec/manuals_publisher/update_published_content_spec.rb
+++ b/spec/manuals_publisher/update_published_content_spec.rb
@@ -2,7 +2,7 @@ feature "Updating content on Manuals Publisher", manuals_publisher: true do
   include ManualsPublisherHelpers
 
   let(:title) { "Updating a manual #{SecureRandom.uuid}" }
-  let(:section_title) { title_with_timestamp }
+  let(:section_title) { unique_title }
   let(:change_note) { sentence }
 
   scenario "Update a published manual with a new section" do

--- a/spec/manuals_publisher/upload_attachment_spec.rb
+++ b/spec/manuals_publisher/upload_attachment_spec.rb
@@ -2,7 +2,7 @@ feature "Uploading an attachment on Manuals Publisher", manuals_publisher: true 
   include ManualsPublisherHelpers
 
   let(:title) { "Uploading atttachent to manual #{SecureRandom.uuid}" }
-  let(:section_title) { title_with_timestamp }
+  let(:section_title) { unique_title }
   let(:attachment_title) { "Uploading atttachent to manual attachment #{SecureRandom.uuid}" }
   let(:file) { File.expand_path("../fixtures/manuals_publisher/manuals.png", __dir__) }
 

--- a/spec/publisher/creating_draft_content_spec.rb
+++ b/spec/publisher/creating_draft_content_spec.rb
@@ -1,7 +1,7 @@
 feature "Creating draft content on Publisher", publisher: true, frontend: true do
   include PublisherHelpers
 
-  let(:title) { title_with_timestamp }
+  let(:title) { unique_title }
   let(:slug) { "creating-draft-publisher-content-#{SecureRandom.uuid}" }
 
   scenario "Creating a draft artefact" do

--- a/spec/publisher/publishing_content_to_frontend_spec.rb
+++ b/spec/publisher/publishing_content_to_frontend_spec.rb
@@ -1,9 +1,9 @@
 feature "Publishing content from Publisher to Frontend", flaky: true, publisher: true, frontend: true do
   include PublisherHelpers
 
-  let(:title) { title_with_timestamp }
+  let(:title) { unique_title }
   let(:slug) { "publishing-content-publisher-to-frontend-#{SecureRandom.uuid}" }
-  let(:subpart_title) { title_with_timestamp }
+  let(:subpart_title) { unique_title }
 
   scenario "Publishing an artefact" do
     given_there_is_a_draft_artefact_with_subpage
@@ -16,7 +16,7 @@ feature "Publishing content from Publisher to Frontend", flaky: true, publisher:
 
   def given_there_is_a_draft_artefact_with_subpage
     create_publisher_artefact(slug: slug, title: title, format: "Guide")
-    add_part_to_artefact(title: title_with_timestamp)
+    add_part_to_artefact(title: unique_title)
     @subpart_slug = add_part_to_artefact(title: subpart_title)
   end
 

--- a/spec/publisher/publishing_content_to_government_frontend_spec.rb
+++ b/spec/publisher/publishing_content_to_government_frontend_spec.rb
@@ -1,7 +1,7 @@
 feature "Publishing content from Publisher to Government Frontend", publisher: true, government_frontend: true do
   include PublisherHelpers
 
-  let(:title) { title_with_timestamp }
+  let(:title) { unique_title }
   let(:slug) { "help/publishing-content-publisher-to-government-frontend-#{SecureRandom.uuid}" }
 
   scenario "Publishing a Help guide" do

--- a/spec/publisher/removing_content_with_redirect_spec.rb
+++ b/spec/publisher/removing_content_with_redirect_spec.rb
@@ -1,7 +1,7 @@
 feature "Removing content by redirecting it from Publisher", publisher: true do
   include PublisherHelpers
 
-  let(:title) { title_with_timestamp }
+  let(:title) { unique_title }
   let(:slug) { "removing-content-with-redirect-publisher-#{SecureRandom.uuid}" }
   let(:redirect_url) { "https://www.gov.uk/help" }
 
@@ -16,8 +16,8 @@ feature "Removing content by redirecting it from Publisher", publisher: true do
 
   def given_there_is_a_published_artefact_with_subpages
     create_publisher_artefact(slug: slug, title: title, format: "Guide")
-    add_part_to_artefact(title: title_with_timestamp)
-    @subpart_slug = add_part_to_artefact(title: title_with_timestamp)
+    add_part_to_artefact(title: unique_title)
+    @subpart_slug = add_part_to_artefact(title: unique_title)
 
     publish_artefact
     @published_url = find_link("View this on the GOV.UK website")[:href]

--- a/spec/publisher/removing_content_without_redirect_spec.rb
+++ b/spec/publisher/removing_content_without_redirect_spec.rb
@@ -1,7 +1,7 @@
 feature "Removing content without a redirect from Publisher", publisher: true, government_frontend: true do
   include PublisherHelpers
 
-  let(:title) { title_with_timestamp }
+  let(:title) { unique_title }
   let(:slug) { "removing-content-without-redirect-publisher-#{SecureRandom.uuid}" }
 
   scenario "Unpublishing an artefact" do
@@ -16,8 +16,8 @@ feature "Removing content without a redirect from Publisher", publisher: true, g
   def given_a_published_artefact_with_subpages
     create_publisher_artefact(slug: slug, title: title, format: "Guide")
 
-    add_part_to_artefact(title: title_with_timestamp)
-    @subpart_slug = add_part_to_artefact(title: title_with_timestamp)
+    add_part_to_artefact(title: unique_title)
+    @subpart_slug = add_part_to_artefact(title: unique_title)
 
     publish_artefact
 

--- a/spec/publisher/updating_published_content_spec.rb
+++ b/spec/publisher/updating_published_content_spec.rb
@@ -1,7 +1,7 @@
 feature "Updating published content from Publisher", publisher: true, frontend: true do
   include PublisherHelpers
 
-  let(:title) { title_with_timestamp }
+  let(:title) { unique_title }
   let(:slug) { "updating-published-content-publisher-#{SecureRandom.uuid}" }
 
   scenario "Scheduling downtime for a transaction on Publisher" do

--- a/spec/support/manuals_publisher_helpers.rb
+++ b/spec/support/manuals_publisher_helpers.rb
@@ -7,7 +7,7 @@ module ManualsPublisherHelpers
     click_button "Save as draft"
   end
 
-  def create_manual_section(title: title_with_timestamp, change_note: nil)
+  def create_manual_section(title: unique_title, change_note: nil)
     click_link "Add section"
     fill_in "Section title", with: title
     fill_in "Section summary", with: Faker::Lorem.sentence

--- a/spec/support/specialist_publisher_helpers.rb
+++ b/spec/support/specialist_publisher_helpers.rb
@@ -37,7 +37,7 @@ module SpecialistPublisherHelpers
 
   def fill_in_aaib_report_form(options = {})
     options = {
-      title: title_with_timestamp,
+      title: unique_title,
       summary: Faker::Lorem.sentence,
       body: Faker::Lorem.paragraph,
       date_of_occurance: Faker::Date.backward,
@@ -53,7 +53,7 @@ module SpecialistPublisherHelpers
 
   def fill_in_asylum_support_decision_form(options = {})
     options = {
-      title: title_with_timestamp,
+      title: unique_title,
       summary: Faker::Lorem.sentence,
       body: Faker::Lorem.paragraph,
       reference_number: Faker::Number.number(10),
@@ -74,7 +74,7 @@ module SpecialistPublisherHelpers
 
   def fill_in_business_finance_support_scheme_form(options = {})
     options = {
-      title: title_with_timestamp,
+      title: unique_title,
       summary: Faker::Lorem.sentence,
       body: Faker::Lorem.paragraph,
       continuation_link: Faker::Internet.url,
@@ -92,7 +92,7 @@ module SpecialistPublisherHelpers
 
   def fill_in_cma_case_form(options = {})
     options = {
-      title: title_with_timestamp,
+      title: unique_title,
       summary: Faker::Lorem.sentence,
       body: Faker::Lorem.paragraph,
     }.merge(options)
@@ -105,7 +105,7 @@ module SpecialistPublisherHelpers
 
   def fill_in_countryside_stewardship_grant_form(options = {})
     options = {
-      title: title_with_timestamp,
+      title: unique_title,
       summary: Faker::Lorem.sentence,
       body: Faker::Lorem.paragraph,
     }.merge(options)
@@ -117,7 +117,7 @@ module SpecialistPublisherHelpers
 
   def fill_in_dfid_research_output_form(options = {})
     options = {
-      title: title_with_timestamp,
+      title: unique_title,
       summary: Faker::Lorem.sentence,
       body: Faker::Lorem.paragraph,
       first_published_at: Faker::Date.backward,
@@ -135,7 +135,7 @@ module SpecialistPublisherHelpers
 
   def fill_in_eat_decision_form(options = {})
     options = {
-      title: title_with_timestamp,
+      title: unique_title,
       summary: Faker::Lorem.sentence,
       body: Faker::Lorem.paragraph,
       decision_date: Faker::Date.backward,

--- a/spec/support/text_helpers.rb
+++ b/spec/support/text_helpers.rb
@@ -7,10 +7,6 @@ module TextHelpers
     "#{Faker::Book.title.delete("'")} #{SecureRandom.uuid}"
   end
 
-  def slug_with_timestamp
-    "#{Faker::Internet.slug(nil, '-')}-#{Time.now.to_i}"
-  end
-
   def paragraph_with_timestamp
     "#{Faker::Lorem.paragraph} #{Time.now.to_i}"
   end

--- a/spec/support/text_helpers.rb
+++ b/spec/support/text_helpers.rb
@@ -1,10 +1,10 @@
 require "faker"
 
 module TextHelpers
-  def title_with_timestamp
+  def unique_title
     # As quotes are changed to curly quotes by govspeak they are a pain to
     # match, so we strip them here
-    "#{Faker::Book.title.delete("'")} #{Time.now.to_i}"
+    "#{Faker::Book.title.delete("'")} #{SecureRandom.uuid}"
   end
 
   def slug_with_timestamp

--- a/spec/support/travel_advice_publisher_helpers.rb
+++ b/spec/support/travel_advice_publisher_helpers.rb
@@ -53,7 +53,7 @@ module TravelAdvicePublisherHelpers
     }.merge(options)
 
     options[:parts] = options[:parts].map do |item|
-      title = title_with_timestamp
+      title = unique_title
       {
         title: title,
         body: Faker::Lorem.sentence,

--- a/spec/travel_advice_publisher/creating_draft_spec.rb
+++ b/spec/travel_advice_publisher/creating_draft_spec.rb
@@ -3,7 +3,7 @@ feature "Creating a draft on Travel Advice Publisher", feature: true, travel_adv
 
   let(:country) { "Chad" }
   let(:summary) { paragraph_with_timestamp }
-  let(:part_title) { title_with_timestamp }
+  let(:part_title) { unique_title }
   let(:part_body) { Faker::Lorem.sentence }
 
   scenario "Creating a draft of Chad" do

--- a/spec/travel_advice_publisher/creating_live_spec.rb
+++ b/spec/travel_advice_publisher/creating_live_spec.rb
@@ -3,7 +3,7 @@ feature "Creating a live edition on Travel Advice Publisher", feature: true, tra
 
   let(:country) { "Malta" }
   let(:summary) { paragraph_with_timestamp }
-  let(:part_title) { title_with_timestamp }
+  let(:part_title) { unique_title }
   let(:part_body) { Faker::Lorem.sentence }
 
   scenario "Creating a live edition of Malta" do


### PR DESCRIPTION
Now that we have tests run in parallel, relying on a timestamp isn't a reliable uniqueness as two tests could run in the same second. UUIDs are more reliable in this regard.