### PR TITLE
Boot up Whitehall so it can publish and render content

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -43,7 +43,7 @@ setup:
 	$(DOCKER_COMPOSE_CMD) run publishing-e2e-tests bundle exec rake setup_rabbitmq_rummager
 	$(DOCKER_COMPOSE_CMD) run -e RUMMAGER_INDEX=all rummager bundle exec rake rummager:create_all_indices
 	$(DOCKER_COMPOSE_CMD) run publishing-api-worker rails runner 'Sidekiq::Queue.new.clear'
-	$(DOCKER_COMPOSE_CMD) run whitehall bundle exec rake db:create db:purge db:setup
+	$(DOCKER_COMPOSE_CMD) run whitehall-admin bundle exec rake db:create db:purge db:setup publishing_api:publish_special_routes
 	$(DOCKER_COMPOSE_CMD) run -e RUN_SEEDS_IN_PRODUCTION=true specialist-publisher bundle exec rake db:seed
 	$(DOCKER_COMPOSE_CMD) run specialist-publisher bundle exec rake publishing_api:publish_finders
 	$(DOCKER_COMPOSE_CMD) run travel-advice-publisher bundle exec rake db:seed

--- a/docker-compose.development.yml
+++ b/docker-compose.development.yml
@@ -104,9 +104,17 @@ services:
     ports:
       - "33011:3011"
 
-  whitehall:
+  whitehall-admin:
     ports:
       - "33020:3020"
+
+  whitehall-frontend:
+    ports:
+      - "33120:3020"
+
+  draft-whitehall-frontend:
+    ports:
+      - "33220:3020"
 
   content-tagger:
     ports:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,6 +6,7 @@ x-govuk-app-env: &govuk-app
   GDS_API_DISABLE_CACHE: "true"
   GOVUK_APP_DOMAIN: dev.gov.uk
   GOVUK_ASSET_ROOT: http://assets-origin.dev.gov.uk
+  GOVUK_ASSET_HOST: http://assets-origin.dev.gov.uk
   GOVUK_WEBSITE_ROOT: http://www.dev.gov.uk
   LOG_PATH: log/live.log
   PLEK_SERVICE_SEARCH_URI: http://rummager.dev.gov.uk
@@ -95,6 +96,7 @@ services:
     command: bundle exec foreman run worker
     depends_on:
       - diet-error-handler
+      - publishing-api
       - rabbitmq
     environment: &rummager-worker-env
       << : *govuk-app
@@ -104,6 +106,9 @@ services:
       RABBITMQ_PASSWORD: guest
       GOVUK_APP_NAME: rummager-worker
       SENTRY_CURRENT_ENV: rummager-worker
+    links:
+      - nginx-proxy:publishing-api.dev.gov.uk
+      - nginx-proxy:error-handler.dev.gov.uk
     ports: []
 
   rummager-listener-publishing-queue:
@@ -165,6 +170,7 @@ services:
       - nginx-proxy:frontend.dev.gov.uk
       - nginx-proxy:calendars.dev.gov.uk
       - nginx-proxy:manuals-frontend.dev.gov.uk
+      - nginx-proxy:whitehall-frontend.dev.gov.uk
     ports:
       - "3054"
       - "3055"
@@ -186,6 +192,7 @@ services:
       - nginx-proxy:draft-collections.dev.gov.uk
       - nginx-proxy:draft-frontend.dev.gov.uk
       - nginx-proxy:draft-manuals-frontend.dev.gov.uk
+      - nginx-proxy:draft-whitehall-frontend.dev.gov.uk
     ports:
       - "3154"
       - "3155"
@@ -477,7 +484,7 @@ services:
       - mysql
       - rummager
       - diet-error-handler
-      - whitehall
+      - whitehall-admin
     environment:
       << : *govuk-app
       SENTRY_CURRENT_ENV: contacts-admin
@@ -618,7 +625,7 @@ services:
       - asset-manager
       - manuals-publisher-worker
       - diet-error-handler
-      - whitehall
+      - whitehall-admin
     environment:
       << : *govuk-app
       SENTRY_CURRENT_ENV: manuals-publisher
@@ -715,34 +722,65 @@ services:
     volumes:
       - ./apps/calendars/log:/app/log
 
-  whitehall: &whitehall
+  whitehall-admin: &whitehall
     image: govuk/whitehall:${WHITEHALL_COMMITISH:-master}
     build:
       context: apps/whitehall
     command: bundle exec unicorn -p 3020
     depends_on:
+      - asset-manager
+      - content-store
+      - diet-error-handler
+      - mysql
       - publishing-api
       - rummager
       - static
-      - asset-manager
-      - diet-error-handler
+      - whitehall-worker
     environment:
       << : *govuk-app
-      SENTRY_CURRENT_ENV: whitehall
+      DISABLE_SECURE_COOKIES: "true"
       VIRTUAL_HOST: whitehall-admin.dev.gov.uk
+      MEMCACHE_SERVERS: memcached
+      SENTRY_CURRENT_ENV: whitehall-admin
+      GOVUK_ASSET_ROOT: http://whitehall-admin.dev.gov.uk
     links:
-      - mysql
-      - nginx-proxy:rummager.dev.gov.uk
-      - nginx-proxy:publishing-api.dev.gov.uk
-      - nginx-proxy:error-handler.dev.gov.uk
       - nginx-proxy:asset-manager.dev.gov.uk
+      - nginx-proxy:content-store.dev.gov.uk
+      - nginx-proxy:error-handler.dev.gov.uk
+      - nginx-proxy:publishing-api.dev.gov.uk
+      - nginx-proxy:rummager.dev.gov.uk
       - nginx-proxy:static.dev.gov.uk
     ports:
       - "3020"
     volumes:
       - ./apps/whitehall/log:/app/log
+      - ./apps/whitehall/asset-manager-tmp:/app/asset-manager-tmp
 
-  # TODO: When adding E2E specs for Whitehall, it is likely we'll need to create a service for the Whitehall workers.
+  whitehall-frontend:
+    << : *whitehall
+    environment:
+      << : *govuk-app
+      VIRTUAL_HOST: whitehall-frontend.dev.gov.uk
+      SENTRY_CURRENT_ENV: whitehall-frontend
+
+  draft-whitehall-frontend:
+    << : *whitehall
+    environment:
+      << : *govuk-app
+      VIRTUAL_HOST: draft-whitehall-frontend.dev.gov.uk
+      SENTRY_CURRENT_ENV: draft-whitehall-frontend
+
+  whitehall-worker:
+    << : *whitehall
+    command: bundle exec sidekiq -C ./config/sidekiq.yml
+    depends_on:
+      - diet-error-handler
+    environment:
+      << : *govuk-app
+      SENTRY_CURRENT_ENV: whitehall-worker
+    healthcheck:
+      disable: true
+    ports: []
 
   content-tagger: &content-tagger
     image: govuk/content-tagger:${CONTENT_TAGGER_COMMITISH:-master}


### PR DESCRIPTION
We were missing containers for the frontend and workers of Whitehall.

Creating Whitehall documents also requires rummager to have a line of communication to publishing-api.

The publishing_api:publish_special_routes rake task configures the router to send /government requests to whitehall-frontend.

We mount the asset-manager-tmp folder as a volume, because the whitehall-admin passes assets to the whitehall-worker via it.