### PR TITLE
Add test which covers publishing a document on Whitehall

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -97,6 +97,9 @@ test-content-tagger:
 test-contacts:
 	$(TEST_CMD) -o '--tag contacts --tag ~flaky --tag ~new'
 
+test-whitehall:
+	$(TEST_CMD) -o '--tag whitehall --tag ~flaky --tag ~new'
+
 stop: kill
 
 .PHONY: all $(APPS) clone kill build setup start up test stop \

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -962,5 +962,6 @@ services:
       - nginx-proxy:manuals-publisher.dev.gov.uk
       - nginx-proxy:content-tagger.dev.gov.uk
       - nginx-proxy:contacts-admin.dev.gov.uk
+      - nginx-proxy:whitehall-admin.dev.gov.uk
     volumes:
       - ./tmp:/app/tmp

--- a/spec/support/whitehall_helpers.rb
+++ b/spec/support/whitehall_helpers.rb
@@ -1,0 +1,21 @@
+module WhitehallHelpers
+  def fill_in_opening_date(date)
+    select(date.year, from: "edition_opening_at_1i")
+    select(Date::MONTHNAMES[date.month], from: "edition_opening_at_2i")
+    select(date.day, from: "edition_opening_at_3i")
+  end
+
+  def fill_in_closing_date(date)
+    select(date.year, from: "edition_closing_at_1i")
+    select(Date::MONTHNAMES[date.month], from: "edition_closing_at_2i")
+    select(date.day, from: "edition_closing_at_3i")
+  end
+
+  # Whitehall makes use of a JS library called chosen to improve its select boxes
+  # https://harvesthq.github.io/chosen/
+  # This code was evolved from the gist at https://gist.github.com/thijsc/1391107
+  def select_from_chosen(item_text, options)
+    option_value = page.evaluate_script("$(\"##{options[:id]} option:contains('#{item_text}')\").val()")
+    page.execute_script("$('##{options[:id]}').val('#{option_value}')")
+  end
+end

--- a/spec/whitehall/publishing_document_spec.rb
+++ b/spec/whitehall/publishing_document_spec.rb
@@ -1,0 +1,55 @@
+feature "Publishing a document with Whitehall", new: true, whitehall: true, government_frontend: true do
+  include WhitehallHelpers
+
+  let(:title) { "Publishing Whitehall #{SecureRandom.uuid}" }
+
+  scenario "Publishing a document with Whitehall" do
+    given_i_have_a_draft_document
+    when_i_publish_it
+    then_i_can_view_it_on_gov_uk
+    and_it_is_displayed_on_the_publication_finder
+  end
+
+  def given_i_have_a_draft_document
+    visit(Plek.find("whitehall-admin") + "/government/admin/consultations/new")
+
+    fill_in "Title", with: title
+    fill_in "Summary", with: sentence
+    fill_in "Body", with: paragraph_with_timestamp
+    fill_in_opening_date(Date.today)
+    fill_in_closing_date(Date.today.next_year)
+    select_from_chosen "Test Policy Area", id: "edition_topic_ids"
+
+    click_button("Save")
+    expect(page).to have_text("The document has been saved")
+  end
+
+  def when_i_publish_it
+    click_link("Force publish")
+    fill_in "Reason for force publishing", with: "End to end test"
+    click_button("Force publish")
+
+    expect(page).to have_text("has been published")
+  end
+
+  def then_i_can_view_it_on_gov_uk
+    click_link title
+    url = find_link("View on website")[:href]
+    reload_url_until_status_code(url, 200)
+
+    switch_to_window(window_opened_by { click_link("View on website") })
+
+    expect_rendering_application("government-frontend")
+    expect_url_matches_live_gov_uk
+    expect(page).to have_content(title)
+  end
+
+  def and_it_is_displayed_on_the_publication_finder
+    publication_finder = find('a', text: "Publications", match: :first)[:href]
+    reload_url_until_match(publication_finder, :has_text?, title)
+    visit(publication_finder)
+
+    expect_rendering_application("whitehall")
+    expect(page).to have_content(title)
+  end
+end


### PR DESCRIPTION
This test gives confidence that Whitehall is able to publish documents
to the live stack, and that government-frontend is able to render that
document.

We also assert that the Whitehall publications finder is able to pull
out the published document via Rummager.