### PR TITLE
Update make setup to reduce errors

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -34,7 +34,6 @@ build: kill
 
 setup:
 	$(DOCKER_COMPOSE_CMD) run --rm --no-deps publishing-e2e-tests bash -c 'find /app/tmp -name .keep -prune -o -type f -exec rm {} \;'
-	$(DOCKER_COMPOSE_CMD) up -d elasticsearch
 	$(DOCKER_COMPOSE_CMD) run --rm router-api bundle exec rake db:purge
 	$(DOCKER_COMPOSE_CMD) run --rm draft-router-api bundle exec rake db:purge
 	$(DOCKER_COMPOSE_CMD) run --rm content-store bundle exec rake db:purge

--- a/Makefile
+++ b/Makefile
@@ -33,29 +33,30 @@ build: kill
 	$(DOCKER_COMPOSE_CMD) build diet-error-handler publishing-e2e-tests $(APPS_TO_BUILD)
 
 setup:
-	$(DOCKER_COMPOSE_CMD) run publishing-e2e-tests bash -c 'find /app/tmp -name .keep -prune -o -type f -exec rm {} \;'
-	$(DOCKER_COMPOSE_CMD) run router-api bundle exec rake db:purge
-	$(DOCKER_COMPOSE_CMD) run draft-router-api bundle exec rake db:purge
-	$(DOCKER_COMPOSE_CMD) run content-store bundle exec rake db:purge
-	$(DOCKER_COMPOSE_CMD) run draft-content-store bundle exec rake db:purge
-	$(DOCKER_COMPOSE_CMD) run asset-manager bundle exec rake db:purge
-	$(DOCKER_COMPOSE_CMD) run publishing-api bundle exec rake db:setup
-	$(DOCKER_COMPOSE_CMD) run publishing-api bundle exec rake setup_exchange
-	$(DOCKER_COMPOSE_CMD) run rummager bundle exec rake message_queue:create_queues
-	$(DOCKER_COMPOSE_CMD) run -e RUMMAGER_INDEX=all rummager bundle exec rake rummager:create_all_indices
-	$(DOCKER_COMPOSE_CMD) run rummager bundle exec rake publishing_api:publish_special_routes
-	$(DOCKER_COMPOSE_CMD) run publishing-api-worker rails runner 'Sidekiq::Queue.new.clear'
-	$(DOCKER_COMPOSE_CMD) run whitehall-admin bundle exec rake db:create db:purge db:setup publishing_api:publish_special_routes
-	$(DOCKER_COMPOSE_CMD) run -e RUN_SEEDS_IN_PRODUCTION=true specialist-publisher bundle exec rake db:seed
-	$(DOCKER_COMPOSE_CMD) run specialist-publisher bundle exec rake publishing_api:publish_finders
-	$(DOCKER_COMPOSE_CMD) run travel-advice-publisher bundle exec rake db:seed
-	$(DOCKER_COMPOSE_CMD) run manuals-publisher bundle exec rake db:seed
-	$(DOCKER_COMPOSE_CMD) run collections-publisher bundle exec rake db:setup
-	$(DOCKER_COMPOSE_CMD) run contacts-admin bundle exec rake db:setup finders:publish
-	$(DOCKER_COMPOSE_CMD) run publisher bundle exec rake db:setup
-	$(DOCKER_COMPOSE_CMD) run frontend bundle exec rake publishing_api:publish_special_routes
-	$(DOCKER_COMPOSE_CMD) run content-tagger bundle exec rake db:setup
-	$(DOCKER_COMPOSE_CMD) run publishing-e2e-tests bundle exec rake wait_for_router
+	$(DOCKER_COMPOSE_CMD) run --rm --no-deps publishing-e2e-tests bash -c 'find /app/tmp -name .keep -prune -o -type f -exec rm {} \;'
+	$(DOCKER_COMPOSE_CMD) up -d elasticsearch
+	$(DOCKER_COMPOSE_CMD) run --rm router-api bundle exec rake db:purge
+	$(DOCKER_COMPOSE_CMD) run --rm draft-router-api bundle exec rake db:purge
+	$(DOCKER_COMPOSE_CMD) run --rm content-store bundle exec rake db:purge
+	$(DOCKER_COMPOSE_CMD) run --rm draft-content-store bundle exec rake db:purge
+	$(DOCKER_COMPOSE_CMD) run --rm asset-manager bundle exec rake db:purge
+	$(DOCKER_COMPOSE_CMD) run --rm publishing-api bundle exec rake db:setup
+	$(DOCKER_COMPOSE_CMD) run --rm publishing-api bundle exec rake setup_exchange
+	$(DOCKER_COMPOSE_CMD) run --rm rummager-worker bundle exec rake message_queue:create_queues
+	$(DOCKER_COMPOSE_CMD) run --rm -e RUMMAGER_INDEX=all rummager bundle exec rake rummager:create_all_indices
+	$(DOCKER_COMPOSE_CMD) run --rm rummager bundle exec rake publishing_api:publish_special_routes
+	$(DOCKER_COMPOSE_CMD) run --rm publishing-api-worker rails runner 'Sidekiq::Queue.new.clear'
+	$(DOCKER_COMPOSE_CMD) run --rm whitehall-admin bundle exec rake db:create db:purge db:setup publishing_api:publish_special_routes
+	$(DOCKER_COMPOSE_CMD) run --rm -e RUN_SEEDS_IN_PRODUCTION=true specialist-publisher bundle exec rake db:seed
+	$(DOCKER_COMPOSE_CMD) run --rm specialist-publisher bundle exec rake publishing_api:publish_finders
+	$(DOCKER_COMPOSE_CMD) run --rm travel-advice-publisher bundle exec rake db:seed
+	$(DOCKER_COMPOSE_CMD) run --rm manuals-publisher bundle exec rake db:seed
+	$(DOCKER_COMPOSE_CMD) run --rm collections-publisher bundle exec rake db:setup
+	$(DOCKER_COMPOSE_CMD) run --rm contacts-admin bundle exec rake db:setup finders:publish
+	$(DOCKER_COMPOSE_CMD) run --rm publisher bundle exec rake db:setup
+	$(DOCKER_COMPOSE_CMD) run --rm frontend bundle exec rake publishing_api:publish_special_routes
+	$(DOCKER_COMPOSE_CMD) run --rm content-tagger bundle exec rake db:setup
+	$(DOCKER_COMPOSE_CMD) run --rm publishing-e2e-tests bundle exec rake wait_for_router
 
 up:
 	$(DOCKER_COMPOSE_CMD) up -d

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -73,21 +73,21 @@ services:
   rummager: &rummager
     image: govuk/rummager:${RUMMAGER_COMMITISH:-master}
     build: apps/rummager
-    command: bundle exec unicorn -p 3009
     depends_on:
       - diet-error-handler
       - publishing-api
+      - elasticsearch
       - rummager-worker
       - rummager-listener-publishing-queue
       - rummager-listener-insert-data
       - rummager-listener-bulk-insert-data
+    command: ["./wait-for-it.sh", "elasticsearch:9200", "--", "bundle", "exec", "unicorn", "-p", "3009"]
     environment:
       << : *govuk-app
       GOVUK_APP_NAME: rummager
       SENTRY_CURRENT_ENV: rummager
       VIRTUAL_HOST: rummager.dev.gov.uk
     links:
-      - elasticsearch
       - redis
       - nginx-proxy:error-handler.dev.gov.uk
       - nginx-proxy:publishing-api.dev.gov.uk
@@ -95,14 +95,16 @@ services:
       - "3009"
     volumes:
       - ./apps/rummager/log:/app/log
+      - ./docker/wait-for-it.sh:/app/wait-for-it.sh
 
   rummager-worker:
     << : *rummager
-    command: bundle exec foreman run worker
     depends_on:
       - diet-error-handler
+      - elasticsearch
       - publishing-api
       - rabbitmq
+    command: ["./wait-for-it.sh", "elasticsearch:9200", "--", "bundle", "exec", "foreman", "run", "worker"]
     environment:
       << : *govuk-app
       GOVUK_APP_NAME: rummager-worker

--- a/docker/wait-for-it.sh
+++ b/docker/wait-for-it.sh
@@ -1,0 +1,178 @@
+#!/usr/bin/env bash
+#   Use this script to test if a given TCP host/port are available
+#   As of commit 8ed92e8
+
+cmdname=$(basename $0)
+
+echoerr() { if [[ $QUIET -ne 1 ]]; then echo "$@" 1>&2; fi }
+
+usage()
+{
+    cat << USAGE >&2
+Usage:
+    $cmdname host:port [-s] [-t timeout] [-- command args]
+    -h HOST | --host=HOST       Host or IP under test
+    -p PORT | --port=PORT       TCP port under test
+                                Alternatively, you specify the host and port as host:port
+    -s | --strict               Only execute subcommand if the test succeeds
+    -q | --quiet                Don't output any status messages
+    -t TIMEOUT | --timeout=TIMEOUT
+                                Timeout in seconds, zero for no timeout
+    -- COMMAND ARGS             Execute command with args after the test finishes
+USAGE
+    exit 1
+}
+
+wait_for()
+{
+    if [[ $TIMEOUT -gt 0 ]]; then
+        echoerr "$cmdname: waiting $TIMEOUT seconds for $HOST:$PORT"
+    else
+        echoerr "$cmdname: waiting for $HOST:$PORT without a timeout"
+    fi
+    start_ts=$(date +%s)
+    while :
+    do
+        if [[ $ISBUSY -eq 1 ]]; then
+            nc -z $HOST $PORT
+            result=$?
+        else
+            (echo > /dev/tcp/$HOST/$PORT) >/dev/null 2>&1
+            result=$?
+        fi
+        if [[ $result -eq 0 ]]; then
+            end_ts=$(date +%s)
+            echoerr "$cmdname: $HOST:$PORT is available after $((end_ts - start_ts)) seconds"
+            break
+        fi
+        sleep 1
+    done
+    return $result
+}
+
+wait_for_wrapper()
+{
+    # In order to support SIGINT during timeout: http://unix.stackexchange.com/a/57692
+    if [[ $QUIET -eq 1 ]]; then
+        timeout $BUSYTIMEFLAG $TIMEOUT $0 --quiet --child --host=$HOST --port=$PORT --timeout=$TIMEOUT &
+    else
+        timeout $BUSYTIMEFLAG $TIMEOUT $0 --child --host=$HOST --port=$PORT --timeout=$TIMEOUT &
+    fi
+    PID=$!
+    trap "kill -INT -$PID" INT
+    wait $PID
+    RESULT=$?
+    if [[ $RESULT -ne 0 ]]; then
+        echoerr "$cmdname: timeout occurred after waiting $TIMEOUT seconds for $HOST:$PORT"
+    fi
+    return $RESULT
+}
+
+# process arguments
+while [[ $# -gt 0 ]]
+do
+    case "$1" in
+        *:* )
+        hostport=(${1//:/ })
+        HOST=${hostport[0]}
+        PORT=${hostport[1]}
+        shift 1
+        ;;
+        --child)
+        CHILD=1
+        shift 1
+        ;;
+        -q | --quiet)
+        QUIET=1
+        shift 1
+        ;;
+        -s | --strict)
+        STRICT=1
+        shift 1
+        ;;
+        -h)
+        HOST="$2"
+        if [[ $HOST == "" ]]; then break; fi
+        shift 2
+        ;;
+        --host=*)
+        HOST="${1#*=}"
+        shift 1
+        ;;
+        -p)
+        PORT="$2"
+        if [[ $PORT == "" ]]; then break; fi
+        shift 2
+        ;;
+        --port=*)
+        PORT="${1#*=}"
+        shift 1
+        ;;
+        -t)
+        TIMEOUT="$2"
+        if [[ $TIMEOUT == "" ]]; then break; fi
+        shift 2
+        ;;
+        --timeout=*)
+        TIMEOUT="${1#*=}"
+        shift 1
+        ;;
+        --)
+        shift
+        CLI=("$@")
+        break
+        ;;
+        --help)
+        usage
+        ;;
+        *)
+        echoerr "Unknown argument: $1"
+        usage
+        ;;
+    esac
+done
+
+if [[ "$HOST" == "" || "$PORT" == "" ]]; then
+    echoerr "Error: you need to provide a host and port to test."
+    usage
+fi
+
+TIMEOUT=${TIMEOUT:-15}
+STRICT=${STRICT:-0}
+CHILD=${CHILD:-0}
+QUIET=${QUIET:-0}
+
+# check to see if timeout is from busybox?
+# check to see if timeout is from busybox?
+TIMEOUT_PATH=$(realpath $(which timeout))
+if [[ $TIMEOUT_PATH =~ "busybox" ]]; then
+        ISBUSY=1
+        BUSYTIMEFLAG="-t"
+else
+        ISBUSY=0
+        BUSYTIMEFLAG=""
+fi
+
+if [[ $CHILD -gt 0 ]]; then
+    wait_for
+    RESULT=$?
+    exit $RESULT
+else
+    if [[ $TIMEOUT -gt 0 ]]; then
+        wait_for_wrapper
+        RESULT=$?
+    else
+        wait_for
+        RESULT=$?
+    fi
+fi
+
+if [[ $CLI != "" ]]; then
+    if [[ $RESULT -ne 0 && $STRICT -eq 1 ]]; then
+        echoerr "$cmdname: strict mode, refusing to execute subprocess"
+        exit $RESULT
+    fi
+    exec "${CLI[@]}"
+else
+    exit $RESULT
+fi


### PR DESCRIPTION
Due to the layout of the setup step we found that we were generating a
large amount of errors that weren't valid. By launching the initial cleanup
command with `--no-deps` we eliminate multiple applications being started
before their setup steps have run. We've also added the
`--rm` flag to all of the run commands to reduce the number of one use
containers that are left around after the setup.

The only error that is still generated during setup is
`InvalidFormatError` from the specialist-publisher publishing it's finders
as these appear to no longer be valid.