### PR TITLE
 Add test for Whitehall unpublishing a document

### DIFF
--- a/spec/whitehall/unpublish_document_spec.rb
+++ b/spec/whitehall/unpublish_document_spec.rb
@@ -1,0 +1,34 @@
+feature "Unpublishing a document by consolidating into another page on Whitehall", new: true, whitehall: true, government_frontend: true do
+  include WhitehallHelpers
+
+  let(:title) { "Unpublishing Whitehall #{SecureRandom.uuid}" }
+  let(:redirection_destination) { Plek.new.website_root + "/help" }
+
+  scenario "Unpublishing a document on Whitehall by consolidating into another page " do
+    given_i_have_a_published_document
+    when_i_unpublish_it_and_redirect_to_another_page
+    then_i_am_redirected_when_i_visit_the_page_on_gov_uk
+  end
+
+  def given_i_have_a_published_document
+    create_consultation(title: title)
+    force_publish_document
+    click_link title
+    @published_url = find_link("View on website")[:href]
+  end
+
+  def when_i_unpublish_it_and_redirect_to_another_page
+    click_link "Withdraw or unpublish"
+    choose "Unpublish: consolidated into another GOV.UK page"
+    fill_in "consolidated_alternative_url", with: redirection_destination
+    click_button "Unpublish"
+    expect(page).to have_text("This document has been unpublished")
+  end
+
+  def then_i_am_redirected_when_i_visit_the_page_on_gov_uk
+    reload_url_until_status_code(@published_url, 301, keep_retrying_while: [200, 404])
+
+    visit @published_url
+    expect(current_url).to eq(redirection_destination)
+  end
+end


### PR DESCRIPTION
This gives confidence that Whitehall is able to communicate with
the live stack to unpublish a document and set up the redirect
correctly.