### PR TITLE
Remove `new` tag from remaining content-tagger tests

### DIFF
--- a/spec/content_tagger/adding_taxon_to_external_content_spec.rb
+++ b/spec/content_tagger/adding_taxon_to_external_content_spec.rb
@@ -1,4 +1,4 @@
-feature "Adding a taxon to external content", new: true, collections: true, content_tagger: true, publisher: true do
+feature "Adding a taxon to external content", collections: true, content_tagger: true, publisher: true do
   include ContentTaggerHelpers
   include PublisherHelpers
 

--- a/spec/content_tagger/linking_related_content_spec.rb
+++ b/spec/content_tagger/linking_related_content_spec.rb
@@ -1,4 +1,4 @@
-feature "Adding related content to Publisher content", new: true, content_tagger: true, frontend: true, publisher: true do
+feature "Adding related content to Publisher content", content_tagger: true, frontend: true, publisher: true do
   include ContentTaggerHelpers
   include PublisherHelpers
 

--- a/spec/content_tagger/removing_taxon_spec.rb
+++ b/spec/content_tagger/removing_taxon_spec.rb
@@ -1,4 +1,4 @@
-feature "Removing content from Content Tagger", new: true, collections: true, content_tagger: true do
+feature "Removing content from Content Tagger", collections: true, content_tagger: true do
   include ContentTaggerHelpers
 
   let(:redirection_destination_title) { "Removed taxon destination " + SecureRandom.uuid }

--- a/spec/content_tagger/updating_taxon_spec.rb
+++ b/spec/content_tagger/updating_taxon_spec.rb
@@ -1,4 +1,4 @@
-feature "Updating a published taxon on Content Tagger", new: true, collections: true, content_tagger: true do
+feature "Updating a published taxon on Content Tagger", collections: true, content_tagger: true do
   include ContentTaggerHelpers
 
   let(:title) { "Updating a taxon" + SecureRandom.uuid }


### PR DESCRIPTION
These have now been running for a week without any issues so we should
graduate them out into the main suite. By enabling these tests we can
trigger E2E tests from content tagger.