### PR TITLE
Add routing to Nginx from assets-origin to the frontends

### DIFF
--- a/docker/nginx.tmpl
+++ b/docker/nginx.tmpl
@@ -266,9 +266,65 @@ server {
   {{ $upstream_name := sha1 $host }}
   {{ $proto := or (first (groupByKeys $containers "Env.VIRTUAL_PROTO")) "http" }}
 
+  {{ if eq $host "calendars.dev.gov.uk" }}
+  location /calendars/ {
+    proxy_set_header Host calendars.dev.gov.uk;
+    proxy_pass {{ trim $proto }}://{{ trim $upstream_name }};
+  }
+  {{ end }}
+
+  {{ if eq $host "collections.dev.gov.uk" }}
+  location /collections/ {
+    proxy_set_header Host collections.dev.gov.uk;
+    proxy_pass {{ trim $proto }}://{{ trim $upstream_name }};
+  }
+  {{ end }}
+
+  {{ if eq $host "finder-frontend.dev.gov.uk" }}
+  location /finder-frontend/ {
+    proxy_set_header Host finder-frontend.dev.gov.uk;
+    proxy_pass {{ trim $proto }}://{{ trim $upstream_name }};
+  }
+  {{ end }}
+
+  {{ if eq $host "frontend.dev.gov.uk" }}
+  location /frontend/ {
+    proxy_set_header Host frontend.dev.gov.uk;
+    proxy_pass {{ trim $proto }}://{{ trim $upstream_name }};
+  }
+  {{ end }}
+
+  {{ if eq $host "government-frontend.dev.gov.uk" }}
+  location /government-frontend/ {
+    proxy_set_header Host government-frontend.dev.gov.uk;
+    proxy_pass {{ trim $proto }}://{{ trim $upstream_name }};
+  }
+  {{ end }}
+
+  {{ if eq $host "manuals-frontend.dev.gov.uk" }}
+  location /manuals-frontend/ {
+    proxy_set_header Host manuals-frontend.dev.gov.uk;
+    proxy_pass {{ trim $proto }}://{{ trim $upstream_name }};
+  }
+  {{ end }}
+
   {{ if eq $host "specialist-frontend.dev.gov.uk" }}
   location /specialist-frontend/ {
     proxy_set_header Host specialist-frontend.dev.gov.uk;
+    proxy_pass {{ trim $proto }}://{{ trim $upstream_name }};
+  }
+  {{ end }}
+
+  {{ if eq $host "static.dev.gov.uk" }}
+  location / {
+    proxy_set_header Host static.dev.gov.uk;
+    proxy_pass {{ trim $proto }}://{{ trim $upstream_name }};
+  }
+  {{ end }}
+
+  {{ if eq $host "whitehall-frontend.dev.gov.uk" }}
+  location /government/assets/ {
+    proxy_set_header Host whitehall-frontend.dev.gov.uk;
     proxy_pass {{ trim $proto }}://{{ trim $upstream_name }};
   }
   {{ end }}
@@ -302,4 +358,8 @@ server {
   {{ end }}
 
   {{ end }}
+
+  add_header "Access-Control-Allow-Origin" "*";
+  add_header "Access-Control-Allow-Methods" "GET, OPTIONS";
+  add_header "Access-Control-Allow-Headers" "origin, authorization";
 }


### PR DESCRIPTION
This fixes the 404s when viewing gov.uk pages.

Sources:
https://github.com/alphagov/govuk-puppet/blob/560c2f4f739f4d369eacb66a5a9b1e344527969a/modules/router/templates/assets_origin.conf.erb#L45
https://github.com/alphagov/govuk-puppet/blob/9a4ad116d8b495690415405e6ee3b0663959d06d/hieradata/common.yaml#L1614

- [x] Depends on https://github.com/alphagov/static/pull/1271 being deployed to production