### PR TITLE
Update Jenkinsfile with new app name

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -24,7 +24,7 @@ def apps = [
   [constantPrefix: "SPECIALIST_PUBLISHER", app: "specialist-publisher", name: "Specialist Publisher"],
   [constantPrefix: "STATIC", app: "static", name: "Static"],
   [constantPrefix: "TRAVEL_ADVICE_PUBLISHER", app: "travel-advice-publisher", name: "Travel Advice Publisher"],
-  [constantPrefix: "WHITEHALL", app: "whitehall", name: "Whitehall"],
+  [constantPrefix: "WHITEHALL", app: "whitehall-admin", name: "Whitehall"],
 ].each { app -> app.defaultCommitish = app.defaultCommitish ?: DEFAULT_COMMITISH }
 
 timestamps {


### PR DESCRIPTION
whitehall was renamed to whitehall-admin as part of the work to set
up whitehall-frontend in 8cd09f8fb7b88e6c44f60f38bf8681eee337da33

This change was missed off from that.