### PR TITLE
Set GOVUK_APP_DOMAIN_EXTERNAL in docker-compose.yml

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,6 +5,7 @@ x-govuk-app-env: &govuk-app
   GDS_SSO_STRATEGY: mock
   GDS_API_DISABLE_CACHE: "true"
   GOVUK_APP_DOMAIN: dev.gov.uk
+  GOVUK_APP_DOMAIN_EXTERNAL: dev.gov.uk
   GOVUK_ASSET_ROOT: http://assets-origin.dev.gov.uk
   GOVUK_ASSET_HOST: http://assets-origin.dev.gov.uk
   GOVUK_WEBSITE_ROOT: http://www.dev.gov.uk


### PR DESCRIPTION
This is new in Plek 2.1.0, and represents the domain used as a
template for external URLS. Applications can use this by using the
`external_url_for` method in Plek.

For the docker-compose environment, this is the same as the
GOVUK_APP_DOMAIN (which is effectively for internal routing), as I'm
assuming that there isn't any different routing by domain for app to
app connections compared to user (or the Publishing E2E tests) to app
connections.