### PR TITLE
Fix the flaky dialog interaction on Publisher

### DIFF
--- a/spec/support/publisher_helpers.rb
+++ b/spec/support/publisher_helpers.rb
@@ -31,22 +31,18 @@ module PublisherHelpers
   end
 
   def confirm_dialog_action(link:, button:)
-    reload_options = {
-      fail_reason: "\"#{link}\" link not opening confirmation dialog with button \"#{button}\"",
-    }
-
-    # There exists a race hazard here whereby the browser is adding the modal event handler to the link in one thread.
-    # While capybara is simultaneously trying to click the link.
-    # If capybara clicks the link before the modal event handler is registered then it won't bring up the modal.
-    # This loop exists to ensure the modal dialog box is brought up.
-    retry_while_false(reload_options) do
-      click_link link
-      is_button_visible? button
-    end
-
-    click_button button
+    wait_for_link link
+    submit_button button
 
     expect(page).to have_text("edition was successfully updated.")
+  end
+
+  def wait_for_link(link)
+    find(:xpath, "//a[text()=\"#{link}\"][not(contains(@class, \"disabled\"))]")
+  end
+
+  def submit_button(button)
+    find(:xpath, "//input[@value=\"#{button}\"]", visible: false).trigger("click")
   end
 
   def is_button_visible?(button)


### PR DESCRIPTION
We were getting a scenario where the test was clicking the
"Skip review" link and progressing to the Publisher homepage.

Instead of clicking the link to open the dialog box we now submit
the form while it is still invisible.

We still need to syncronize each form submission as the form is
put into the DOM at each step even if it is inaccessible.  We use
the link without the disabled class as a way to ensure the document
has progressed to the next state.

Example failure:
https://ci.integration.publishing.service.gov.uk/job/publishing-e2e-tests/job/test-against/4571/