### PR TITLE
Wait for Preview draft manual page load to finish on attachment test

### DIFF
--- a/spec/manuals_publisher/upload_attachment_spec.rb
+++ b/spec/manuals_publisher/upload_attachment_spec.rb
@@ -38,11 +38,7 @@ feature "Uploading an attachment on Manuals Publisher", manuals_publisher: true 
   end
 
   def then_i_can_access_the_attachment_through_the_draft
-    url = find_link("Preview draft")[:href]
-
-    reload_url_until_status_code(url, 200)
-
-    click_link("Preview draft")
+    visit_draft_manual
 
     section_url = find_link(section_title)[:href]
     reload_url_until_match(section_url, :has_text?, attachment_title)
@@ -55,5 +51,13 @@ feature "Uploading an attachment on Manuals Publisher", manuals_publisher: true 
     reload_url_until_status_code(attachment_link, 200)
 
     expect_matching_uploaded_file(attachment_link, file)
+  end
+
+  def visit_draft_manual
+    url = find_link("Preview draft")[:href]
+    reload_url_until_status_code(url, 200)
+
+    click_link("Preview draft")
+    expect_rendering_application("manuals-frontend")
   end
 end


### PR DESCRIPTION
We've had a flakyness from this test where the find_link(section_title)
was picking up the title from the publishing app page and not the frontend.

By waiting for the frontend page to be loaded we can ensure that it
is picking up the link on the rendered version of the document.

Example failure:
https://ci.integration.publishing.service.gov.uk/job/publishing-e2e-tests/job/test-against/4555/