### PR TITLE
Remove new tag from publishing document + publishing person whitehall tests

### DIFF
--- a/spec/whitehall/publishing_document_spec.rb
+++ b/spec/whitehall/publishing_document_spec.rb
@@ -1,4 +1,4 @@
-feature "Publishing a document with Whitehall", new: true, whitehall: true, government_frontend: true do
+feature "Publishing a document with Whitehall", whitehall: true, government_frontend: true do
   include WhitehallHelpers
 
   let(:title) { "Publishing Whitehall #{SecureRandom.uuid}" }

--- a/spec/whitehall/publishing_person_spec.rb
+++ b/spec/whitehall/publishing_person_spec.rb
@@ -1,4 +1,4 @@
-feature "Publishing a person on Whitehall", new: true, whitehall: true do
+feature "Publishing a person on Whitehall", whitehall: true do
   include WhitehallHelpers
 
   let(:forename) { "Adrian #{SecureRandom.uuid}" }


### PR DESCRIPTION
These tests have been running since a week ago without displaying
flakiness.

By removing the new tag they will be run as part of the other tests.
Any change which breaks these flows will now fail the E2E build.