### PR TITLE
Add expect_rendering_application to Specialist Publisher tests

### DIFF
--- a/spec/specialist_publisher/change_note_spec.rb
+++ b/spec/specialist_publisher/change_note_spec.rb
@@ -53,6 +53,7 @@ feature "Change notes on Specialist Publisher", specialist_publisher: true, gove
     reload_url_until_match(url, :has_text?, ignore_quotes_regex(new_body))
 
     click_link("View on website")
+    expect_rendering_application("government-frontend")
     expect_url_matches_live_gov_uk
     click_link("show all updates")
     within("#full-history") do

--- a/spec/specialist_publisher/editing_spec.rb
+++ b/spec/specialist_publisher/editing_spec.rb
@@ -35,6 +35,7 @@ feature "Editing with Specialist Publisher", specialist_publisher: true, governm
     reload_url_until_status_code(url, 200)
 
     click_link("Preview draft")
+    expect_rendering_application("government-frontend")
     expect_url_matches_draft_gov_uk
     expect(page).to have_content(new_title)
   end


### PR DESCRIPTION
For Specialist Publisher tests where it asserts against the current_url straight after navigating to the frontend it is possible that page hasn't performed a full reload.

By adding expect_rendering_application it will use Capybaras repeated find functionality to look for the rendering-application meta tag until the page loads.

Example failure on Jenkins:
https://ci.integration.publishing.service.gov.uk/job/publishing-e2e-tests/job/flaky-publisher-add-new-part/1/