### PR TITLE
Remove new tag from the  contacts publisher tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -87,7 +87,7 @@ test-collections:
 	$(TEST_CMD) -o '--tag collections --tag ~flaky --tag ~new'
 
 test-finder-frontend:
-	$(TEST_CMD) -o '--tag finder-frontend --tag ~flaky --tag ~new'
+	$(TEST_CMD) -o '--tag finder_frontend --tag ~flaky --tag ~new'
 
 test-frontend:
 	$(TEST_CMD) -o '--tag frontend --tag ~flaky --tag ~new'

--- a/spec/contacts/publish_a_contact_spec.rb
+++ b/spec/contacts/publish_a_contact_spec.rb
@@ -1,4 +1,4 @@
-feature "Publishing a contact", contacts: true, new: true, finder_frontend: true, government_frontend: true do
+feature "Publishing a contact", contacts: true, finder_frontend: true, government_frontend: true do
   include ContactsHelpers
 
   let(:title) { "Creating a contact #{SecureRandom.uuid}" }

--- a/spec/contacts/removing_a_contact_spec.rb
+++ b/spec/contacts/removing_a_contact_spec.rb
@@ -1,4 +1,4 @@
-feature "Removing a contact", contacts: true, finder_frontend: true, government_frontend: true, new: true do
+feature "Removing a contact", contacts: true, finder_frontend: true, government_frontend: true do
   include ContactsHelpers
 
   let(:title) { "Removing a contact #{SecureRandom.uuid}" }

--- a/spec/contacts/updating_a_contact_spec.rb
+++ b/spec/contacts/updating_a_contact_spec.rb
@@ -1,4 +1,4 @@
-feature "Updating a contact", contacts: true, finder_frontend: true, government_frontend: true, new: true do
+feature "Updating a contact", contacts: true, finder_frontend: true, government_frontend: true do
   include ContactsHelpers
 
   let(:title) { "Updating a contact #{SecureRandom.uuid}" }


### PR DESCRIPTION
These tests have been running in CI since last Monday without displaying signs of flakiness.  By removing the new tag these tests will fail the build if the tests break.