### PR TITLE
Match the RSpec contacts tag name to its standard name

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -98,8 +98,8 @@ test-government-frontend:
 test-content-tagger:
 	$(TEST_CMD) -o '--tag content_tagger --tag ~flaky --tag ~new'
 
-test-contacts:
-	$(TEST_CMD) -o '--tag contacts --tag ~flaky --tag ~new'
+test-contacts-admin:
+	$(TEST_CMD) -o '--tag contacts_admin --tag ~flaky --tag ~new'
 
 test-whitehall:
 	$(TEST_CMD) -o '--tag whitehall --tag ~flaky --tag ~new'
@@ -109,5 +109,5 @@ stop: kill
 .PHONY: all $(APPS) clone kill build setup start up test stop \
 	test-specialist-publisher test-travel-advice-publisher \
 	test-collections-publisher test-publisher test-manuals-publisher \
-	test-frontend test-content-tagger test-contacts test-finder-frontend \
+	test-frontend test-content-tagger test-contacts-admin test-finder-frontend \
 	pull

--- a/spec/contacts_admin/publish_a_contact_spec.rb
+++ b/spec/contacts_admin/publish_a_contact_spec.rb
@@ -1,4 +1,4 @@
-feature "Publishing a contact", contacts: true, finder_frontend: true, government_frontend: true do
+feature "Publishing a contact", contacts_admin: true, finder_frontend: true, government_frontend: true do
   include ContactsHelpers
 
   let(:title) { "Creating a contact #{SecureRandom.uuid}" }

--- a/spec/contacts_admin/removing_a_contact_spec.rb
+++ b/spec/contacts_admin/removing_a_contact_spec.rb
@@ -1,4 +1,4 @@
-feature "Removing a contact", contacts: true, finder_frontend: true, government_frontend: true do
+feature "Removing a contact", contacts_admin: true, finder_frontend: true, government_frontend: true do
   include ContactsHelpers
 
   let(:title) { "Removing a contact #{SecureRandom.uuid}" }

--- a/spec/contacts_admin/updating_a_contact_spec.rb
+++ b/spec/contacts_admin/updating_a_contact_spec.rb
@@ -1,4 +1,4 @@
-feature "Updating a contact", contacts: true, finder_frontend: true, government_frontend: true do
+feature "Updating a contact", contacts_admin: true, finder_frontend: true, government_frontend: true do
   include ContactsHelpers
 
   let(:title) { "Updating a contact #{SecureRandom.uuid}" }


### PR DESCRIPTION
Contacts Admin is called this in most places, apart from Jenkins.
Use this name here to be more standardised.