### PR TITLE
Remove new tag from Whitehall tests and the finder-frontend /search test

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -833,6 +833,7 @@ services:
       - nginx-proxy:error-handler.dev.gov.uk
     environment:
       << : *govuk-app
+      ASSET_MANAGER_CLAMSCAN_PATH: /bin/true
       REDIS_HOST: redis
       SENTRY_CURRENT_ENV: asset-manager
       VIRTUAL_HOST: asset-manager.dev.gov.uk
@@ -852,6 +853,7 @@ services:
       - diet-error-handler
     environment:
       << : *govuk-app
+      ASSET_MANAGER_CLAMSCAN_PATH: /bin/true
       REDIS_HOST: redis
       SENTRY_CURRENT_ENV: asset-manager-worker
       FAKE_S3_HOST: http://127.0.0.1

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -765,6 +765,7 @@ services:
     << : *whitehall
     environment:
       << : *govuk-app
+      MEMCACHE_SERVERS: memcached
       VIRTUAL_HOST: whitehall-frontend.dev.gov.uk
       SENTRY_CURRENT_ENV: whitehall-frontend
 
@@ -772,6 +773,7 @@ services:
     << : *whitehall
     environment:
       << : *govuk-app
+      MEMCACHE_SERVERS: memcached
       VIRTUAL_HOST: draft-whitehall-frontend.dev.gov.uk
       SENTRY_CURRENT_ENV: draft-whitehall-frontend
 

--- a/spec/publisher/publishing_content_to_government_frontend_spec.rb
+++ b/spec/publisher/publishing_content_to_government_frontend_spec.rb
@@ -1,4 +1,4 @@
-feature "Publishing content from Publisher to Government Frontend", new: true, finder_frontend: true, publisher: true, government_frontend: true do
+feature "Publishing content from Publisher to Government Frontend", finder_frontend: true, publisher: true, government_frontend: true do
   include PublisherHelpers
 
   let(:title) { unique_title }

--- a/spec/whitehall/publishing_document_spec.rb
+++ b/spec/whitehall/publishing_document_spec.rb
@@ -33,7 +33,7 @@ feature "Publishing a document with Whitehall", whitehall: true, government_fron
   def and_it_is_displayed_on_the_publication_finder
     publication_finder = find('a', text: "Publications", match: :first)[:href]
     reload_url_until_match(publication_finder, :has_text?, title)
-    visit(publication_finder)
+    click_link("Publications", match: :first)
 
     expect_rendering_application("whitehall")
     expect(page).to have_content(title)

--- a/spec/whitehall/unpublish_document_spec.rb
+++ b/spec/whitehall/unpublish_document_spec.rb
@@ -1,4 +1,4 @@
-feature "Unpublishing a document by consolidating into another page on Whitehall", new: true, whitehall: true, government_frontend: true do
+feature "Unpublishing a document by consolidating into another page on Whitehall", whitehall: true, government_frontend: true do
   include WhitehallHelpers
 
   let(:title) { "Unpublishing Whitehall #{SecureRandom.uuid}" }

--- a/spec/whitehall/updating_document_spec.rb
+++ b/spec/whitehall/updating_document_spec.rb
@@ -1,4 +1,4 @@
-feature "Creating a new edition of a document with Whitehall", new: true, whitehall: true, government_frontend: true do
+feature "Creating a new edition of a document with Whitehall", whitehall: true, government_frontend: true do
   include WhitehallHelpers
 
   let(:title) { "Updating Whitehall Before #{SecureRandom.uuid}" }
@@ -37,7 +37,7 @@ feature "Creating a new edition of a document with Whitehall", new: true, whiteh
   def and_it_is_updated_on_the_publication_finder
     publication_finder = find('a', text: "Publications", match: :first)[:href]
     reload_url_until_match(publication_finder, :has_text?, updated_title)
-    visit(publication_finder)
+    click_link("Publications", match: :first)
 
     expect_rendering_application("whitehall")
     expect(page).to have_content(updated_title)

--- a/spec/whitehall/uploading_attachment_spec.rb
+++ b/spec/whitehall/uploading_attachment_spec.rb
@@ -1,4 +1,4 @@
-feature "Uploading an attachment on Whitehall", new: true, whitehall: true, government_frontend: true do
+feature "Uploading an attachment on Whitehall", whitehall: true, government_frontend: true do
   include WhitehallHelpers
 
   let(:title) { "Attachment Whitehall #{SecureRandom.uuid}" }

--- a/spec/whitehall/withdraw_document_spec.rb
+++ b/spec/whitehall/withdraw_document_spec.rb
@@ -1,4 +1,4 @@
-feature "Withdraw a document with Whitehall", new: true, whitehall: true, government_frontend: true do
+feature "Withdraw a document with Whitehall", whitehall: true, government_frontend: true do
   include WhitehallHelpers
 
   let(:title) { "Withdraw Whitehall #{SecureRandom.uuid}" }


### PR DESCRIPTION
These have all been running in CI since 30th January without displaying signs of flakiness.

Also disable clamav.  Now that we run a number of tests through asset-manager, it is too slow to be running the antivirus on each request.  **Depends on https://github.com/alphagov/asset-manager/pull/462**
