### PR TITLE
Wait for Whitehall document to be published before unpublishing it

### DIFF
--- a/spec/whitehall/unpublish_document_spec.rb
+++ b/spec/whitehall/unpublish_document_spec.rb
@@ -15,6 +15,7 @@ feature "Unpublishing a document by consolidating into another page on Whitehall
     force_publish_document
     click_link title
     @published_url = find_link("View on website")[:href]
+    reload_url_until_status_code(@published_url, 200)
   end
 
   def when_i_unpublish_it_and_redirect_to_another_page


### PR DESCRIPTION
We've seen a number of failures of this test, and in these cases
whitehall is unpublishing before the content-store has a copy.

In these cases the document gets published after the unpublish
and the assertion that URL becomes a 301 never passes.

https://ci.integration.publishing.service.gov.uk/job/publishing-e2e-tests/job/run-tests-continually/654/
https://ci.integration.publishing.service.gov.uk/job/publishing-e2e-tests/job/run-tests-continually/504/

Example docker.log
```
whitehall-admin_1                     | 2018-02-10T07:26:33.882000123Z 172.18.0.54 - - [10/Feb/2018:07:26:33 +0000] "POST /government/admin/editions/3/unpublish?lock_version=1 HTTP/1.1" 302 - 0.2046
```
…
```
nginx-proxy_1                         | 2018-02-10T07:26:34.283669387Z nginx.1    | www.dev.gov.uk 172.18.0.54 - - [10/Feb/2018:07:26:34 +0000] "HEAD /government/consultations/unpublishing-whit
ehall-7412b185-3d7e-4cdf-923c-3b5f79f8327f HTTP/1.1" 404 0 "-" "Ruby"
```
…
```
content-store_1                       | 2018-02-10T07:26:34.314386881Z {"method":"PUT","path":"/content/government/consultations/unpublishing-whitehall-7412b185-3d7e-4cdf-923c-3b5f79f8327f","format":"json","controller":"content_items","action":"update","status":201,"duration":38.68,"view":0.19,"db":0.0,"ip":"172.18.0.5","route":"content_items#update","request_id":"a2323fbc-eb8c-46ec-973c-4df80f82311c","govuk_dependency_resolution_source_content_id":"56cb57e2-7e7f-4f67-b2f6-39c9a55385dc","source":"unknown","tags":["request"],"@timestamp":"2018-02-10T07:26:34.313Z","@version":"1"}
```
…
```
nginx-proxy_1                         | 2018-02-10T07:26:34.847905780Z nginx.1    | www.dev.gov.uk 172.18.0.54 - - [10/Feb/2018:07:26:34 +0000] "HEAD /government/consultations/unpublishing-whitehall-7412b185-3d7e-4cdf-923c-3b5f79f8327f HTTP/1.1" 200 0 "-" "Ruby"
```