### PR TITLE
Wait for taxon to be published before visiting the tagging page

### DIFF
--- a/spec/content_tagger/adding_taxon_to_external_content_spec.rb
+++ b/spec/content_tagger/adding_taxon_to_external_content_spec.rb
@@ -30,6 +30,7 @@ feature "Adding a taxon to external content", collections: true, content_tagger:
 
   def when_i_tag_the_guide_with_the_taxon
     wait_for_artefact_to_be_viewable(@published_guide_url)
+    reload_url_until_status_code(@taxon_url, 200)
     visit_tag_external_content_page(slug: guide_slug)
     select2(taxon_title, css: "#s2id_tagging_tagging_update_form_taxons")
     click_button "Update tagging"


### PR DESCRIPTION
Content tagger grabs the available taxons on the tagging page via the publishing API GET /v2/linkables route.

We have had some flakiness when the tagging page is visited before a taxon is published.

https://ci.integration.publishing.service.gov.uk/job/publishing-e2e-tests/job/run-tests-continually/1067/