### PR TITLE
Move `expect_rendering_application` above `expect_url_matches_*_gov_uk`

### DIFF
--- a/spec/contacts_admin/publish_a_contact_spec.rb
+++ b/spec/contacts_admin/publish_a_contact_spec.rb
@@ -19,9 +19,9 @@ feature "Publishing a contact", contacts_admin: true, finder_frontend: true, gov
     reload_url_until_match(url, :has_text?, "Contact HMRC")
 
     click_link title
+    expect_rendering_application("government-frontend")
     expect(page).to have_content(title)
     expect_url_matches_live_gov_uk
-    expect_rendering_application("government-frontend")
   end
 
   def and_i_can_view_it_on_finder

--- a/spec/contacts_admin/updating_a_contact_spec.rb
+++ b/spec/contacts_admin/updating_a_contact_spec.rb
@@ -36,9 +36,9 @@ feature "Updating a contact", contacts_admin: true, finder_frontend: true, gover
     reload_url_until_match(url, :has_text?, "Contact HMRC")
 
     click_link new_title
+    expect_rendering_application("government-frontend")
     expect(page).to have_content(new_title)
     expect_url_matches_live_gov_uk
-    expect_rendering_application("government-frontend")
   end
 
   def and_i_can_view_it_on_finder

--- a/spec/content_tagger/adding_taxon_to_external_content_spec.rb
+++ b/spec/content_tagger/adding_taxon_to_external_content_spec.rb
@@ -38,9 +38,9 @@ feature "Adding a taxon to external content", collections: true, content_tagger:
   def then_the_taxon_on_gov_uk_links_to_the_guide
     reload_url_until_match(@taxon_url, :has_text?, guide_title)
     visit(@taxon_url)
+    expect_rendering_application("collections")
     expect(page).to have_content(taxon_title)
     expect(page).to have_content(guide_title)
     expect_url_matches_live_gov_uk
-    expect_rendering_application("collections")
   end
 end

--- a/spec/content_tagger/create_draft_taxon_spec.rb
+++ b/spec/content_tagger/create_draft_taxon_spec.rb
@@ -18,8 +18,8 @@ feature "Creating a draft taxon on Content Tagger", collections: true, content_t
     reload_url_until_status_code(url, 200)
 
     click_link "/" + slug
+    expect_rendering_application("collections")
     expect(page).to have_content(title)
     expect_url_matches_draft_gov_uk
-    expect_rendering_application("collections")
   end
 end

--- a/spec/content_tagger/linking_related_content_spec.rb
+++ b/spec/content_tagger/linking_related_content_spec.rb
@@ -33,11 +33,11 @@ feature "Adding related content to Publisher content", content_tagger: true, fro
     reload_url_until_match(@guide_url, :has_text?, related_content_title)
     visit(@guide_url)
 
+    expect_rendering_application("frontend")
     related_content_link = find_link(related_content_title)[:href]
 
     expect(related_content_link).to eq(@related_content_url)
     expect_url_matches_live_gov_uk
-    expect_rendering_application("frontend")
   end
 
   def create_and_publish_guide(slug:, title:)

--- a/spec/content_tagger/publishing_taxon_spec.rb
+++ b/spec/content_tagger/publishing_taxon_spec.rb
@@ -23,8 +23,8 @@ feature "Publishing a taxon on Content Tagger", collections: true, content_tagge
     reload_url_until_status_code(url, 200)
 
     click_link "/" + slug
+    expect_rendering_application("collections")
     expect(page).to have_content(title)
     expect_url_matches_live_gov_uk
-    expect_rendering_application("collections")
   end
 end

--- a/spec/content_tagger/removing_taxon_spec.rb
+++ b/spec/content_tagger/removing_taxon_spec.rb
@@ -28,8 +28,8 @@ feature "Removing content from Content Tagger", collections: true, content_tagge
   def then_visiting_the_removed_taxon_redirects_to_the_other_taxon
     reload_url_until_status_code(@redirected_taxon_url, 301, keep_retrying_while: [200])
     visit @redirected_taxon_url
-    expect(current_url).to eq(@redirection_destination_url)
     expect_rendering_application("collections")
+    expect(current_url).to eq(@redirection_destination_url)
   end
 
   private

--- a/spec/content_tagger/updating_taxon_spec.rb
+++ b/spec/content_tagger/updating_taxon_spec.rb
@@ -32,9 +32,9 @@ feature "Updating a published taxon on Content Tagger", collections: true, conte
     reload_url_until_match(url, :has_text?, updated_content)
 
     click_link "/" + slug
+    expect_rendering_application("collections")
     expect(page).to have_content(title)
     expect(page).to have_content(updated_content)
     expect_url_matches_live_gov_uk
-    expect_rendering_application("collections")
   end
 end

--- a/spec/manuals_publisher/creating_draft_spec.rb
+++ b/spec/manuals_publisher/creating_draft_spec.rb
@@ -17,8 +17,8 @@ feature "Creating a draft on Manuals Publisher", manuals_publisher: true do
     reload_url_until_status_code(url, 200)
 
     click_link "Preview draft"
+    expect_rendering_application("manuals-frontend")
     expect(page).to have_content(title)
     expect_url_matches_draft_gov_uk
-    expect_rendering_application("manuals-frontend")
   end
 end

--- a/spec/manuals_publisher/publish_live_spec.rb
+++ b/spec/manuals_publisher/publish_live_spec.rb
@@ -23,8 +23,8 @@ feature "Publishing content on Manuals Publisher", manuals_publisher: true do
     reload_url_until_status_code(url, 200)
 
     click_link "View on website"
+    expect_rendering_application("manuals-frontend")
     expect(page).to have_content(title)
     expect_url_matches_live_gov_uk
-    expect_rendering_application("manuals-frontend")
   end
 end

--- a/spec/manuals_publisher/removing_content_spec.rb
+++ b/spec/manuals_publisher/removing_content_spec.rb
@@ -51,10 +51,10 @@ feature "Removing content on Manuals Publisher", manuals_publisher: true do
 
     visit removed_section_url
 
+    expect_rendering_application("manuals-frontend")
     expect(current_url).to eq(url)
     expect(page).to have_content(title)
     expect_url_matches_live_gov_uk
-    expect_rendering_application("manuals-frontend")
   end
 
   def removed_section_url

--- a/spec/manuals_publisher/update_published_content_spec.rb
+++ b/spec/manuals_publisher/update_published_content_spec.rb
@@ -33,10 +33,10 @@ feature "Updating content on Manuals Publisher", manuals_publisher: true do
     reload_url_until_match(url, :has_text?, section_title)
 
     click_link "View on website"
+    expect_rendering_application("manuals-frontend")
     expect(page).to have_content(title)
     expect(page).to have_content(section_title)
     expect_url_matches_live_gov_uk
-    expect_rendering_application("manuals-frontend")
   end
 
   def and_the_update_log_has_the_change_note

--- a/spec/manuals_publisher/upload_attachment_spec.rb
+++ b/spec/manuals_publisher/upload_attachment_spec.rb
@@ -44,8 +44,8 @@ feature "Uploading an attachment on Manuals Publisher", manuals_publisher: true 
     reload_url_until_match(section_url, :has_text?, attachment_title)
 
     click_link(section_title)
-    expect_url_matches_draft_gov_uk
     expect_rendering_application("manuals-frontend")
+    expect_url_matches_draft_gov_uk
 
     attachment_link = find_link(attachment_title)[:href]
     reload_url_until_status_code(attachment_link, 200)

--- a/spec/publisher/creating_draft_content_spec.rb
+++ b/spec/publisher/creating_draft_content_spec.rb
@@ -19,9 +19,9 @@ feature "Creating draft content on Publisher", publisher: true, frontend: true d
     wait_for_draft_to_be_published
 
     click_link("Preview")
+    expect_rendering_application("frontend")
     expect(page).to have_content(title)
     expect_url_matches_draft_gov_uk
-    expect_rendering_application("frontend")
   end
 
   def wait_for_draft_to_be_published

--- a/spec/publisher/publishing_content_to_government_frontend_spec.rb
+++ b/spec/publisher/publishing_content_to_government_frontend_spec.rb
@@ -25,9 +25,9 @@ feature "Publishing content from Publisher to Government Frontend", finder_front
     wait_for_artefact_to_be_published
 
     click_link("View this on the GOV.UK website")
+    expect_rendering_application("government-frontend")
     expect(page).to have_content(title)
     expect_url_matches_live_gov_uk
-    expect_rendering_application("government-frontend")
   end
 
   def and_i_can_view_it_on_finder


### PR DESCRIPTION
It is possible for PhantomJS to be loading the rendered version, but for Capybara to have gone past the `expect(page).to have_content` as the publishing application already has the content.

By moving the `expect_rendering_application` above the call to `expect_url_matches_live_gov_uk` Capybara will use its built in repeated find functionality to ensure the frontend has loaded.

https://ci.integration.publishing.service.gov.uk/job/publishing-e2e-tests/job/run-tests-continually/1128/