### PR TITLE
Use case insensitivity when checking if the page shows "gone"

### DIFF
--- a/spec/contacts_admin/removing_a_contact_spec.rb
+++ b/spec/contacts_admin/removing_a_contact_spec.rb
@@ -30,7 +30,7 @@ feature "Removing a contact", contacts_admin: true, finder_frontend: true, gover
     reload_url_until_status_code(@url, 410, keep_retrying_while: [404, 200])
 
     visit(@url)
-    expect(page).to have_content("gone")
+    expect(page).to have_content(/gone/i)
   end
 
   def and_it_is_not_shown_on_finder

--- a/spec/publisher/removing_content_without_redirect_spec.rb
+++ b/spec/publisher/removing_content_without_redirect_spec.rb
@@ -39,7 +39,7 @@ feature "Removing content without a redirect from Publisher", publisher: true, g
     reload_url_until_status_code(@published_url, 410, keep_retrying_while: [200])
 
     visit(@published_url)
-    expect(page).to have_content("gone")
+    expect(page).to have_content(/gone/i)
   end
 
   def and_visiting_a_subpage_gives_a_404_on_gov_uk

--- a/spec/specialist_publisher/unpublishing_spec.rb
+++ b/spec/specialist_publisher/unpublishing_spec.rb
@@ -41,6 +41,6 @@ feature "Unpublishing with Specialist Publisher", specialist_publisher: true, go
 
     visit(@url)
     expect_url_matches_live_gov_uk
-    expect(page).to have_content("gone")
+    expect(page).to have_content(/gone/i)
   end
 end


### PR DESCRIPTION
There exists a race condition where the router will query content-store and it exists, but when it gets to the government-frontend the document is gone.

If the router renders the 410 then it displays a message with a lowercase "gone".

If the government-frontend renders the 410 then it displays it as "Gone".

By using a case-insensitive match we can handle both cases.

Example race condition example:
https://ci.integration.publishing.service.gov.uk/job/publishing-e2e-tests/job/run-tests-continually/1084/