### PR TITLE
Register a JQuery ready handler for syncronizing Capybara and PhantomJS

### DIFF
--- a/spec/support/javascript_helpers.rb
+++ b/spec/support/javascript_helpers.rb
@@ -1,0 +1,11 @@
+module JavascriptHelpers
+  def wait_for_jquery_ready_event
+    ready_class_name = "e2e-jquery-ready-event"
+    page.execute_script <<-JS
+      $(function() {
+        document.documentElement.className += " #{ready_class_name}";
+      });
+    JS
+    find(".#{ready_class_name}")
+  end
+end

--- a/spec/support/publisher_helpers.rb
+++ b/spec/support/publisher_helpers.rb
@@ -1,4 +1,8 @@
+require_relative 'javascript_helpers'
+
 module PublisherHelpers
+  include JavascriptHelpers
+
   def visit_publisher(path = "/")
     visit(Plek.find("publisher") + path)
   end
@@ -55,15 +59,8 @@ module PublisherHelpers
   end
 
   def add_part_to_artefact(title:, body: sentence)
-    # There exists a race hazard here between the browser adding the event handler to the "Add new part" link and
-    # Capybara trying to click that link.
-
-    # If capybara clicks the link before the event handler is registered then it won't open up the new part form.
-    # This loop exists to ensure that the "Add new part" link is clicked until the form appears.
-    retry_while_false(fail_reason: "Unable to open up new part form") do
-      click_link "Add new part"
-      !all("div#untitled-part").empty?
-    end
+    wait_for_jquery_ready_event
+    click_link "Add new part"
 
     slug = within("div#untitled-part") do
       fill_in "Title", with: title


### PR DESCRIPTION
For situations where you want to block until the DOM is full loaded the `wait_for_jquery_ready_event` will allow you to do so.

JQuery won't add the "e2e-tests-loaded" class onto the document until the DOM is loaded.  We then use Capybaras built in `find` method which repeatedly looks for that class for the configured timeout period.

For Mainstream publisher adding a part to an artefact this should be a suitable replacement for the current loop behaviour.  Once the DOM is loaded the nested_form event on the "Add new part" link will have been attached.

Going forward this method should be a simple and reusable method to use in similar situations.