### PR TITLE
Add make clean command

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,13 @@ endif
 
 TEST_CMD = $(DOCKER_COMPOSE_CMD) run publishing-e2e-tests bundle exec parallel_rspec -n $(TEST_PROCESSES) $(TEST_ARGS)
 
-all: clean clone pull build start test stop
+all:
+	$(MAKE) clean
+	$(MAKE) clone
+	$(MAKE) pull build
+	$(MAKE) start
+	$(MAKE) test
+	$(MAKE) stop
 
 $(APPS):
 	bin/clone-app $@
@@ -34,7 +40,6 @@ kill:
 build: kill
 	$(DOCKER_COMPOSE_CMD) build diet-error-handler publishing-e2e-tests $(APPS_TO_BUILD)
 
-	
 setup:
 	bundle exec rake docker:wait_for_dbs
 	$(MAKE) setup_dbs
@@ -100,8 +105,7 @@ setup_queues:
 	$(DOCKER_COMPOSE_CMD) run --rm publishing-api-worker rails runner 'Sidekiq::Queue.new.clear'
 	$(DOCKER_COMPOSE_CMD) exec -T rummager-worker bundle exec rake message_queue:create_queues
 
-publish_routes: publish_rummager publish_specialist publish_frontend \
-  publish_contacts_admin publish_whitehall
+publish_routes: publish_rummager publish_specialist publish_frontend publish_contacts_admin publish_whitehall
 
 publish_rummager:
 	$(DOCKER_COMPOSE_CMD) exec -T rummager bundle exec rake publishing_api:publish_special_routes
@@ -135,7 +139,9 @@ up:
 pull:
 	$(DOCKER_COMPOSE_CMD) pull --parallel --ignore-pull-failures
 
-start: up setup
+start:
+	$(MAKE) up
+	$(MAKE) setup
 
 test:
 	$(TEST_CMD)

--- a/Makefile
+++ b/Makefile
@@ -121,10 +121,13 @@ publish_whitehall:
 clean_apps:
 	$(DOCKER_RUN) bash -c 'rm -rf /app/apps/*'
 
+clean_docker:
+	bundle exec rake docker:remove_built_app_images
+
 clean_tmp:
 	$(DOCKER_RUN) bash -c 'find /app/tmp -name .keep -prune -o -type f -exec rm {} \;'
 
-clean: clean_tmp clean_apps
+clean: clean_tmp clean_apps clean_docker
 
 up:
 	$(DOCKER_COMPOSE_CMD) up -d
@@ -186,4 +189,4 @@ stop: kill
 	rummager_setup publish_rummager publish_specialist publish_frontend \
 	publish_contacts_admin publish_whitehall setup_dbs setup_queues \
 	wait_for_whitehall_admin contacts_admin_setup pull \
-	clean_apps clean_tmp clean
+	clean_apps clean_docker clean_tmp clean

--- a/README.md
+++ b/README.md
@@ -33,8 +33,8 @@ $ make
 ```
 
 Running this command executes the following targets in order, which you can
-choose to run separately to speed up development: `clone`, `pull`, `build`, `start`,
-`test` and `stop`.
+choose to run separately to speed up development: `clean`, `clone`, `pull`, `build`,
+`start`, `test` and `stop`.
 
 For example, to run only the tests for the specialist publisher, you need only
 do:
@@ -45,11 +45,10 @@ $ make pull build start test-specialist-publisher stop
 ```
 
 If you need to run the tests against a branch of an application other than
-deployed-to-production you can specify it to be built as below:
+deployed-to-production you need to explicitly build it as below:
 
 ```bash
-$ make -j4 clone
-$ make pull
+$ make -j4 clone pull
 $ docker-compose build publisher
 $ make start test-publisher stop
 ```

--- a/README.md
+++ b/README.md
@@ -61,10 +61,12 @@ $ docker-compose build publisher
 ```
 
 When you have finished testing against your branch version and want to switch back
-to the deployed-to-production version you will need to untag the built image before you can re-pull.
+to the deployed-to-production version you will need to untag the built image before
+you can re-pull.  The `clean_docker` make recipe will untag all locally built images.
 
 ```bash
-$ docker rmi publisher:master
+$ make clean_docker
+$ make pull
 ```
 
 See [docs/docker.md](docs/docker.md) for more information

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Once you have [installed Docker][install-docker] you can build and run the test
 suite with:
 
 ```
-$ make
+$ make -j4
 ```
 
 Running this command executes the following targets in order, which you can

--- a/lib/docker_service.rb
+++ b/lib/docker_service.rb
@@ -14,6 +14,31 @@ class DockerService
     raise "Container(s) #{unhealthy_container_names.join(',')} were unhealthy after 60 seconds" if unhealthy_containers.any?
   end
 
+  def self.remove_built_app_images
+    built_app_images.map do |image|
+      image.remove
+      image.info["RepoTags"].first
+    end
+  end
+
+  def self.built_app_images
+    # A repo digest is a unique identifier for an image made up of the tag name + hash
+    # e.g. govuk/publishing-api@sha256:a5e459c5e6f855a4ce3684d333312848768676a23651ad1a46cefe7e4c64b11a
+    # Images are only assigned digests after being pushed to a registry.
+    # If an image doesn't have a digest, it must have been built locally.
+    app_images.reject do |image|
+      image.info["RepoDigests"]
+    end
+  end
+
+  def self.app_images
+    Docker::Image.all.select do |image|
+      Array(image.info["RepoTags"]).any? do |tag|
+        tag.start_with?("govuk/")
+      end
+    end
+  end
+
   def self.get_services_containers(only:, except:)
     containers = Docker::Compose.new.ps
 

--- a/lib/tasks/docker.rake
+++ b/lib/tasks/docker.rake
@@ -20,4 +20,9 @@ namespace :docker do
   task :wait_for_apps do
     DockerService.wait_for_healthy_services(except: %w(publishing-e2e-tests))
   end
+
+  task :remove_built_app_images do
+    removed_images = DockerService.remove_built_app_images
+    puts "Removed #{removed_images.join(',')}" unless removed_images.empty?
+  end
 end


### PR DESCRIPTION
This makes it easier to reset your local development environment to a fresh state.

Both out of date app folders + locally built versions of apps are gotchas which can cause out of date applications to be used.