### PR TITLE
Clean out the workspace before performing a build

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -134,6 +134,12 @@ timestamps {
       try {
         originBuildStatus("Running publishing end-to-end tests on Jenkins", "PENDING")
 
+        stage("Clean workspace") {
+          checkout(scm)
+          sh("make -j clean_tmp clean_apps")
+          cleanWs()
+        }
+
         stage("Checkout") {
           checkout(scm)
         }


### PR DESCRIPTION
It is good practice to start from a clean workspace when building on Jenkins because then any files from previous builds can't affect the current build.

Given some of the files in /tmp and /apps will have root permissions, we run `make clean_tmp clean_apps` commands to remove those before cleaning the rest of the workspace.  These make recipes use docker to delete the files.

Given we are using the make commands we'll need a copy of the Makefile, which means cloning the repo before cleaning the workspace.