### PR TITLE
Use deployed-to-production branch instead of master

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -18,7 +18,7 @@ def apps = [
   [constantPrefix: "MANUALS_PUBLISHER", app: "manuals-publisher", name: "Manuals Publisher"],
   [constantPrefix: "PUBLISHER", app: "publisher", name: "Publisher"],
   [constantPrefix: "PUBLISHING_API", app: "publishing-api", name: "Publishing API"],
-  [constantPrefix: "ROUTER", app: "router", name: "Router", defaultCommitish: "master"],
+  [constantPrefix: "ROUTER", app: "router", name: "Router"],
   [constantPrefix: "ROUTER_API", app: "router-api", name: "Router API"],
   [constantPrefix: "RUMMAGER", app: "rummager", name: "Rummager"],
   [constantPrefix: "SPECIALIST_PUBLISHER", app: "specialist-publisher", name: "Specialist Publisher"],

--- a/bin/clone-app
+++ b/bin/clone-app
@@ -70,7 +70,7 @@ private
   end
 
   def commitish
-    ENV.fetch("#{upper_name}_COMMITISH", "master")
+    ENV.fetch("#{upper_name}_COMMITISH", "deployed-to-production")
   end
 
   def detached?

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -82,7 +82,7 @@ services:
       - ./docker/elasticsearch.yml:/usr/share/elasticsearch/config/elasticsearch.yml
 
   rummager: &rummager
-    image: govuk/rummager:${RUMMAGER_COMMITISH:-master}
+    image: govuk/rummager:${RUMMAGER_COMMITISH:-deployed-to-production}
     build: apps/rummager
     depends_on:
       - redis
@@ -170,7 +170,7 @@ services:
       - ./tmp:/app/tmp
 
   router: &router
-    image: govuk/router:${ROUTER_COMMITISH:-master}
+    image: govuk/router:${ROUTER_COMMITISH:-deployed-to-production}
     build: apps/router
     depends_on:
       - mongo
@@ -212,7 +212,7 @@ services:
       - "3155"
 
   router-api: &router-api
-    image: govuk/router-api:${ROUTER_API_COMMITISH:-master}
+    image: govuk/router-api:${ROUTER_API_COMMITISH:-deployed-to-production}
     build: apps/router-api
     command: bundle exec unicorn -p 3056
     depends_on:
@@ -252,7 +252,7 @@ services:
       - "3156"
 
   content-store: &content-store
-    image: govuk/content-store:${CONTENT_STORE_COMMITISH:-master}
+    image: govuk/content-store:${CONTENT_STORE_COMMITISH:-deployed-to-production}
     build: apps/content-store
     command: bundle exec unicorn -p 3068
     depends_on:
@@ -295,7 +295,7 @@ services:
       - "3100"
 
   publishing-api: &publishing-api
-    image: govuk/publishing-api:${PUBLISHING_API_COMMITISH:-master}
+    image: govuk/publishing-api:${PUBLISHING_API_COMMITISH:-deployed-to-production}
     build: apps/publishing-api
     command: bundle exec unicorn -p 3093
     depends_on:
@@ -342,7 +342,7 @@ services:
     ports: []
 
   specialist-publisher:
-    image: govuk/specialist-publisher:${SPECIALIST_PUBLISHER_COMMITISH:-master}
+    image: govuk/specialist-publisher:${SPECIALIST_PUBLISHER_COMMITISH:-deployed-to-production}
     build:
       context: apps/specialist-publisher
     command: bundle exec unicorn -p 3064
@@ -369,7 +369,7 @@ services:
       - ./apps/specialist-publisher/log:/app/log
 
   travel-advice-publisher: &travel-advice-publisher
-    image: govuk/travel-advice-publisher:${TRAVEL_ADVICE_PUBLISHER_COMMITISH:-master}
+    image: govuk/travel-advice-publisher:${TRAVEL_ADVICE_PUBLISHER_COMMITISH:-deployed-to-production}
     build:
       context: apps/travel-advice-publisher
     command: bundle exec unicorn -p 3035
@@ -413,7 +413,7 @@ services:
     ports: []
 
   collections-publisher: &collections-publisher
-    image: govuk/collections-publisher:${COLLECTIONS_PUBLISHER_COMMITISH:-master}
+    image: govuk/collections-publisher:${COLLECTIONS_PUBLISHER_COMMITISH:-deployed-to-production}
     build:
       context: apps/collections-publisher
     command: bundle exec unicorn -p 3071
@@ -452,7 +452,7 @@ services:
     ports: []
 
   collections: &collections
-    image: govuk/collections:${COLLECTIONS_COMMITISH:-master}
+    image: govuk/collections:${COLLECTIONS_COMMITISH:-deployed-to-production}
     build:
       context: apps/collections
     command: bundle exec unicorn -p 3070
@@ -497,7 +497,7 @@ services:
       - "3170"
 
   contacts-admin:
-    image: govuk/contacts:${CONTACTS_ADMIN_COMMITISH:-master}
+    image: govuk/contacts:${CONTACTS_ADMIN_COMMITISH:-deployed-to-production}
     build:
       context: apps/contacts-admin
     depends_on:
@@ -523,7 +523,7 @@ services:
       - ./apps/contacts-admin/log:/app/log
 
   finder-frontend:
-    image: govuk/finder-frontend:${FINDER_FRONTEND_COMMITISH:-master}
+    image: govuk/finder-frontend:${FINDER_FRONTEND_COMMITISH:-deployed-to-production}
     build:
       context: apps/finder-frontend
     depends_on:
@@ -548,7 +548,7 @@ services:
       - ./apps/finder-frontend/log:/app/log
 
   publisher: &publisher
-    image: govuk/publisher:${PUBLISHER_COMMITISH:-master}
+    image: govuk/publisher:${PUBLISHER_COMMITISH:-deployed-to-production}
     build:
       context: apps/publisher
     command: bundle exec unicorn -p 3000
@@ -594,7 +594,7 @@ services:
     ports: []
 
   frontend: &frontend
-    image: govuk/frontend:${FRONTEND_COMMITISH:-master}
+    image: govuk/frontend:${FRONTEND_COMMITISH:-deployed-to-production}
     build:
       context: apps/frontend
     command: bundle exec unicorn -p 3005
@@ -643,7 +643,7 @@ services:
       - "3105"
 
   manuals-publisher: &manuals-publisher
-    image: govuk/manuals-publisher:${MANUALS_PUBLISHER_COMMITISH:-master}
+    image: govuk/manuals-publisher:${MANUALS_PUBLISHER_COMMITISH:-deployed-to-production}
     build:
       context: apps/manuals-publisher
     command: bundle exec unicorn -p 3205
@@ -684,7 +684,7 @@ services:
     ports: []
 
   manuals-frontend: &manuals-frontend
-    image: govuk/manuals-frontend:${MANUALS_FRONTEND_COMMITISH:-master}
+    image: govuk/manuals-frontend:${MANUALS_FRONTEND_COMMITISH:-deployed-to-production}
     build:
       context: apps/manuals-frontend
     command: bundle exec unicorn -p 3072
@@ -725,7 +725,7 @@ services:
       - "3172"
 
   calendars: &calendars
-    image: govuk/calendars:${CALENDARS_COMMITISH:-master}
+    image: govuk/calendars:${CALENDARS_COMMITISH:-deployed-to-production}
     build:
       context: apps/calendars
     command: bundle exec unicorn -p 3011
@@ -751,7 +751,7 @@ services:
       - ./apps/calendars/log:/app/log
 
   whitehall-admin: &whitehall
-    image: govuk/whitehall:${WHITEHALL_COMMITISH:-master}
+    image: govuk/whitehall:${WHITEHALL_COMMITISH:-deployed-to-production}
     build:
       context: apps/whitehall
     command: bundle exec unicorn -p 3020
@@ -815,7 +815,7 @@ services:
     ports: []
 
   content-tagger: &content-tagger
-    image: govuk/content-tagger:${CONTENT_TAGGER_COMMITISH:-master}
+    image: govuk/content-tagger:${CONTENT_TAGGER_COMMITISH:-deployed-to-production}
     build: apps/content-tagger
     depends_on:
       - content-tagger-worker
@@ -850,7 +850,7 @@ services:
     ports: []
 
   asset-manager: &asset-manager
-    image: govuk/asset-manager:${ASSET_MANAGER_COMMITISH:-master}
+    image: govuk/asset-manager:${ASSET_MANAGER_COMMITISH:-deployed-to-production}
     build: apps/asset-manager
     command: bundle exec unicorn -p 3037
     depends_on:
@@ -894,7 +894,7 @@ services:
     ports: []
 
   static: &static
-    image: govuk/static:${STATIC_COMMITISH:-master}
+    image: govuk/static:${STATIC_COMMITISH:-deployed-to-production}
     build: apps/static
     command: bundle exec unicorn -p 3013
     depends_on:
@@ -924,7 +924,7 @@ services:
       - "3113"
 
   government-frontend: &government-frontend
-    image: govuk/government-frontend:${GOVERNMENT_FRONTEND_COMMITISH:-master}
+    image: govuk/government-frontend:${GOVERNMENT_FRONTEND_COMMITISH:-deployed-to-production}
     build: apps/government-frontend
     command: bundle exec unicorn -p 3090
     depends_on:


### PR DESCRIPTION
To more closely match what we run on Jenkins we should use
deployed-to-production for our images and default branch to check out.

This also updates router to use the deployed-to-production tag that is
now available.