### PR TITLE
Update `make all` to split up cleanup steps and run stop

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,8 +21,10 @@ endif
 TEST_CMD = $(DOCKER_COMPOSE_CMD) run publishing-e2e-tests bundle exec parallel_rspec -n $(TEST_PROCESSES) $(TEST_ARGS)
 
 all:
-	$(MAKE) clean
+	$(MAKE) clean_apps clean_tmp
 	$(MAKE) clone
+	$(MAKE) stop
+	$(MAKE) clean_docker
 	$(MAKE) pull build
 	$(MAKE) start
 	$(MAKE) test


### PR DESCRIPTION
As part of local development if the `make all` command fails before
running the stop step it will fail on subsequent runs due to the images
still being used by running containers during the clean step. By moving
the `clean_docker` to run on its own after all containers have been
stopped we can avoid this.