### PR TITLE
Move the timeout up to 20s and interval up to 10s

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,8 +17,8 @@ x-govuk-app-env: &govuk-app
   SENTRY_DSN: http://user:password@error-handler.dev.gov.uk/123
 
 x-default-healthcheck: &default-healthcheck
-  interval: 2s
-  timeout: 2s
+  interval: 10s
+  timeout: 20s
 
 x-draft-govuk-app-env: &draft-govuk-app
   << : *govuk-app


### PR DESCRIPTION
Reducing the timeout in eb8025f4 had the unforeseen side effect of increasing the amount of CPU time required to service these healthcheck requests.  We're now in a balancing act of finding a
frequency of healthchecking which provides a healthy status quickly vs one which consumes a proportionate amount of system resources.

After much experimentation on both Ryan and Adrians macs, the combination of 20s timeout + 10s interval was performing well. At the beginning of the boot up process, the timeouts will be
more common so we believe this is why a longer backoff here gives enhanced stability.