### PR TITLE
Run apps via foreman commands

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -214,8 +214,9 @@ def buildDockerEnvironmnet(params) {
 def startDockerApps() {
   stage("Start docker apps") {
     try {
+      sh("make setup_dependencies -j12")
       sh("make up")
-      sh("make setup -j12")
+      sh("make setup_apps -j12")
     } catch(e) {
       echo("We weren't able to setup for tests, this probably means there is a bigger problem. Test aborting")
       throw e

--- a/bin/clone-app
+++ b/bin/clone-app
@@ -32,7 +32,7 @@ private
 
   def checkout
     unless system "git checkout -f #{commitish}"
-      raise "git failed to checkout #{commitish}"
+      raise "git failed to checkout #{commitish} for #{name}"
     end
   end
 
@@ -45,7 +45,7 @@ private
   def merge
     return if detached?
     unless system "git merge --ff-only origin/#{commitish}"
-      raise "merge failed for #{commitish}"
+      raise "merging #{name} failed for #{commitish}"
     end
   end
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,6 +15,7 @@ x-govuk-app-env: &govuk-app
   RAILS_SERVE_STATIC_FILES: "true"
   SECRET_KEY_BASE: 875c6bf4c48da9bb41f4cfd25d09bf5e2a62d88b39efc4bd9c498e6c8f61e4df740af87386f97269525e01b5f74402512eb6a4723882579f10aa95f6e2971fc2
   SENTRY_DSN: http://user:password@error-handler.dev.gov.uk/123
+  UNICORN_WORKER_PROCESSES: 1
 
 x-default-healthcheck: &default-healthcheck
   interval: 10s

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -93,7 +93,6 @@ services:
       - rummager-listener-insert-data
       - rummager-listener-bulk-insert-data
       - diet-error-handler
-    command: bundle exec unicorn -p 3009
     environment:
       << : *govuk-app
       GOVUK_APP_NAME: rummager
@@ -214,7 +213,6 @@ services:
   router-api: &router-api
     image: govuk/router-api:${ROUTER_API_COMMITISH:-deployed-to-production}
     build: apps/router-api
-    command: bundle exec unicorn -p 3056
     depends_on:
       - mongo
       - router
@@ -232,7 +230,6 @@ services:
 
   draft-router-api:
     << : *router-api
-    command: bundle exec unicorn -p 3156
     depends_on:
       - mongo
       - draft-router
@@ -254,7 +251,6 @@ services:
   content-store: &content-store
     image: govuk/content-store:${CONTENT_STORE_COMMITISH:-deployed-to-production}
     build: apps/content-store
-    command: bundle exec unicorn -p 3068
     depends_on:
       - mongo
       - router-api
@@ -275,7 +271,6 @@ services:
 
   draft-content-store:
     << : *content-store
-    command: bundle exec unicorn -p 3100
     depends_on:
       - mongo
       - draft-router-api
@@ -297,7 +292,6 @@ services:
   publishing-api: &publishing-api
     image: govuk/publishing-api:${PUBLISHING_API_COMMITISH:-deployed-to-production}
     build: apps/publishing-api
-    command: bundle exec unicorn -p 3093
     depends_on:
       - postgres
       - redis
@@ -320,7 +314,7 @@ services:
 
   publishing-api-worker:
     << : *publishing-api
-    command: bundle exec sidekiq -C ./config/sidekiq.yml
+    command: foreman run worker
     depends_on:
       - postgres
       - redis
@@ -345,7 +339,6 @@ services:
     image: govuk/specialist-publisher:${SPECIALIST_PUBLISHER_COMMITISH:-deployed-to-production}
     build:
       context: apps/specialist-publisher
-    command: bundle exec unicorn -p 3064
     depends_on:
       - mongo
       - redis
@@ -372,7 +365,6 @@ services:
     image: govuk/travel-advice-publisher:${TRAVEL_ADVICE_PUBLISHER_COMMITISH:-deployed-to-production}
     build:
       context: apps/travel-advice-publisher
-    command: bundle exec unicorn -p 3035
     depends_on:
       - mongo
       - redis
@@ -401,7 +393,7 @@ services:
 
   travel-advice-publisher-worker:
     << : *travel-advice-publisher
-    command: bundle exec sidekiq -C ./config/sidekiq.yml
+    command: foreman run worker
     depends_on:
       - publishing-api
       - diet-error-handler
@@ -416,7 +408,6 @@ services:
     image: govuk/collections-publisher:${COLLECTIONS_PUBLISHER_COMMITISH:-deployed-to-production}
     build:
       context: apps/collections-publisher
-    command: bundle exec unicorn -p 3071
     depends_on:
       - publishing-api
       - mysql
@@ -440,7 +431,7 @@ services:
 
   collections-publisher-worker:
     << : *collections-publisher
-    command: bundle exec sidekiq -C ./config/sidekiq.yml
+    command: foreman run worker
     depends_on:
       - publishing-api
       - diet-error-handler
@@ -455,7 +446,6 @@ services:
     image: govuk/collections:${COLLECTIONS_COMMITISH:-deployed-to-production}
     build:
       context: apps/collections
-    command: bundle exec unicorn -p 3070
     depends_on:
       - content-store
       - static
@@ -477,7 +467,6 @@ services:
 
   draft-collections:
     << : *collections
-    command: bundle exec unicorn -p 3170
     depends_on:
       - draft-content-store
       - draft-static
@@ -551,7 +540,6 @@ services:
     image: govuk/publisher:${PUBLISHER_COMMITISH:-deployed-to-production}
     build:
       context: apps/publisher
-    command: bundle exec unicorn -p 3000
     depends_on:
       - publishing-api
       - publisher-worker
@@ -582,7 +570,7 @@ services:
 
   publisher-worker:
     << : *publisher
-    command: bundle exec sidekiq -C ./config/sidekiq.yml
+    command: foreman run worker
     depends_on:
       - publishing-api
       - diet-error-handler
@@ -597,7 +585,6 @@ services:
     image: govuk/frontend:${FRONTEND_COMMITISH:-deployed-to-production}
     build:
       context: apps/frontend
-    command: bundle exec unicorn -p 3005
     depends_on:
       - content-store
       - static
@@ -623,7 +610,6 @@ services:
 
   draft-frontend:
     << : *frontend
-    command: bundle exec unicorn -p 3105
     depends_on:
       - draft-content-store
       - draft-static
@@ -646,7 +632,6 @@ services:
     image: govuk/manuals-publisher:${MANUALS_PUBLISHER_COMMITISH:-deployed-to-production}
     build:
       context: apps/manuals-publisher
-    command: bundle exec unicorn -p 3205
     depends_on:
       - publishing-api
       - mongo
@@ -672,7 +657,7 @@ services:
 
   manuals-publisher-worker:
     << : *manuals-publisher
-    command: bundle exec sidekiq -C ./config/sidekiq.yml
+    command: foreman run worker
     depends_on:
       - publishing-api
       - diet-error-handler
@@ -687,7 +672,6 @@ services:
     image: govuk/manuals-frontend:${MANUALS_FRONTEND_COMMITISH:-deployed-to-production}
     build:
       context: apps/manuals-frontend
-    command: bundle exec unicorn -p 3072
     depends_on:
       - content-store
       - static
@@ -707,7 +691,6 @@ services:
 
   draft-manuals-frontend: &draft-manuals-frontend
     << : *manuals-frontend
-    command: bundle exec unicorn -p 3172
     depends_on:
       - draft-content-store
       - draft-static
@@ -728,7 +711,6 @@ services:
     image: govuk/calendars:${CALENDARS_COMMITISH:-deployed-to-production}
     build:
       context: apps/calendars
-    command: bundle exec unicorn -p 3011
     depends_on:
       - rummager
       - content-store
@@ -754,7 +736,6 @@ services:
     image: govuk/whitehall:${WHITEHALL_COMMITISH:-deployed-to-production}
     build:
       context: apps/whitehall
-    command: bundle exec unicorn -p 3020
     depends_on:
       - asset-manager
       - content-store
@@ -807,7 +788,7 @@ services:
 
   whitehall-worker:
     << : *whitehall
-    command: bundle exec sidekiq -C ./config/sidekiq.yml
+    command: foreman run worker
     depends_on:
       - diet-error-handler
     environment:
@@ -855,7 +836,6 @@ services:
   asset-manager: &asset-manager
     image: govuk/asset-manager:${ASSET_MANAGER_COMMITISH:-deployed-to-production}
     build: apps/asset-manager
-    command: bundle exec unicorn -p 3037
     depends_on:
       - asset-manager-worker
       - diet-error-handler
@@ -882,7 +862,7 @@ services:
 
   asset-manager-worker:
     << : *asset-manager
-    command: bundle exec sidekiq -C ./config/sidekiq.yml
+    command: foreman run worker
     depends_on:
       - diet-error-handler
     environment:
@@ -899,7 +879,6 @@ services:
   static: &static
     image: govuk/static:${STATIC_COMMITISH:-deployed-to-production}
     build: apps/static
-    command: bundle exec unicorn -p 3013
     depends_on:
       - diet-error-handler
     environment:
@@ -915,7 +894,6 @@ services:
 
   draft-static:
     << : *static
-    command: bundle exec unicorn -p 3113
     environment:
       << : *draft-govuk-app
       GOVUK_APP_NAME: draft-static
@@ -929,7 +907,6 @@ services:
   government-frontend: &government-frontend
     image: govuk/government-frontend:${GOVERNMENT_FRONTEND_COMMITISH:-deployed-to-production}
     build: apps/government-frontend
-    command: bundle exec unicorn -p 3090
     depends_on:
       - content-store
       - static
@@ -954,7 +931,6 @@ services:
 
   draft-government-frontend:
     << : *government-frontend
-    command: bundle exec unicorn -p 3190
     depends_on:
       - draft-content-store
       - draft-static

--- a/lib/docker_service.rb
+++ b/lib/docker_service.rb
@@ -2,10 +2,10 @@ require 'docker'
 require 'docker/compose'
 
 class DockerService
-  def self.wait_for_healthy_services(services: [], except: [])
+  def self.wait_for_healthy_services(services: [], except: [], reload_seconds: 60, interval_seconds: 10)
     unhealthy_containers = get_services_containers(only: services, except: except)
 
-    RetryWhileFalse.call(reload_seconds: 60, interval_seconds: 1) do
+    RetryWhileFalse.call(reload_seconds: reload_seconds, interval_seconds: interval_seconds) do
       unhealthy_containers = unhealthy_containers.reject { |service_container| container_is_healthy(service_container) }
       unhealthy_containers.empty?
     end

--- a/lib/tasks/docker.rake
+++ b/lib/tasks/docker.rake
@@ -2,7 +2,7 @@ require_relative "../docker_service"
 
 namespace :docker do
   task :wait_for_dbs do
-    DockerService.wait_for_healthy_services(services: %w(elasticsearch mongo mysql postgres))
+    DockerService.wait_for_healthy_services(services: %w(elasticsearch mongo mysql postgres redis))
   end
 
   task :wait_for_rabbitmq do
@@ -10,7 +10,7 @@ namespace :docker do
   end
 
   task :wait_for_publishing_api do
-    DockerService.wait_for_healthy_services(services: %w(publishing-api redis))
+    DockerService.wait_for_healthy_services(services: %w(publishing-api))
   end
 
   task :wait_for_whitehall_admin do

--- a/lib/tasks/docker.rake
+++ b/lib/tasks/docker.rake
@@ -14,7 +14,7 @@ namespace :docker do
   end
 
   task :wait_for_whitehall_admin do
-    DockerService.wait_for_healthy_services(services: %w(whitehall-admin))
+    DockerService.wait_for_healthy_services(services: %w(whitehall-admin), reload_seconds: 180)
   end
 
   task :wait_for_apps do


### PR DESCRIPTION
Trello: https://trello.com/c/DQn6qMe3/145-set-up-unicorn-configs-in-apps

This switches all the apps to run their respective commands via foreman which means they're all run from commands in their Procfiles rather than us copying over commands. Which means we get to use the unicorn configurations that are defined in the apps.

In setting this up it was revealed that some apps blow up when they're database isn't created before they start, so this has a bit of refactoring around the database creation to set all these up with `docker run --rm --no-deps` commands. This hopefully will have a positive impact on the quantities of things in logs.

In the process of this I've managed to break running `make -j4` locally - @RyanMacG can you help?

This is DNM as I've edited the Jenkinsfile to specify which branches to run apps on and there's about a million related PRs to merge and deploy first.

- [x] https://github.com/alphagov/asset-manager/pull/486
- [x] https://github.com/alphagov/calendars/pull/221
- [x] https://github.com/alphagov/collections/pull/510
- [x] https://github.com/alphagov/collections-publisher/pull/319
- [x] https://github.com/alphagov/contacts-admin/pull/353
- [x] https://github.com/alphagov/content-store/pull/384
- [x] https://github.com/alphagov/content-tagger/pull/654
- [x] https://github.com/alphagov/finder-frontend/pull/408
- [x] https://github.com/alphagov/government-frontend/pull/782
- [x] https://github.com/alphagov/manuals-frontend/pull/319
- [x] https://github.com/alphagov/manuals-publisher/pull/1291
- [x] https://github.com/alphagov/publisher/pull/786
- [x] https://github.com/alphagov/publishing-api/pull/1169
- [x] https://github.com/alphagov/router-api/pull/141
- [x] https://github.com/alphagov/rummager/pull/1182
- [x] https://github.com/alphagov/specialist-publisher/pull/1167
- [x] https://github.com/alphagov/static/pull/1302
- [x] https://github.com/alphagov/travel-advice-publisher/pull/295
- [x] https://github.com/alphagov/specialist-publisher/pull/1167
- [x] https://github.com/alphagov/whitehall/pull/3796
- [x] https://github.com/alphagov/govuk-puppet/pull/7284

It's currently failing on jenkins as some of the branches haven't been rebased for the govuk_frontend_toolkit backwards incompatible change.