### PR TITLE
Update to clear page cache before each test run

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -113,6 +113,10 @@ RSpec.configure do |config|
 =end
 
   config.add_setting :reload_page_wait_time, default: 60
+
+  config.before(:each) do
+    page.driver.clear_memory_cache
+  end
 end
 
 Capybara.configure do |config|

--- a/spec/whitehall/publishing_document_spec.rb
+++ b/spec/whitehall/publishing_document_spec.rb
@@ -33,7 +33,7 @@ feature "Publishing a document with Whitehall", whitehall: true, government_fron
   def and_it_is_displayed_on_the_publication_finder
     publication_finder = find('a', text: "Publications", match: :first)[:href]
     reload_url_until_match(publication_finder, :has_text?, title)
-    click_link("Publications", match: :first)
+    visit(publication_finder)
 
     expect_rendering_application("whitehall")
     expect(page).to have_content(title)

--- a/spec/whitehall/updating_document_spec.rb
+++ b/spec/whitehall/updating_document_spec.rb
@@ -37,7 +37,7 @@ feature "Creating a new edition of a document with Whitehall", whitehall: true, 
   def and_it_is_updated_on_the_publication_finder
     publication_finder = find('a', text: "Publications", match: :first)[:href]
     reload_url_until_match(publication_finder, :has_text?, updated_title)
-    click_link("Publications", match: :first)
+    visit(publication_finder)
 
     expect_rendering_application("whitehall")
     expect(page).to have_content(updated_title)


### PR DESCRIPTION
This protects against potential cache pollution from other tests that were
previously observed with Whitehall. As such we have switched these to
use the old method rather than the workaround