### PR TITLE
Add name of spec to error screenshot

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -126,6 +126,10 @@ Capybara.configure do |config|
   config.default_max_wait_time = 4
 end
 
+Capybara::Screenshot.register_filename_prefix_formatter(:rspec) do |example|
+  "screenshot-#{example.description.downcase.gsub(/\W/, '-').gsub(/^.*\/spec\//, '')}"
+end
+
 # Capybara::Webkit.configure do |config|
 #   config.allow_url("*.dev.gov.uk")
 #   config.block_unknown_urls


### PR DESCRIPTION
This allows for easier matching of a failing test to a corresponding
screenshot in the situation where more than one test fails.

New format: `screenshot-creating-a-contact_2018-02-22-12-28-57.774.png`