### PR TITLE
Move the help message from the console output to the description

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -187,31 +187,36 @@ timestamps {
         }
 
         try {
-            stage("Run flaky/new tests") {
-              echo "Running flaky/new tests that aren't in main build with `make test TEST_ARGS='--tag flaky --tag new'`"
-              try {
-                sh("make test TEST_PROCESSES=${params.TEST_PROCESSES} TEST_ARGS=\"spec -o '--tag flaky --tag new'\"")
-              } catch(err) {
-                // Send a slack message just when tests fail within docker context
-                def message = "Publishing end-to-end flaky/new tests <${BUILD_URL}|failed>"
-                message += (params.ORIGIN_REPO) ? " for ${params.ORIGIN_REPO}" : ""
-                slackSend(color: "#ffff94", channel: "#end-to-end-tests", message: message)
-              }
+          stage("Run flaky/new tests") {
+            echo "Running flaky/new tests that aren't in main build with `make test TEST_ARGS='--tag flaky --tag new'`"
+            try {
+              sh("make test TEST_PROCESSES=${params.TEST_PROCESSES} TEST_ARGS=\"spec -o '--tag flaky --tag new'\"")
+            } catch(err) {
+              // Send a slack message just when tests fail within docker context
+              def message = "Publishing end-to-end flaky/new tests <${BUILD_URL}|failed>"
+              message += (params.ORIGIN_REPO) ? " for ${params.ORIGIN_REPO}" : ""
+              slackSend(color: "#ffff94", channel: "#end-to-end-tests", message: message)
             }
+          }
 
-            stage("Run tests") {
-              echo "Running tests with `make ${params.TEST_COMMAND}`"
-              sh("make ${params.TEST_COMMAND} TEST_PROCESSES=${params.TEST_PROCESSES}")
+          stage("Run tests") {
+            echo "Running tests with `make ${params.TEST_COMMAND}`"
+            sh("make ${params.TEST_COMMAND} TEST_PROCESSES=${params.TEST_PROCESSES}")
+          }
+
+          if (env.BRANCH_NAME == "master") {
+            echo 'Pushing to test-against branch'
+            sshagent(['govuk-ci-ssh-key']) {
+              sh("git push git@github.com:alphagov/publishing-e2e-tests.git HEAD:refs/heads/test-against --force")
             }
+          }
 
-            if (env.BRANCH_NAME == "master") {
-              echo 'Pushing to test-against branch'
-              sshagent(['govuk-ci-ssh-key']) {
-                sh("git push git@github.com:alphagov/publishing-e2e-tests.git HEAD:refs/heads/test-against --force")
-              }
-            }
-
-            originBuildStatus("Publishing end-to-end tests succeeded on Jenkins", "SUCCESS")
+          originBuildStatus("Publishing end-to-end tests succeeded on Jenkins", "SUCCESS")
+        } catch (e) {
+          def GUIDE_URL = "https://github.com/alphagov/publishing-e2e-tests/blob/master/CONTRIBUTING.md#dealing-with-flaky-tests"
+          currentBuild.description = "<p style=\"color: red\">Is the failure unrelated to your change?</p>" +
+                                     "<p>We have <a href=\"${GUIDE_URL}\">flaky test advice available</a> to help.</p>"
+          throw e
         } finally {
             stage("JUnit") {
               junit 'tmp/rspec*.xml'
@@ -221,7 +226,6 @@ timestamps {
       } catch (e) {
         failBuild()
 
-        echo("Did this fail due to a flaky test? See: https://github.com/alphagov/publishing-e2e-tests/blob/master/CONTRIBUTING.md")
         // Send a slack message just when tests fail within docker context
         def message = "Publishing end-to-end tests <${BUILD_URL}|failed>"
         message += (params.ORIGIN_REPO) ? " for ${params.ORIGIN_REPO}" : ""


### PR DESCRIPTION
This makes the message more obvious, at the moment it gets lost in a sea of std out.

Example of message:

![image](https://user-images.githubusercontent.com/976274/36546071-4f91f9f0-17e2-11e8-867e-5fef1e068299.png)


Also fix indentation