### PR TITLE
Change log disarding behaviour

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -44,12 +44,9 @@ timestamps {
     }
 
     properties([
-      [$class: "BuildDiscarderProperty",
-       strategy: [$class: "LogRotator",
-                  artifactDaysToKeepStr: "",
-                  artifactDaysToKeepStr: "",
-                  daysToKeepStr: "30",
-                  numToKeepStr: ""]],
+      buildDiscarder(
+        logRotator(artifactDaysToKeepStr: "3", daysToKeepStr: "14", numToKeepStr: "400")
+      ),
       parameters([
         stringParam(
           defaultValue: "",


### PR DESCRIPTION
This will keep builds for up to 14 days (or a maximum of 400) and artefacts for 3 days.

This is in response to e2e tests using up a ton of resources on ci boxes.

As always with these groovy things, there seems to be a nicer syntax than the horrid `$class` business but as such I'm kinda just hoping that because it's building ok it means it works as I'm not sure how to test it beyond having something hit the limits. 