### PR TITLE
Allow configuring govuk-content-schemas commitish

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -13,6 +13,7 @@ def apps = [
   [constantPrefix: "CONTENT_TAGGER", app: "content-tagger", name: "Content Tagger"],
   [constantPrefix: "FINDER_FRONTEND", app: "finder-frontend", name: "Finder Frontend"],
   [constantPrefix: "FRONTEND", app: "frontend", name: "Frontend"],
+  [constantPrefix: "GOVUK_CONTENT_SCHEMAS", app: "govuk-content-schemas", name: "GOV.UK Content Schemas"],
   [constantPrefix: "GOVERNMENT_FRONTEND", app: "government-frontend", name: "Government Frontend"],
   [constantPrefix: "MANUALS_FRONTEND", app: "manuals-frontend", name: "Manuals Frontend"],
   [constantPrefix: "MANUALS_PUBLISHER", app: "manuals-publisher", name: "Manuals Publisher"],


### PR DESCRIPTION
This allows us to specify which commit/branch is used to build the tests
and is a pre-requisite before enabling these tests on the
govuk-content-schemas repository.