### PR TITLE
Update form field in Content Tagger specs

### DIFF
--- a/spec/content_tagger/adding_taxon_to_external_content_spec.rb
+++ b/spec/content_tagger/adding_taxon_to_external_content_spec.rb
@@ -3,7 +3,7 @@ feature "Adding a taxon to external content", collections: true, content_tagger:
   include PublisherHelpers
 
   let(:taxon_title) { "Tagging external content taxon " + SecureRandom.uuid }
-  let(:taxon_slug) { "tagging-taxon-" + SecureRandom.uuid }
+  let(:taxon_base_path) { "/tagging-taxon-" + SecureRandom.uuid }
   let(:guide_title) { "Tagging external content guide " + SecureRandom.uuid }
   let(:guide_slug) { "tagging-taxon-guide-" + SecureRandom.uuid }
 
@@ -22,7 +22,7 @@ feature "Adding a taxon to external content", collections: true, content_tagger:
   end
 
   def and_there_is_a_published_taxon
-    create_draft_taxon(slug: taxon_slug, title: taxon_title)
+    create_draft_taxon(base_path: taxon_base_path, title: taxon_title)
     publish_taxon
     @taxon_url = find_link("View on GOV.UK")[:href]
     reload_url_until_status_code(@taxon_url, 200)

--- a/spec/content_tagger/create_draft_taxon_spec.rb
+++ b/spec/content_tagger/create_draft_taxon_spec.rb
@@ -2,7 +2,7 @@ feature "Creating a draft taxon on Content Tagger", collections: true, content_t
   include ContentTaggerHelpers
 
   let(:title) { "Create Draft Taxon #{SecureRandom.uuid}" }
-  let(:slug) { "draft-taxon-#{SecureRandom.uuid}" }
+  let(:base_path) { "/draft-taxon-#{SecureRandom.uuid}" }
 
   scenario "Creating a draft taxon" do
     when_i_create_a_new_taxon
@@ -10,7 +10,7 @@ feature "Creating a draft taxon on Content Tagger", collections: true, content_t
   end
 
   def when_i_create_a_new_taxon
-    create_draft_taxon(slug: slug, title: title)
+    create_draft_taxon(base_path: base_path, title: title)
   end
 
   def then_i_can_preview_it_on_draft_gov_uk

--- a/spec/content_tagger/publishing_taxon_spec.rb
+++ b/spec/content_tagger/publishing_taxon_spec.rb
@@ -2,7 +2,7 @@ feature "Publishing a taxon on Content Tagger", collections: true, content_tagge
   include ContentTaggerHelpers
 
   let(:title) { "Publishing a taxon #{SecureRandom.uuid}" }
-  let(:slug) { "publishing-taxon-#{SecureRandom.uuid}" }
+  let(:base_path) { "/publishing-taxon-#{SecureRandom.uuid}" }
 
   scenario "Publishing a taxon" do
     given_there_is_a_draft_taxon
@@ -11,7 +11,7 @@ feature "Publishing a taxon on Content Tagger", collections: true, content_tagge
   end
 
   def given_there_is_a_draft_taxon
-    create_draft_taxon(slug: slug, title: title)
+    create_draft_taxon(base_path: base_path, title: title)
   end
 
   def when_i_publish_the_taxon

--- a/spec/content_tagger/removing_taxon_spec.rb
+++ b/spec/content_tagger/removing_taxon_spec.rb
@@ -2,8 +2,8 @@ feature "Removing content from Content Tagger", collections: true, content_tagge
   include ContentTaggerHelpers
 
   let(:redirection_destination_title) { "Removed taxon destination " + SecureRandom.uuid }
-  let(:redirection_destination_slug) { "redirection-taxon-" + SecureRandom.uuid }
-  let(:removed_slug) { "removed-taxon-" + SecureRandom.uuid }
+  let(:redirection_destination_base_path) { "/redirection-taxon-" + SecureRandom.uuid }
+  let(:removed_base_path) { "/removed-taxon-" + SecureRandom.uuid }
 
   scenario "Unpublishing a taxon" do
     given_there_are_two_published_taxons
@@ -12,10 +12,14 @@ feature "Removing content from Content Tagger", collections: true, content_tagge
   end
 
   def given_there_are_two_published_taxons
-    @redirection_destination_url = create_and_publish_taxon(slug: redirection_destination_slug, title: redirection_destination_title)
+    @redirection_destination_url = create_and_publish_taxon(
+      base_path: redirection_destination_base_path, title: redirection_destination_title
+    )
     reload_url_until_status_code(@redirection_destination_url, 200)
 
-    @redirected_taxon_url = create_and_publish_taxon(slug: removed_slug, title: "Removed taxon " + SecureRandom.uuid)
+    @redirected_taxon_url = create_and_publish_taxon(
+      base_path: removed_base_path, title: "Removed taxon " + SecureRandom.uuid
+    )
     reload_url_until_status_code(@redirected_taxon_url, 200)
   end
 
@@ -34,8 +38,8 @@ feature "Removing content from Content Tagger", collections: true, content_tagge
 
   private
 
-  def create_and_publish_taxon(slug:, title:)
-    create_draft_taxon(slug: slug, title: title)
+  def create_and_publish_taxon(base_path:, title:)
+    create_draft_taxon(base_path: base_path, title: title)
     publish_taxon
     find_link("View on GOV.UK")[:href]
   end

--- a/spec/content_tagger/updating_taxon_spec.rb
+++ b/spec/content_tagger/updating_taxon_spec.rb
@@ -2,7 +2,7 @@ feature "Updating a published taxon on Content Tagger", collections: true, conte
   include ContentTaggerHelpers
 
   let(:title) { "Updating a taxon" + SecureRandom.uuid }
-  let(:slug) { "updating-taxon" + SecureRandom.uuid }
+  let(:base_path) { "/updating-taxon" + SecureRandom.uuid }
   let(:updated_content) { "Updated content" + SecureRandom.uuid }
 
   scenario "Updating a taxon" do
@@ -14,7 +14,7 @@ feature "Updating a published taxon on Content Tagger", collections: true, conte
   private
 
   def given_there_is_a_published_taxon
-    create_draft_taxon(slug: slug, title: title)
+    create_draft_taxon(base_path: base_path, title: title)
     publish_taxon
 
     url = find_link("View on GOV.UK")[:href]

--- a/spec/support/content_tagger_helpers.rb
+++ b/spec/support/content_tagger_helpers.rb
@@ -1,7 +1,7 @@
 module ContentTaggerHelpers
-  def create_draft_taxon(slug:, title:)
+  def create_draft_taxon(base_path:, title:)
     visit(Plek.find("content-tagger") + "/taxons/new")
-    fill_in "Path", with: slug
+    fill_in "Base path", with: base_path
     fill_in "Internal taxon name", with: title
     fill_in "External taxon name", with: title
     fill_in "Description", with: Faker::Lorem.paragraph


### PR DESCRIPTION
In the taxon form of Content Tagger, we have removed the 'slug' field
and replaced it with a 'base path' field. Further details at [1]

[1] https://github.com/alphagov/content-tagger/pull/669