### PR TITLE
Clean temporary files on exit

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -78,7 +78,14 @@ timestamps {
       } finally {
         makeLogsAvailable()
         alertTestOutcome(params, testStatus)
+
         stopDocker()
+
+        // Docker leaves these owned by root which makes it difficult for
+        // Jenkins to clean them up
+        stage("Clean temporary files") {
+          sh("make clean_tmp")
+        }
       }
     }
   }


### PR DESCRIPTION
These otherwise get left around owned by root and can't be cleaned up by Jenkins. Which can cause a super massive slowdown for Jenkins :cry: