### PR TITLE
Clean apps on Jenkins exit

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -85,7 +85,7 @@ timestamps {
         // Docker leaves these owned by root which makes it difficult for
         // Jenkins to clean them up
         stage("Clean temporary files") {
-          sh("make clean_tmp")
+          sh("make -j clean_tmp clean_apps")
         }
       }
     }


### PR DESCRIPTION
I hadn't realised before but the apps also leave files owned by root
which can't be cleaned up by Jenkins automatically.