### PR TITLE
Mark removing a taxon test as flaky

### DIFF
--- a/spec/content_tagger/removing_taxon_spec.rb
+++ b/spec/content_tagger/removing_taxon_spec.rb
@@ -1,4 +1,4 @@
-feature "Removing content from Content Tagger", collections: true, content_tagger: true do
+feature "Removing content from Content Tagger", collections: true, content_tagger: true, flaky: true do
   include ContentTaggerHelpers
 
   let(:redirection_destination_title) { "Removed taxon destination " + SecureRandom.uuid }


### PR DESCRIPTION
Trello: https://trello.com/c/ijEN9RWY/384-handle-unpublished-content-items-in-collections-publisher

We are seeing a number of tests fail with messages like this:

Aborting reloading
http://www.dev.gov.uk/removed-taxon-bb2627d6-a21a-4d7e-a802-1b0b32507997
as a 500 was returned

Which seem to have originated since
https://github.com/alphagov/collections/pull/615 was merged - although I'm not
sure how this didn't error in some way before this.

The hypothesis for why this is occurring is that router is updated after
content store and collections is trying to serve an unpublished
document. Once collections can return correct redirect/gone responses
then this test can have the flaky tag removed.