### PR TITLE
Pull docker images when building

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -39,7 +39,7 @@ kill:
 	$(DOCKER_COMPOSE_CMD) rm -f
 
 build: kill
-	$(DOCKER_COMPOSE_CMD) build diet-error-handler publishing-e2e-tests $(APPS_TO_BUILD)
+	$(DOCKER_COMPOSE_CMD) build --pull diet-error-handler publishing-e2e-tests $(APPS_TO_BUILD)
 
 setup_dependencies:
 	$(DOCKER_COMPOSE_CMD) up -d elasticsearch mongo mysql postgres rabbitmq redis


### PR DESCRIPTION
Trello: https://trello.com/c/AWKGj0d2/218-investigate-random-dockerfile-failures

This is to try ensure we always use up to date images when building