### PR TITLE
Include Email Alert API and Email Alert Service in application suite

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -13,6 +13,8 @@ def apps = [
   [constantPrefix: "CONTACTS_ADMIN", app: "contacts-admin", name: "Contacts Admin"],
   [constantPrefix: "CONTENT_STORE", app: "content-store", name: "Content Store"],
   [constantPrefix: "CONTENT_TAGGER", app: "content-tagger", name: "Content Tagger"],
+  [constantPrefix: "EMAIL_ALERT_API", app: "email-alert-api", name: "Email Alert API"],
+  [constantPrefix: "EMAIL_ALERT_SERVICE", app: "email-alert-service", name: "Email Alert Service"],
   [constantPrefix: "FINDER_FRONTEND", app: "finder-frontend", name: "Finder Frontend"],
   [constantPrefix: "FRONTEND", app: "frontend", name: "Frontend"],
   [constantPrefix: "GOVUK_CONTENT_SCHEMAS", app: "govuk-content-schemas", name: "GOV.UK Content Schemas"],

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ APPS = asset-manager content-store govuk-content-schemas government-frontend \
 	specialist-publisher static travel-advice-publisher collections-publisher \
 	collections frontend publisher calendars \
 	manuals-publisher manuals-frontend whitehall content-tagger \
-	contacts-admin finder-frontend email-alert-api
+	contacts-admin finder-frontend email-alert-api email-alert-service
 
 RUBY_VERSION = `cat .ruby-version`
 DOCKER_RUN = docker run --rm -v `pwd`:/app ruby:$(RUBY_VERSION)

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ APPS = asset-manager content-store govuk-content-schemas government-frontend \
 	specialist-publisher static travel-advice-publisher collections-publisher \
 	collections frontend publisher calendars \
 	manuals-publisher manuals-frontend whitehall content-tagger \
-	contacts-admin finder-frontend
+	contacts-admin finder-frontend email-alert-api
 
 RUBY_VERSION = `cat .ruby-version`
 DOCKER_RUN = docker run --rm -v `pwd`:/app ruby:$(RUBY_VERSION)
@@ -56,9 +56,10 @@ setup_apps:
 	bundle exec rake docker:wait_for_apps
 
 setup_dbs: router_setup content_store_setup asset_manager_setup \
-  publishing_api_setup travel_advice_setup whitehall_setup \
-  content_tagger_setup manuals_publisher_setup specialist_publisher_setup \
-  publisher_setup collections_publisher_setup rummager_setup contacts_admin_setup
+	publishing_api_setup travel_advice_setup whitehall_setup \
+	content_tagger_setup manuals_publisher_setup specialist_publisher_setup \
+	publisher_setup collections_publisher_setup rummager_setup \
+	contacts_admin_setup email_alert_api_setup
 
 router_setup:
 	$(DOCKER_COMPOSE_CMD) run --rm --no-deps router-api bundle exec rake db:purge
@@ -97,6 +98,9 @@ collections_publisher_setup:
 
 rummager_setup:
 	$(DOCKER_COMPOSE_CMD) run --rm --no-deps rummager env RUMMAGER_INDEX=all bundle exec rake rummager:create_all_indices
+
+email_alert_api_setup:
+	$(DOCKER_COMPOSE_CMD) run --rm --no-deps email-alert-api bundle exec rake db:setup
 
 wait_for_whitehall_admin:
 	bundle exec rake docker:wait_for_whitehall_admin

--- a/docker-compose.development.yml
+++ b/docker-compose.development.yml
@@ -124,6 +124,10 @@ services:
     ports:
       - "33037:3037"
 
+  email-alert-api:
+    ports:
+      - "33088:3088"
+
   static:
     ports:
       - "33013:3013"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -805,6 +805,7 @@ services:
     depends_on:
       - content-tagger-worker
       - diet-error-handler
+      - email-alert-api
       - publishing-api
       - postgres
       - redis
@@ -815,6 +816,7 @@ services:
     healthcheck:
       << : *default-healthcheck
     links:
+      - nginx-proxy:email-alert-api.dev.gov.uk
       - nginx-proxy:error-handler.dev.gov.uk
       - nginx-proxy:publishing-api.dev.gov.uk
     ports:
@@ -873,6 +875,43 @@ services:
       SENTRY_CURRENT_ENV: asset-manager-worker
       FAKE_S3_HOST: http://127.0.0.1
       ALLOW_FAKE_S3_IN_PRODUCTION_FOR_PUBLISHING_E2E_TESTS: "true"
+    healthcheck:
+      disable: true
+    ports: []
+
+  email-alert-api: &email-alert-api
+    image: govuk/email-alert-api:${EMAIL_ALERT_API_COMMITISH:-deployed-to-production}
+    build: apps/email-alert-api
+    depends_on:
+      - diet-error-handler
+      - email-alert-api-worker
+      - postgres
+      - redis
+    links:
+      - nginx-proxy:error-handler.dev.gov.uk
+    environment:
+      << : *govuk-app
+      EMAIL_ALERT_AUTH_TOKEN: 9d3e07ca727cd08cc503191f233919877160bfc57eaaa33541761c2d1ffd951ae205263be5832f26ba2670b142d7c593ec0f6bdd11a84cf325a32dbdd889ff44
+      REDIS_HOST: redis
+      SENTRY_CURRENT_ENV: email-alert-api
+      VIRTUAL_HOST: email-alert-api.dev.gov.uk
+    healthcheck:
+      << : *default-healthcheck
+    ports:
+      - "3088"
+    volumes:
+      - ./apps/email-alert-api/log:/app/log
+
+  email-alert-api-worker:
+    << : *email-alert-api
+    command: foreman run worker
+    depends_on:
+      - diet-error-handler
+    environment:
+      << : *govuk-app
+      EMAIL_ALERT_AUTH_TOKEN: 9d3e07ca727cd08cc503191f233919877160bfc57eaaa33541761c2d1ffd951ae205263be5832f26ba2670b142d7c593ec0f6bdd11a84cf325a32dbdd889ff44
+      REDIS_HOST: redis
+      SENTRY_CURRENT_ENV: email-alert-api-worker
     healthcheck:
       disable: true
     ports: []

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -916,6 +916,24 @@ services:
       disable: true
     ports: []
 
+  email-alert-service:
+    image: govuk/email-alert-service:${EMAIL_ALERT_SERVICE_COMMITISH:-deployed-to-production}
+    build: apps/email-alert-service
+    depends_on:
+      - diet-error-handler
+      - email-alert-api
+      - rabbitmq
+      - redis
+    links:
+      - nginx-proxy:email-alert-api.dev.gov.uk
+      - nginx-proxy:error-handler.dev.gov.uk
+    environment:
+      << : *govuk-app
+      GOVUK_ENV: production
+      SENTRY_CURRENT_ENV: email-alert-service
+    volumes:
+      - ./apps/email-alert-service/log:/app/log
+
   static: &static
     image: govuk/static:${STATIC_COMMITISH:-deployed-to-production}
     build: apps/static

--- a/docker/nginx.tmpl
+++ b/docker/nginx.tmpl
@@ -1,5 +1,5 @@
 {{/* This is a copy of the file from https://github.com/jwilder/nginx-proxy/blob/master/nginx.tmpl */}}
-{{/* It had to be duplicated so we could add customisations, they are at the end of this file */}}
+{{/* It had to be duplicated so we could add customisations */}}
 {{ $CurrentContainer := where $ "ID" .Docker.CurrentContainerID | first }}
 
 {{ define "upstream" }}
@@ -46,6 +46,13 @@ map $scheme $proxy_x_forwarded_ssl {
   https on;
 }
 
+# Pass through Govuk-Request-Id if we're given it otherwise use the
+# nginx $request_id
+map $http_govuk_request_id $proxy_govuk_request_id {
+  default $http_govuk_request_id;
+  ''      $request_id;
+}
+
 gzip_types text/plain text/css application/javascript application/json application/x-javascript text/xml application/xml application/xml+rss text/javascript;
 
 log_format vhost '$host $remote_addr - $remote_user [$time_local] '
@@ -68,6 +75,7 @@ proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
 proxy_set_header X-Forwarded-Proto $proxy_x_forwarded_proto;
 proxy_set_header X-Forwarded-Ssl $proxy_x_forwarded_ssl;
 proxy_set_header X-Forwarded-Port $proxy_x_forwarded_port;
+proxy_set_header GOVUK-Request-Id $proxy_govuk_request_id;
 
 # Mitigate httpoxy attack (see README for details)
 proxy_set_header Proxy "";


### PR DESCRIPTION
Trello: https://trello.com/c/U9nNDFrH/222-decide-on-whether-e2e-tests-should-include-email-alert-api-following-on-from-content-tagger-work

This adds in Email Alert Service and Email Alert API as applications that run as part of the end-to-end testing suite.

The primary motivation for adding these in is that we are currently seeing a lot of errors due to the lack of Email Alert API existing. 

Ideally we'd also test that emails send with this as this is addition is a bit risky with the lack of active tests. However it's not trivial working out how to test this and does resolve the issue of error output.

This also adds govuk_request_id to the nginx config as this was needed for Email Alert Service.