### PR TITLE
[Do not merge] Update whitehall tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -52,6 +52,7 @@ setup_apps:
 	bundle exec rake docker:wait_for_publishing_api
 	$(MAKE) contacts_admin_seed
 	$(MAKE) publish_routes
+	$(MAKE) populate_end_to_end_test_data_from_whitehall
 	$(DOCKER_COMPOSE_CMD) run --rm publishing-e2e-tests bundle exec rake govuk:wait_for_router
 	bundle exec rake docker:wait_for_apps
 
@@ -134,6 +135,9 @@ publish_contacts_admin:
 
 publish_whitehall:
 	$(DOCKER_COMPOSE_CMD) exec -T whitehall-admin bundle exec rake publishing_api:publish_special_routes
+
+populate_end_to_end_test_data_from_whitehall:
+	$(DOCKER_COMPOSE_CMD) exec -T whitehall-admin bundle exec rake taxonomy:populate_end_to_end_test_data
 
 clean_apps:
 	$(DOCKER_RUN) bash -c 'rm -rf /app/apps/*'

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -743,6 +743,7 @@ services:
       - diet-error-handler
       - mysql
       - publishing-api
+      - redis
       - rummager
       - static
       - whitehall-worker
@@ -754,6 +755,7 @@ services:
       SENTRY_CURRENT_ENV: whitehall-admin
       GOVUK_ASSET_ROOT: http://whitehall-admin.dev.gov.uk
       LOG_PATH: log/admin.log
+      REDIS_URL: redis://redis/1
     healthcheck:
       << : *default-healthcheck
     links:
@@ -794,6 +796,7 @@ services:
       - diet-error-handler
     environment:
       << : *govuk-app
+      REDIS_URL: redis://redis/1
       SENTRY_CURRENT_ENV: whitehall-worker
     healthcheck:
       disable: true

--- a/spec/support/whitehall_helpers.rb
+++ b/spec/support/whitehall_helpers.rb
@@ -4,6 +4,9 @@ module WhitehallHelpers
     fill_in_consultation_form(title: title)
     click_button("Save and continue")
     expect(page).to have_text("The document has been saved")
+    check "Test taxon"
+    click_button("Save and review legacy tagging")
+    expect(page).to have_text("The tags have been updated")
     click_button("Save")
     expect(page).to have_text("The associations have been saved")
   end

--- a/spec/whitehall/updating_document_spec.rb
+++ b/spec/whitehall/updating_document_spec.rb
@@ -50,6 +50,8 @@ feature "Creating a new edition of a document with Whitehall", whitehall: true, 
     fill_in "Title", with: updated_title
     fill_in "Public change note", with: "Testing update behaviour"
     click_button("Save and continue")
+    check "Test taxon"
+    click_button("Save and review legacy tagging")
     click_button("Save")
     expect(page).to have_text("The associations have been saved")
   end

--- a/spec/whitehall/uploading_attachment_spec.rb
+++ b/spec/whitehall/uploading_attachment_spec.rb
@@ -20,6 +20,8 @@ feature "Uploading an attachment on Whitehall", whitehall: true, government_fron
     image_markdown = "!!1"
     fill_in_consultation_form(title: title, body: "Attached image\n\n#{image_markdown}")
     click_button("Save and continue")
+    check "Test taxon"
+    click_button("Save and review legacy tagging")
     click_button("Save")
     expect(page).to have_text("The associations have been saved")
   end


### PR DESCRIPTION
Trello: https://trello.com/c/7k55NmyU

Dependant on: https://github.com/alphagov/whitehall/pull/4143

## What's changed

The publishing flow in Whitehall is being updated to make all publishers tag content to the topic taxonomy. Every time a publisher updates a draft, they are routed to the topic tagging page.