### PR TITLE
Revert "Revert "Add regions facet to business support finder spec""

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -147,6 +147,9 @@ def initializeParameters(govuk, appsCollection) {
     "TEST_PROCESSES": "6"] + appDefaultCommits
   )
 
+  unbuildableApps = [
+    "govuk-content-schemas",
+  ]
   appsToBuild = []
   appsCollection.each { app ->
     commitishConstant = "${app.constantPrefix}_COMMITISH"
@@ -154,7 +157,7 @@ def initializeParameters(govuk, appsCollection) {
     commitish = params[commitishConstant].trim()
     govuk.setEnvar(commitishConstant, commitish)
 
-    if (commitish != app.defaultCommitish) {
+    if (commitish != app.defaultCommitish && !unbuildableApps.contains(app.app)) {
       appsToBuild << app.app
     }
   }

--- a/spec/support/specialist_publisher_helpers.rb
+++ b/spec/support/specialist_publisher_helpers.rb
@@ -88,6 +88,7 @@ module SpecialistPublisherHelpers
     select_all_select2("business_finance_support_scheme_business_sizes")
     select_all_select2("business_finance_support_scheme_industries")
     select_all_select2("business_finance_support_scheme_business_stages")
+    select_all_select2("business_finance_support_scheme_regions")
   end
 
   def fill_in_cma_case_form(options = {})


### PR DESCRIPTION
Restores alphagov/publishing-e2e-tests#242

https://trello.com/c/yUWfjwSN/514-deploy-regional-location-facet-to-finance-and-support-for-your-business-finder