### PR TITLE
Include draft-whitehall-frontend /government/assets endpoint

### DIFF
--- a/docker/nginx.tmpl
+++ b/docker/nginx.tmpl
@@ -337,6 +337,13 @@ server {
   }
   {{ end }}
 
+  {{ if eq $host "draft-whitehall-frontend.dev.gov.uk" }}
+  location /government/assets/ {
+    proxy_set_header Host draft-whitehall-frontend.dev.gov.uk;
+    proxy_pass {{ trim $proto }}://{{ trim $upstream_name }};
+  }
+  {{ end }}
+
   {{ if eq $host "asset-manager.dev.gov.uk" }}
   # Ref: https://github.com/alphagov/govuk-puppet/blob/3001e50c2c44c5456e316ae5bd0d241eade063b8/modules/govuk/templates/static_extra_nginx_config.conf.erb#L19-L37
   location ~ ^/media/ {


### PR DESCRIPTION
This used to be handled by whitehall-admin but as we migrate fully to asset-manager, it's handled by whitehall-frontend with a redirect to asset-manager.