### PR TITLE
Add org api dependencies to contacts

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -492,10 +492,12 @@ services:
     build:
       context: apps/contacts-admin
     depends_on:
-      - publishing-api
-      - mysql
-      - rummager
+      - collections
       - diet-error-handler
+      - mysql
+      - publishing-api
+      - router
+      - rummager
       - whitehall-admin
     environment:
       << : *govuk-app
@@ -508,6 +510,7 @@ services:
       - nginx-proxy:publishing-api.dev.gov.uk
       - nginx-proxy:error-handler.dev.gov.uk
       - nginx-proxy:whitehall-admin.dev.gov.uk
+      - nginx-proxy:www.dev.gov.uk
     ports:
       - "3051"
     volumes:


### PR DESCRIPTION
The organisations API is [now expected to be served from www.gov.uk](https://github.com/alphagov/gds-api-adapters/commit/bd9d95911b5c389c691c14174a7d12d0b85fd8ee).

We now need to update the contacts-admin config to include the applications involved in serving the API to the tests.