### PR TITLE
Add org api dependencies to manuals-publisher

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -637,12 +637,14 @@ services:
     build:
       context: apps/manuals-publisher
     depends_on:
-      - publishing-api
-      - mongo
-      - rummager
       - asset-manager
-      - manuals-publisher-worker
+      - collections
       - diet-error-handler
+      - manuals-publisher-worker
+      - mongo
+      - publishing-api
+      - router
+      - rummager
       - whitehall-admin
     environment:
       << : *govuk-app
@@ -654,6 +656,7 @@ services:
       - nginx-proxy:error-handler.dev.gov.uk
       - nginx-proxy:asset-manager.dev.gov.uk
       - nginx-proxy:whitehall-admin.dev.gov.uk
+      - nginx-proxy:www.dev.gov.uk
     ports:
       - "3205"
     volumes:


### PR DESCRIPTION
The organisations API is now expected to be served from www.gov.uk.

We now need to update the manuals-publisher tests to include the applications
involved in serving the API to the tests.