### PR TITLE
Revert "Add org api dependencies to manuals-publisher"

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -637,14 +637,12 @@ services:
     build:
       context: apps/manuals-publisher
     depends_on:
-      - asset-manager
-      - collections
-      - diet-error-handler
-      - manuals-publisher-worker
-      - mongo
       - publishing-api
-      - router
+      - mongo
       - rummager
+      - asset-manager
+      - manuals-publisher-worker
+      - diet-error-handler
       - whitehall-admin
     environment:
       << : *govuk-app
@@ -656,7 +654,6 @@ services:
       - nginx-proxy:error-handler.dev.gov.uk
       - nginx-proxy:asset-manager.dev.gov.uk
       - nginx-proxy:whitehall-admin.dev.gov.uk
-      - nginx-proxy:www.dev.gov.uk
     ports:
       - "3205"
     volumes:


### PR DESCRIPTION
Reverts alphagov/publishing-e2e-tests#259

We were originally going to be good citizens and use the public organisations API rather than depending on whitehall. However this change is more complex than originally intended and is holding up the work to add authentication to our writable API endpoints.

It seems that contacts-admin is also affected by changing the organisations endpoint as gds-api-adapters hasn't been updated since this PR https://github.com/alphagov/contacts-admin/pull/495 was merged.

The plan now is to get authentication working in manual-publisher for link-checker-api, and then change the organisations endpoint as a separate piece of work.

Trello: https://trello.com/c/2IdzHdtp