### PR TITLE
Revert "Reset DB on router-api instead of Purge"

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -63,8 +63,8 @@ setup_dbs: router_setup content_store_setup asset_manager_setup \
 	contacts_admin_setup email_alert_api_setup
 
 router_setup:
-	$(DOCKER_COMPOSE_CMD) run --rm --no-deps router-api bundle exec rake db:reset
-	$(DOCKER_COMPOSE_CMD) run --rm --no-deps draft-router-api bundle exec rake db:reset
+	$(DOCKER_COMPOSE_CMD) run --rm --no-deps router-api bundle exec rake db:purge
+	$(DOCKER_COMPOSE_CMD) run --rm --no-deps draft-router-api bundle exec rake db:purge
 
 content_store_setup:
 	$(DOCKER_COMPOSE_CMD) run --rm --no-deps content-store bundle exec rake db:reset


### PR DESCRIPTION
Reverts alphagov/publishing-e2e-tests#260

The changes for this aren't in the deployed-to-production branch for router-api yet.