### PR TITLE
Reload whitehall publication finder once

### DIFF
--- a/spec/whitehall/publishing_document_spec.rb
+++ b/spec/whitehall/publishing_document_spec.rb
@@ -42,6 +42,10 @@ feature "Publishing a document with Whitehall", whitehall: true, government_fron
     publication_finder = find('a', text: "Publications", match: :first)[:href]
     reload_url_until_match(publication_finder, :has_text?, title)
     visit(publication_finder)
+
+    # This test is pretty flakey, with the 'page.find' below often
+    # failing.  I don't really understand why, but reloading the page
+    # makes it work much more reliably..
     visit(publication_finder)
 
     expect_rendering_application("whitehall")

--- a/spec/whitehall/publishing_document_spec.rb
+++ b/spec/whitehall/publishing_document_spec.rb
@@ -42,6 +42,7 @@ feature "Publishing a document with Whitehall", whitehall: true, government_fron
     publication_finder = find('a', text: "Publications", match: :first)[:href]
     reload_url_until_match(publication_finder, :has_text?, title)
     visit(publication_finder)
+    visit(publication_finder)
 
     expect_rendering_application("whitehall")
     # Session#find waits until an element is visible


### PR DESCRIPTION
This test seems quite unreliable, I ran it 30 times without success.
It fails because `Session#find` can't find an `<a>` with the right text,
which I find strange because I think the `reload_url_until_match`
should make that work.  Whatever the cause, adding in another page
load makes this test pass.

It's not a great solution, but this one test is making developing the
e2e tests really hard, so it'll do for now.