### PR TITLE
Add an elasticsearch5 container, which rummager depends on

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -42,7 +42,7 @@ build: kill
 	$(DOCKER_COMPOSE_CMD) build --pull diet-error-handler publishing-e2e-tests $(APPS_TO_BUILD)
 
 setup_dependencies:
-	$(DOCKER_COMPOSE_CMD) up -d elasticsearch mongo mysql postgres rabbitmq redis
+	$(DOCKER_COMPOSE_CMD) up -d elasticsearch elasticsearch5 mongo mysql postgres rabbitmq redis
 	bundle exec rake docker:wait_for_dbs
 	$(MAKE) setup_dbs
 	bundle exec rake docker:wait_for_rabbitmq

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -101,6 +101,7 @@ services:
     depends_on:
       - redis
       - elasticsearch
+      - elasticsearch5
       - publishing-api
       - rummager-worker
       - rummager-listener-publishing-queue

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -83,6 +83,18 @@ services:
     volumes:
       - ./docker/elasticsearch.yml:/usr/share/elasticsearch/config/elasticsearch.yml
 
+  elasticsearch5:
+    image: elasticsearch:5.6.14
+    environment:
+      - http.host=0.0.0.0
+      - transport.host=127.0.0.1
+      - xpack.security.enabled=false
+    healthcheck:
+      << : *default-healthcheck
+      test: "curl --silent --fail localhost:9200/_cluster/health || exit 1"
+    volumes:
+      - ./docker/elasticsearch5.yml:/usr/share/elasticsearch/config/elasticsearch.yml
+
   rummager: &rummager
     image: govuk/rummager:${RUMMAGER_COMMITISH:-deployed-to-production}
     build: apps/rummager

--- a/docker/elasticsearch5.yml
+++ b/docker/elasticsearch5.yml
@@ -1,0 +1,1 @@
+network.host: 0.0.0.0

--- a/lib/tasks/docker.rake
+++ b/lib/tasks/docker.rake
@@ -2,7 +2,7 @@ require_relative "../docker_service"
 
 namespace :docker do
   task :wait_for_dbs do
-    DockerService.wait_for_healthy_services(services: %w(elasticsearch mongo mysql postgres redis))
+    DockerService.wait_for_healthy_services(services: %w(elasticsearch elasticsearch5 mongo mysql postgres redis))
   end
 
   task :wait_for_rabbitmq do


### PR DESCRIPTION
This will be used by the search-api branch of rummager (https://github.com/alphagov/rummager/pull/1439), as a much easier alternative to duplicating all the tests which involve search and running them first against rummager and then against search-api.

---

[Trello card](https://trello.com/c/oqlNhmVt/72-ensure-end-to-end-tests-work-with-managed-elasticsearch)