### PR TITLE
Expose public bank holidays API to publisher

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -565,6 +565,7 @@ services:
       - calendars
       - redis
       - mongo
+      - router
     environment:
       << : *govuk-app
       DISABLE_SECURE_COOKIES: "true"
@@ -580,6 +581,7 @@ services:
       - nginx-proxy:publishing-api.dev.gov.uk
       - nginx-proxy:error-handler.dev.gov.uk
       - nginx-proxy:calendars.dev.gov.uk
+      - nginx-proxy:www.dev.gov.uk
     ports:
       - "3000"
     volumes:


### PR DESCRIPTION
It now uses the public bank holidays API instead of going directly though Calendars, so we need to make sure the publishing-e2e-tests allows access to this. This is similar to https://github.com/alphagov/publishing-e2e-tests/pull/259.

Required by https://github.com/alphagov/publisher/pull/1043.