### PR TITLE
Replace search in site search with all content finder

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -538,6 +538,7 @@ services:
       - static
       - rummager
       - diet-error-handler
+      - whitehall-admin
     environment:
       << : *govuk-app
       SENTRY_CURRENT_ENV: finder-frontend
@@ -549,6 +550,7 @@ services:
       - nginx-proxy:content-store.dev.gov.uk
       - nginx-proxy:static.dev.gov.uk
       - nginx-proxy:error-handler.dev.gov.uk
+      - nginx-proxy:whitehall-admin.dev.gov.uk
     ports:
       - "3062"
     volumes:

--- a/spec/publisher/publishing_content_to_government_frontend_spec.rb
+++ b/spec/publisher/publishing_content_to_government_frontend_spec.rb
@@ -38,8 +38,7 @@ private
   end
 
   def and_i_can_view_it_on_finder
-    fill_in "Search", with: title
-    click_button "Search"
+    visit "#{Plek.new.website_root}/search/all?keywords=#{CGI.escape(title)}"
 
     expect_rendering_application("finder-frontend")
     expect(page).to have_content(title)


### PR DESCRIPTION
This PR updates publishing end-to-end tests to use the all content finder instead of site search. As part of this, we need to add a dependency from `finder-frontend` to `whitehall-admin` inside of `docker-compose.yml`.