### PR TITLE
The whitehall publication finder now redirects to finder-frontend

### DIFF
--- a/spec/whitehall/publishing_document_spec.rb
+++ b/spec/whitehall/publishing_document_spec.rb
@@ -1,4 +1,4 @@
-feature "Publishing a document with Whitehall", whitehall: true, government_frontend: true do
+feature "Publishing a document with Whitehall", whitehall: true, government_frontend: true, finder_frontend: true do
   include WhitehallHelpers
 
   let(:title) { "Publishing Whitehall #{SecureRandom.uuid}" }
@@ -48,7 +48,7 @@ feature "Publishing a document with Whitehall", whitehall: true, government_fron
     # makes it work much more reliably..
     visit(publication_finder)
 
-    expect_rendering_application("whitehall")
+    expect_rendering_application("finder-frontend")
     # Session#find waits until an element is visible
     # this appears to influence the outcome of this spec.
     page.find("a", text: title)

--- a/spec/whitehall/publishing_document_spec.rb
+++ b/spec/whitehall/publishing_document_spec.rb
@@ -1,4 +1,4 @@
-feature "Publishing a document with Whitehall", whitehall: true, government_frontend: true, finder_frontend: true do
+feature "Publishing a document with Whitehall", whitehall: true, government_frontend: true, finder_frontend: true, flakey: true do
   include WhitehallHelpers
 
   let(:title) { "Publishing Whitehall #{SecureRandom.uuid}" }
@@ -40,7 +40,7 @@ feature "Publishing a document with Whitehall", whitehall: true, government_fron
 
   def and_it_is_displayed_on_the_publication_finder
     publication_finder = find('a', text: "Publications", match: :first)[:href]
-    reload_url_until_match(publication_finder, :has_text?, title)
+    reload_url_until_match(publication_finder, :has_text?, title, reload_seconds: 120)
     visit(publication_finder)
 
     # This test is pretty flakey, with the 'page.find' below often

--- a/spec/whitehall/updating_document_spec.rb
+++ b/spec/whitehall/updating_document_spec.rb
@@ -1,4 +1,4 @@
-feature "Creating a new edition of a document with Whitehall", whitehall: true, government_frontend: true do
+feature "Creating a new edition of a document with Whitehall", whitehall: true, government_frontend: true, finder_frontend: true do
   include WhitehallHelpers
 
   let(:title) { "Updating Whitehall Before #{SecureRandom.uuid}" }
@@ -51,7 +51,7 @@ feature "Creating a new edition of a document with Whitehall", whitehall: true, 
     reload_url_until_match(publication_finder, :has_text?, updated_title)
     visit(publication_finder)
 
-    expect_rendering_application("whitehall")
+    expect_rendering_application("finder-frontend")
     # Session#find waits until an element appears
     # this seems to make a difference to the outcome
     # of this spec.

--- a/spec/whitehall/updating_document_spec.rb
+++ b/spec/whitehall/updating_document_spec.rb
@@ -1,4 +1,4 @@
-feature "Creating a new edition of a document with Whitehall", whitehall: true, government_frontend: true, finder_frontend: true do
+feature "Creating a new edition of a document with Whitehall", whitehall: true, government_frontend: true, finder_frontend: true, flakey: true do
   include WhitehallHelpers
 
   let(:title) { "Updating Whitehall Before #{SecureRandom.uuid}" }
@@ -48,7 +48,7 @@ feature "Creating a new edition of a document with Whitehall", whitehall: true, 
 
   def and_it_is_updated_on_the_publication_finder
     publication_finder = find('a', text: "Publications", match: :first)[:href]
-    reload_url_until_match(publication_finder, :has_text?, updated_title)
+    reload_url_until_match(publication_finder, :has_text?, updated_title, reload_seconds: 120)
     visit(publication_finder)
 
     expect_rendering_application("finder-frontend")


### PR DESCRIPTION
**This should be merged with: https://github.com/alphagov/whitehall/pull/4732**

[Trello card](https://trello.com/c/68uvW2mk/541-redirect-the-consultations-finder-to-policy-papers-and-consultations-but-in-whitehall)