### PR TITLE
Improve documentation for testing against a branch of an application

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ If you need to run the tests against a branch of an application other than
 deployed-to-production you need to explicitly build it as below:
 
 ```bash
-$ make -j4 clone pull
+$ make -j4 clone pull PUBLISHER_COMMITISH=your_branch
 $ docker-compose build publisher
 $ make start test-publisher stop
 ```


### PR DESCRIPTION
Adds minor change to documentation for running the tests against a specific branch or commit for a repo.
Had I known this sooner it would have saved me at least an hour.
I'll never get that hour back.
This means other people might be more lucky.