### PR TITLE
Change rummager port to 3233, to match search-api

### DIFF
--- a/docker-compose.development.yml
+++ b/docker-compose.development.yml
@@ -12,7 +12,7 @@ services:
 
   rummager:
     ports:
-      - "33009:3009"
+      - "33233:3233"
 
   diet-error-handler:
     ports:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -117,7 +117,7 @@ services:
       - nginx-proxy:error-handler.dev.gov.uk
       - nginx-proxy:publishing-api.dev.gov.uk
     ports:
-      - "3009"
+      - "3233"
     volumes:
       - ./apps/rummager/log:/app/log
 


### PR DESCRIPTION
This should be merged together with https://github.com/alphagov/rummager/pull/1439

---

[Trello card](https://trello.com/c/nABGyw0B/73-%F0%9F%92%80-remove-rummager-%F0%9F%92%80)