### PR TITLE
Fix spelling of flaky

### DIFF
--- a/spec/whitehall/publishing_document_spec.rb
+++ b/spec/whitehall/publishing_document_spec.rb
@@ -1,4 +1,4 @@
-feature "Publishing a document with Whitehall", whitehall: true, government_frontend: true, finder_frontend: true, flakey: true do
+feature "Publishing a document with Whitehall", whitehall: true, government_frontend: true, finder_frontend: true, flaky: true do
   include WhitehallHelpers
 
   let(:title) { "Publishing Whitehall #{SecureRandom.uuid}" }
@@ -43,7 +43,7 @@ feature "Publishing a document with Whitehall", whitehall: true, government_fron
     reload_url_until_match(publication_finder, :has_text?, title, reload_seconds: 120)
     visit(publication_finder)
 
-    # This test is pretty flakey, with the 'page.find' below often
+    # This test is pretty flaky, with the 'page.find' below often
     # failing.  I don't really understand why, but reloading the page
     # makes it work much more reliably..
     visit(publication_finder)

--- a/spec/whitehall/updating_document_spec.rb
+++ b/spec/whitehall/updating_document_spec.rb
@@ -1,4 +1,4 @@
-feature "Creating a new edition of a document with Whitehall", whitehall: true, government_frontend: true, finder_frontend: true, flakey: true do
+feature "Creating a new edition of a document with Whitehall", whitehall: true, government_frontend: true, finder_frontend: true, flaky: true do
   include WhitehallHelpers
 
   let(:title) { "Updating Whitehall Before #{SecureRandom.uuid}" }


### PR DESCRIPTION
This means the tests are correctly ignored. This was the intention of https://github.com/alphagov/publishing-e2e-tests/commit/749aaf98a159be5922c2d2f1bd505733ce45c1b2.

[Trello Card](https://trello.com/c/UXAnPEP4/878-investigate-whether-flaky-means-that-it-wont-mark-a-build-as-red-if-it-fails)