### PR TITLE
Fix Whitehall flaky tests

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -230,9 +230,9 @@ def startDockerApps() {
 }
 
 def runFlakyNewTests(params, testStatus) {
-  echo "Running flaky/new tests that aren't in main build with `make test TEST_ARGS='--tag flaky --tag new'`"
+  echo "Running flaky/new tests that aren't in main build with `make test TEST_ARGS='--tag flaky --tag flakey --tag new'`"
   try {
-    sh("make test TEST_PROCESSES=${params.TEST_PROCESSES} TEST_ARGS=\"spec -o '--tag flaky --tag new'\"")
+    sh("make test TEST_PROCESSES=${params.TEST_PROCESSES} TEST_ARGS=\"spec -o '--tag flaky --tag flakey --tag new'\"")
   } catch(err) {
     testStatus.flakyNewFailed = true
   }

--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@ ifndef JENKINS_URL
 endif
 
 ifndef TEST_ARGS
-  TEST_ARGS = spec -o '--tag ~flaky --tag ~new'
+  TEST_ARGS = spec -o '--tag ~flaky --tag ~flakey --tag ~new'
 endif
 
 TEST_CMD = $(DOCKER_COMPOSE_CMD) run publishing-e2e-tests bundle exec parallel_rspec -n $(TEST_PROCESSES) $(TEST_ARGS)
@@ -175,40 +175,40 @@ test:
 	$(TEST_CMD)
 
 test-specialist-publisher:
-	$(TEST_CMD) -o '--tag specialist_publisher --tag ~flaky --tag ~new'
+	$(TEST_CMD) -o '--tag specialist_publisher --tag ~flaky --tag ~flakey --tag ~new'
 
 test-travel-advice-publisher:
-	$(TEST_CMD) -o '--tag travel_advice_publisher --tag ~flaky --tag ~new'
+	$(TEST_CMD) -o '--tag travel_advice_publisher --tag ~flaky --tag ~flakey --tag ~new'
 
 test-collections-publisher:
-	$(TEST_CMD) -o '--tag collections_publisher --tag ~flaky --tag ~new'
+	$(TEST_CMD) -o '--tag collections_publisher --tag ~flaky --tag ~flakey --tag ~new'
 
 test-publisher:
-	$(TEST_CMD) -o '--tag publisher --tag ~flaky --tag ~new'
+	$(TEST_CMD) -o '--tag publisher --tag ~flaky --tag ~flakey --tag ~new'
 
 test-manuals-publisher:
-	$(TEST_CMD) -o '--tag manuals_publisher --tag ~flaky --tag ~new'
+	$(TEST_CMD) -o '--tag manuals_publisher --tag ~flaky --tag ~flakey --tag ~new'
 
 test-collections:
-	$(TEST_CMD) -o '--tag collections --tag ~flaky --tag ~new'
+	$(TEST_CMD) -o '--tag collections --tag ~flaky --tag ~flakey --tag ~new'
 
 test-finder-frontend:
-	$(TEST_CMD) -o '--tag finder_frontend --tag ~flaky --tag ~new'
+	$(TEST_CMD) -o '--tag finder_frontend --tag ~flaky --tag ~flakey --tag ~new'
 
 test-frontend:
-	$(TEST_CMD) -o '--tag frontend --tag ~flaky --tag ~new'
+	$(TEST_CMD) -o '--tag frontend --tag ~flaky --tag ~flakey --tag ~new'
 
 test-government-frontend:
-	$(TEST_CMD) -o '--tag government_frontend --tag ~flaky --tag ~new'
+	$(TEST_CMD) -o '--tag government_frontend --tag ~flaky --tag ~flakey --tag ~new'
 
 test-content-tagger:
-	$(TEST_CMD) -o '--tag content_tagger --tag ~flaky --tag ~new'
+	$(TEST_CMD) -o '--tag content_tagger --tag ~flaky --tag ~flakey --tag ~new'
 
 test-contacts-admin:
-	$(TEST_CMD) -o '--tag contacts_admin --tag ~flaky --tag ~new'
+	$(TEST_CMD) -o '--tag contacts_admin --tag ~flaky --tag ~flakey --tag ~new'
 
 test-whitehall:
-	$(TEST_CMD) -o '--tag whitehall --tag ~flaky --tag ~new'
+	$(TEST_CMD) -o '--tag whitehall --tag ~flaky --tag ~flakey --tag ~new'
 
 stop: kill
 

--- a/spec/whitehall/publishing_document_spec.rb
+++ b/spec/whitehall/publishing_document_spec.rb
@@ -1,4 +1,4 @@
-feature "Publishing a document with Whitehall", whitehall: true, government_frontend: true, finder_frontend: true, flaky: true do
+feature "Publishing a document with Whitehall", whitehall: true, government_frontend: true, finder_frontend: true do
   include WhitehallHelpers
 
   let(:title) { "Publishing Whitehall #{SecureRandom.uuid}" }
@@ -7,7 +7,7 @@ feature "Publishing a document with Whitehall", whitehall: true, government_fron
     given_i_have_a_draft_document
     when_i_publish_it
     then_i_can_view_it_on_gov_uk
-    and_it_is_displayed_on_the_publication_finder
+    and_it_is_displayed_on_the_consultations_finder
   end
 
   def signin_to_signon
@@ -38,15 +38,15 @@ feature "Publishing a document with Whitehall", whitehall: true, government_fron
     expect(page).to have_content("Test taxon")
   end
 
-  def and_it_is_displayed_on_the_publication_finder
-    publication_finder = find('a', text: "Publications", match: :first)[:href]
-    reload_url_until_match(publication_finder, :has_text?, title, reload_seconds: 120)
-    visit(publication_finder)
+  def and_it_is_displayed_on_the_consultations_finder
+    consultations_finder = find('a', text: "Policy papers and consultations", match: :first)[:href]
+    reload_url_until_match(consultations_finder, :has_text?, title, reload_seconds: 120)
+    visit(consultations_finder)
 
     # This test is pretty flaky, with the 'page.find' below often
     # failing.  I don't really understand why, but reloading the page
     # makes it work much more reliably..
-    visit(publication_finder)
+    visit(consultations_finder)
 
     expect_rendering_application("finder-frontend")
     # Session#find waits until an element is visible

--- a/spec/whitehall/updating_document_spec.rb
+++ b/spec/whitehall/updating_document_spec.rb
@@ -1,4 +1,4 @@
-feature "Creating a new edition of a document with Whitehall", whitehall: true, government_frontend: true, finder_frontend: true, flaky: true do
+feature "Creating a new edition of a document with Whitehall", whitehall: true, government_frontend: true, finder_frontend: true do
   include WhitehallHelpers
 
   let(:title) { "Updating Whitehall Before #{SecureRandom.uuid}" }
@@ -9,7 +9,7 @@ feature "Creating a new edition of a document with Whitehall", whitehall: true, 
     given_i_have_a_published_document
     when_i_publish_a_new_edition_of_the_document
     then_i_can_view_the_updated_content_on_gov_uk
-    and_it_is_updated_on_the_publication_finder
+    and_it_is_updated_on_the_consultations_finder
   end
 
   def signin_to_signon
@@ -46,10 +46,10 @@ feature "Creating a new edition of a document with Whitehall", whitehall: true, 
     expect(page).to have_content(change_note)
   end
 
-  def and_it_is_updated_on_the_publication_finder
-    publication_finder = find('a', text: "Publications", match: :first)[:href]
-    reload_url_until_match(publication_finder, :has_text?, updated_title, reload_seconds: 120)
-    visit(publication_finder)
+  def and_it_is_updated_on_the_consultations_finder
+    consultations_finder = find('a', text: "Policy papers and consultations", match: :first)[:href]
+    reload_url_until_match(consultations_finder, :has_text?, updated_title, reload_seconds: 120)
+    visit(consultations_finder)
 
     expect_rendering_application("finder-frontend")
     # Session#find waits until an element appears


### PR DESCRIPTION
This reinstates the tests that were marked as flaky in https://github.com/alphagov/publishing-e2e-tests/pull/292.

My theory (based on the fact that I haven't seen the tests fail yet after this change) is that the tests were looking for the document in the new "publications finder". This finder is actually just a list of all documents known to search-api and there are enough of these in the e2e tests that it spans over multiple pages. Therefore there are no guarantees that the document would appear on the first page. I've changed it so that we look in the "policy papers and consulations" finder instead.

As part of this PR, I've also allowed `flaky` to be spelt as `flakey` to avoid situations like https://github.com/alphagov/publishing-e2e-tests/pull/302.

[Trello Card](https://trello.com/c/eFkWvJuQ/956-whitehall-publishing-updating-e2e-tests-are-flakey-after-redirecting-the-publications-finder-to-finder-frontend)