### PR TITLE
Reset databases rather than setup

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -74,16 +74,16 @@ asset_manager_setup:
 	$(DOCKER_COMPOSE_CMD) run --rm --no-deps asset-manager bundle exec rake db:purge
 
 publishing_api_setup:
-	$(DOCKER_COMPOSE_CMD) run --rm --no-deps publishing-api bundle exec rake db:setup
+	$(DOCKER_COMPOSE_CMD) run --rm --no-deps publishing-api bundle exec rake db:reset
 
 travel_advice_setup:
 	$(DOCKER_COMPOSE_CMD) run --rm --no-deps travel-advice-publisher bundle exec rake db:seed
 
 whitehall_setup:
-	$(DOCKER_COMPOSE_CMD) run --rm --no-deps whitehall-admin bundle exec rake db:create db:purge db:setup
+	$(DOCKER_COMPOSE_CMD) run --rm --no-deps whitehall-admin bundle exec rake db:reset
 
 content_tagger_setup:
-	$(DOCKER_COMPOSE_CMD) run --rm --no-deps content-tagger bundle exec rake db:setup
+	$(DOCKER_COMPOSE_CMD) run --rm --no-deps content-tagger bundle exec rake db:reset
 
 manuals_publisher_setup:
 	$(DOCKER_COMPOSE_CMD) run --rm --no-deps manuals-publisher bundle exec rake db:seed
@@ -92,16 +92,16 @@ specialist_publisher_setup:
 	$(DOCKER_COMPOSE_CMD) run --rm --no-deps specialist-publisher env RUN_SEEDS_IN_PRODUCTION=true bundle exec rake db:seed
 
 publisher_setup:
-	$(DOCKER_COMPOSE_CMD) run --rm --no-deps publisher bundle exec rake db:setup
+	$(DOCKER_COMPOSE_CMD) run --rm --no-deps publisher bundle exec rake db:reset
 
 collections_publisher_setup:
-	$(DOCKER_COMPOSE_CMD) run --rm --no-deps collections-publisher bundle exec rake db:setup
+	$(DOCKER_COMPOSE_CMD) run --rm --no-deps collections-publisher bundle exec rake db:reset
 
 rummager_setup:
 	$(DOCKER_COMPOSE_CMD) run --rm --no-deps rummager env SEARCH_INDEX=all bundle exec rake search:create_all_indices
 
 email_alert_api_setup:
-	$(DOCKER_COMPOSE_CMD) run --rm --no-deps email-alert-api bundle exec rake db:setup
+	$(DOCKER_COMPOSE_CMD) run --rm --no-deps email-alert-api bundle exec rake db:reset
 
 wait_for_whitehall_admin:
 	bundle exec rake docker:wait_for_whitehall_admin


### PR DESCRIPTION
Databases were being setup with rake db:setup, which
creates the database, loads the schema and seeds it.
Changing it to rake db:reset means that it drops
the database before creating it, loading the schema
and then seeds data.

The change is desirable because when developing tests
the setup occasionally exits when validations fail and
the lengthy docker startup procedure has to be restarted.
This is a source of pain and frustration and makes
developing tests take longer than necessary.

https://edgeguides.rubyonrails.org/active_record_migrations.html#setup-the-database