### PR TITLE
Pin chromedriver to version 73

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,8 @@ RUN wget -q -O - https://dl-ssl.google.com/linux/linux_signing_key.pub | apt-key
 RUN sh -c 'echo "deb [arch=amd64] http://dl.google.com/linux/chrome/deb/ stable main" >> /etc/apt/sources.list.d/google.list'
 RUN apt-get update && apt-get install -y google-chrome-stable
 
-RUN echo "73.0.3683.68" > /root/.chromedriver-version
+RUN mkdir /root/.chromedriver-helper
+RUN echo "73.0.3683.68" > /root/.chromedriver-helper/.chromedriver-version
 
 ENV APP_HOME /app
 RUN mkdir $APP_HOME


### PR DESCRIPTION
Version 74 of chromedriver was recently released as stable (2 days ago) and since then the tests have frequently been failing due to this change:

```
Fixed the type of error when click is intercepted by a different element
```

We should rollback to get the tests working again while figuring out what to do next.

This will work [while we continue to use chromedriver-helper in the e2e tests](https://github.com/flavorjones/chromedriver-helper/blob/5508af7ff3b955d4417baa2ebd882c510d190c1c/lib/chromedriver/helper.rb#L90-L96).