### PR TITLE
Add test for tagging content to Business Finder

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -53,6 +53,7 @@ setup_apps:
 	$(MAKE) contacts_admin_seed
 	$(MAKE) publish_routes
 	$(MAKE) populate_end_to_end_test_data_from_whitehall
+	$(MAKE) publish_facets
 	$(DOCKER_COMPOSE_CMD) run --rm publishing-e2e-tests bundle exec rake govuk:wait_for_router
 	bundle exec rake docker:wait_for_apps
 
@@ -147,6 +148,11 @@ publish_calendars:
 
 populate_end_to_end_test_data_from_whitehall:
 	$(DOCKER_COMPOSE_CMD) exec -T whitehall-admin bundle exec rake taxonomy:populate_end_to_end_test_data
+
+publish_facets:
+	$(DOCKER_COMPOSE_CMD) exec -T content-tagger bundle exec rake facets:import_facet_group[lib/data/find-eu-exit-guidance-business.yml]
+	$(DOCKER_COMPOSE_CMD) exec -T content-tagger bundle exec rake facets:publish_facet_group[lib/data/find-eu-exit-guidance-business.yml]
+	$(DOCKER_COMPOSE_CMD) exec -T rummager bundle exec rake publishing_api:publish_facet_group_eu_exit_business_finder
 
 clean_apps:
 	$(DOCKER_RUN) bash -c 'rm -rf /app/apps/*'

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -837,6 +837,8 @@ services:
       - publishing-api
       - postgres
       - redis
+      - rummager
+      - content-store
     environment:
       << : *govuk-app
       SENTRY_CURRENT_ENV: content-tagger

--- a/spec/content_tagger/tagging_to_business_finder_spec.rb
+++ b/spec/content_tagger/tagging_to_business_finder_spec.rb
@@ -1,0 +1,54 @@
+feature "Adding a facet tag to a finder content", search_api: true, finder_frontend: true, content_tagger: true, new: true do
+  include ContentTaggerHelpers
+  include PublisherHelpers
+
+  let(:guide_title) { "Rail transport if theres no Brexit deal" }
+  let(:guide_slug) { "rail-transport-if-theres-no-brexit-deal" }
+  let(:facet_tag) { "Rail (passengers and freight)" }
+
+  scenario "Adding a facet tag to a published document" do
+    given_there_is_a_published_document
+    when_i_tag_the_document_with_the_facet
+    then_the_business_finder_shows_the_document
+  end
+
+  def signin_to_signon
+    @user = signin_with_next_user(
+      "Publisher" => %w[skip_review],
+      "Content Tagger" => ["GDS Editor"],
+    )
+  end
+
+  def given_there_is_a_published_document
+    signin_to_signon if use_signon?
+    create_publisher_artefact(slug: guide_slug, title: guide_title, format: "Answer")
+    publish_artefact
+    wait_for_artefact_to_be_published
+  end
+
+  def when_i_tag_the_document_with_the_facet
+    visit(Plek.find("content-tagger"))
+    click_link "Facets"
+    click_link "Find EU Exit guidance business"
+    # '/' is required in the Content Tagger
+    fill_in "content_lookup_form_base_path", with: "/#{guide_slug}"
+    click_button "Edit page"
+    select2("Rail (passengers and freight)", css: "#s2id_facets_tagging_update_form_sector_business_area")
+    click_button "Update facet values"
+  end
+
+  def then_the_business_finder_shows_the_document
+    finder_url = "#{Plek.new.website_root}/find-eu-exit-guidance-business"
+    reload_url_until_match(finder_url, :has_text?, guide_title)
+    visit(finder_url)
+    expect_rendering_application("finder-frontend")
+    within('.filtered-results__group') do
+      expect(page).to have_content(guide_title)
+    end
+  end
+
+  def wait_for_artefact_to_be_published
+    @published_url = find_link("View this on the GOV.UK website")[:href]
+    wait_for_artefact_to_be_viewable(@published_url)
+  end
+end


### PR DESCRIPTION
Tests that someone can run a rake task to publish the
business finder and facet groups, create a new content item,
tag it to the facet group and that the new content item
is visible in the business finder

Trello: https://trello.com/c/svgckaS3/32-end-to-end-test-for-content-tagging