### PR TITLE
adds integration test for finder email frequency

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -14,6 +14,7 @@ def apps = [
   [constantPrefix: "CONTENT_STORE", app: "content-store", name: "Content Store"],
   [constantPrefix: "CONTENT_TAGGER", app: "content-tagger", name: "Content Tagger"],
   [constantPrefix: "EMAIL_ALERT_API", app: "email-alert-api", name: "Email Alert API"],
+  [constantPrefix: "EMAIL_ALERT_FRONTEND", app: "email-alert-frontend", name: "Email Alert Frontend"],
   [constantPrefix: "EMAIL_ALERT_SERVICE", app: "email-alert-service", name: "Email Alert Service"],
   [constantPrefix: "FINDER_FRONTEND", app: "finder-frontend", name: "Finder Frontend"],
   [constantPrefix: "FRONTEND", app: "frontend", name: "Frontend"],

--- a/Makefile
+++ b/Makefile
@@ -2,8 +2,8 @@ APPS = asset-manager content-store govuk-content-schemas government-frontend \
 	publishing-api router router-api rummager \
 	specialist-publisher static travel-advice-publisher collections-publisher \
 	collections frontend publisher calendars \
-	manuals-publisher manuals-frontend whitehall content-tagger \
-	contacts-admin finder-frontend email-alert-api email-alert-service
+	manuals-publisher manuals-frontend whitehall content-tagger contacts-admin \
+	finder-frontend email-alert-api email-alert-frontend email-alert-service
 
 RUBY_VERSION = `cat .ruby-version`
 DOCKER_RUN = docker run --rm -v `pwd`:/app ruby:$(RUBY_VERSION)

--- a/docker-compose.development.yml
+++ b/docker-compose.development.yml
@@ -128,6 +128,10 @@ services:
     ports:
       - "33088:3088"
 
+  email-alert-frontend:
+    ports:
+      - "33099:3099"
+
   static:
     ports:
       - "33013:3013"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -946,6 +946,57 @@ services:
       disable: true
     ports: []
 
+  finder-frontend:
+    image: govuk/finder-frontend:${FINDER_FRONTEND_COMMITISH:-deployed-to-production}
+    build:
+      context: apps/finder-frontend
+    depends_on:
+      - content-store
+      - static
+      - rummager
+      - diet-error-handler
+      - whitehall-admin
+    environment:
+      << : *govuk-app
+      SENTRY_CURRENT_ENV: finder-frontend
+      VIRTUAL_HOST: finder-frontend.dev.gov.uk
+    healthcheck:
+      << : *default-healthcheck
+    links:
+      - nginx-proxy:rummager.dev.gov.uk
+      - nginx-proxy:content-store.dev.gov.uk
+      - nginx-proxy:static.dev.gov.uk
+      - nginx-proxy:error-handler.dev.gov.uk
+      - nginx-proxy:whitehall-admin.dev.gov.uk
+    ports:
+      - "3062"
+    volumes:
+      - ./apps/finder-frontend/log:/app/log
+
+  email-alert-frontend:
+    image: govuk/email-alert-frontend:${EMAIL_ALERT_FRONTEND_COMMITISH:-deployed-to-production}
+    build:
+      context: apps/email-alert-frontend
+    depends_on:
+      - content-store
+      - email-alert-api
+      - static
+      - diet-error-handler
+    environment:
+      << : *govuk-app
+      SENTRY_CURRENT_ENV: email-alert-frontend
+      VIRTUAL_HOST: email-alert-frontend.dev.gov.uk
+    healthcheck:
+      << : *default-healthcheck
+    links:
+      - nginx-proxy:content-store.dev.gov.uk
+      - nginx-proxy:static.dev.gov.uk
+      - nginx-proxy:error-handler.dev.gov.uk
+    ports:
+      - "3099"
+    volumes:
+      - ./apps/email-alert-frontend/log:/app/log
+
   email-alert-service:
     image: govuk/email-alert-service:${EMAIL_ALERT_SERVICE_COMMITISH:-deployed-to-production}
     build: apps/email-alert-service

--- a/lib/docker_service.rb
+++ b/lib/docker_service.rb
@@ -66,6 +66,8 @@ class DockerService
   def self.container_is_healthy(container)
     container_state = Docker::Container.get(container.id).json["State"]
     health = container_state["Health"]
-    container_state["Status"] == "running" && (health.nil? || health["Status"] == "healthy")
+    healthy = container_state["Status"] == "running" && (health.nil? || health["Status"] == "healthy")
+    puts "healthy? #{healthy} (container_state: #{container_state['Status']} health_status: #{health.nil? ? 'nil' : health['Status']} container_id: #{container.id})"
+    healthy
   end
 end

--- a/spec/applications/business_finder_email_spec.rb
+++ b/spec/applications/business_finder_email_spec.rb
@@ -1,0 +1,42 @@
+feature "Default email frequency", search_api: true, finder_frontend: true do
+  context "within the Business Finder" do
+    let(:signup_url) { "/find-eu-exit-guidance-business/email-signup" }
+    let(:expected_option) { "daily" }
+
+    scenario "email frequency should be daily" do
+      when_i_visit signup_url
+      and_i_click_create_subscription
+      then_this_option_should_be_selected expected_option
+    end
+  end
+
+  context "within other Finders" do
+    let(:signup_url) { "/drug-device-alerts/email-signup" }
+    let(:expected_option) { "immediately" }
+
+    scenario "email frequency should be immediately" do
+      when_i_visit signup_url
+      and_i_click_create_subscription
+      then_this_option_should_be_selected expected_option
+    end
+  end
+
+private
+
+  def when_i_visit(signup_url)
+    visit "#{Plek.new.website_root}#{signup_url}"
+    puts "FINDER CURRENT URL #{current_url}"
+    # puts "FINDER PAGE CONTENT #{page.text}"
+  end
+
+  def and_i_click_create_subscription
+    click_button "Create subscription"
+    sleep 5 # allow time for page to be redirected
+  end
+
+  def then_this_option_should_be_selected(option_text)
+    puts "SIGNUP CURRENT URL #{current_url}"
+    # puts "SIGNUP PAGE CONTENT #{page.text}"
+    expect(page.find("input[name='frequency'][value='#{option_text}']")).to be_checked
+  end
+end


### PR DESCRIPTION
This test brings together these two pieces of work:

- https://github.com/alphagov/finder-frontend/pull/1104
- https://github.com/alphagov/email-alert-frontend/pull/461

...in order to test https://trello.com/c/f7DWeg4q/.

All finders -> subscription journeys should have 'As soon as possible' selected by default, unless they've explicitly opted in to pre-selecting a different option (as in the Business Finder case, where we want 'No more than once a day' preselected).

NB: this is rebased onto https://github.com/alphagov/publishing-e2e-tests/pull/315 as it makes the business finder available to the test suite.