### PR TITLE
Remove old elasticsearch

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -42,7 +42,7 @@ build: kill
 	$(DOCKER_COMPOSE_CMD) build --pull diet-error-handler publishing-e2e-tests $(APPS_TO_BUILD)
 
 setup_dependencies:
-	$(DOCKER_COMPOSE_CMD) up -d elasticsearch elasticsearch5 mongo mysql postgres rabbitmq redis
+	$(DOCKER_COMPOSE_CMD) up -d elasticsearch5 mongo mysql postgres rabbitmq redis
 	bundle exec rake docker:wait_for_dbs
 	$(MAKE) setup_dbs
 	bundle exec rake docker:wait_for_rabbitmq

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -71,18 +71,6 @@ services:
       << : *default-healthcheck
       test: "rabbitmqctl node_health_check"
 
-  elasticsearch:
-    image: elasticsearch:2.4.6
-    environment:
-      - http.host=0.0.0.0
-      - transport.host=127.0.0.1
-      - xpack.security.enabled=false
-    healthcheck:
-      << : *default-healthcheck
-      test: "curl --silent --fail localhost:9200/_cluster/health || exit 1"
-    volumes:
-      - ./docker/elasticsearch.yml:/usr/share/elasticsearch/config/elasticsearch.yml
-
   elasticsearch5:
     image: elasticsearch:5.6.14
     environment:
@@ -100,7 +88,6 @@ services:
     build: apps/rummager
     depends_on:
       - redis
-      - elasticsearch
       - elasticsearch5
       - publishing-api
       - rummager-worker
@@ -124,7 +111,7 @@ services:
   rummager-worker:
     << : *rummager
     depends_on:
-      - elasticsearch
+      - elasticsearch5
       - rabbitmq
       - publishing-api
       - diet-error-handler

--- a/docker/elasticsearch.yml
+++ b/docker/elasticsearch.yml
@@ -1,3 +1,0 @@
-network.host: 0.0.0.0
-script.indexed: on
-script.inline: on

--- a/lib/tasks/docker.rake
+++ b/lib/tasks/docker.rake
@@ -2,7 +2,7 @@ require_relative "../docker_service"
 
 namespace :docker do
   task :wait_for_dbs do
-    DockerService.wait_for_healthy_services(services: %w(elasticsearch elasticsearch5 mongo mysql postgres redis))
+    DockerService.wait_for_healthy_services(services: %w(elasticsearch5 mongo mysql postgres redis))
   end
 
   task :wait_for_rabbitmq do


### PR DESCRIPTION
We're now using Elasticsearch 5 everywhere so we don't need the old container. This will also save a few seconds downloading and running the container.