### PR TITLE
Reference correct elasticsearch5.yml

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -81,7 +81,7 @@ services:
       << : *default-healthcheck
       test: "curl --silent --fail localhost:9200/_cluster/health || exit 1"
     volumes:
-      - ./docker/elasticsearch5.yml:/usr/share/elasticsearch/config/elasticsearch.yml
+      - ./docker/elasticsearch5.yml:/usr/share/elasticsearch/config/elasticsearch5.yml
 
   rummager: &rummager
     image: govuk/search-api:${RUMMAGER_COMMITISH:-deployed-to-production}


### PR DESCRIPTION
When we emoved elasticsearch we also removed `docker/elasticsearch.yml`.
We should point the old reference to `elasticsearch.yml` to the new `elasticsearch5.yml` in our
docker-compose.