### PR TITLE
Seed asset-manager database

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -72,7 +72,7 @@ content_store_setup:
 	$(DOCKER_COMPOSE_CMD) run --rm --no-deps draft-content-store bundle exec rake db:reset
 
 asset_manager_setup:
-	$(DOCKER_COMPOSE_CMD) run --rm --no-deps asset-manager bundle exec rake db:purge
+	$(DOCKER_COMPOSE_CMD) run --rm --no-deps asset-manager bundle exec rake db:reset
 
 publishing_api_setup:
 	$(DOCKER_COMPOSE_CMD) run --rm --no-deps publishing-api bundle exec rake db:reset


### PR DESCRIPTION
This means we will get a test user available in asset-manager from https://github.com/alphagov/asset-manager/pull/653.

Once this is merged, it should enable https://github.com/alphagov/travel-advice-publisher/pull/602 to pass correctly.