### PR TITLE
Update manuals publisher test

### DIFF
--- a/spec/manuals_publisher/update_published_content_spec.rb
+++ b/spec/manuals_publisher/update_published_content_spec.rb
@@ -49,7 +49,7 @@ feature "Updating content on Manuals Publisher", manuals_publisher: true do
 
   def and_the_update_log_has_the_change_note
     click_link "see all updates"
-    first(".section-content a", text: "Open all").click
+    first(".section-content button", text: "Open all").click
 
     expect(page).to have_content(change_note)
   end


### PR DESCRIPTION
Updates the test to accommodate for the markup change being introduced
with https://github.com/alphagov/manuals-frontend/pull/650

Do not merge until app feature is deployed to production as per https://github.com/alphagov/publishing-e2e-tests/blob/master/docs/breaking-app-change.md