### PR TITLE
Add missing 'redis' dependencies to workers

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -115,6 +115,7 @@ services:
       - rabbitmq
       - publishing-api
       - diet-error-handler
+      - redis
     command: foreman run worker
     environment:
       << : *govuk-app
@@ -437,6 +438,7 @@ services:
     depends_on:
       - publishing-api
       - diet-error-handler
+      - redis
     environment:
       << : *govuk-app
       SENTRY_CURRENT_ENV: collections-publisher-worker
@@ -806,6 +808,7 @@ services:
     command: foreman run worker
     depends_on:
       - diet-error-handler
+      - redis
     environment:
       << : *govuk-app
       REDIS_URL: redis://redis/1
@@ -885,6 +888,7 @@ services:
     command: foreman run worker
     depends_on:
       - diet-error-handler
+      - redis
     environment:
       << : *govuk-app
       ASSET_MANAGER_CLAMSCAN_PATH: /bin/true
@@ -924,6 +928,7 @@ services:
     command: foreman run worker
     depends_on:
       - diet-error-handler
+      - redis
     environment:
       << : *govuk-app
       EMAIL_ALERT_AUTH_TOKEN: 9d3e07ca727cd08cc503191f233919877160bfc57eaaa33541761c2d1ffd951ae205263be5832f26ba2670b142d7c593ec0f6bdd11a84cf325a32dbdd889ff44


### PR DESCRIPTION
Fixes errors like this:

```
12:25:15 :timestamp: 2019-06-11 11:21:05.491303686 +00:00
12:25:15 :errors:
12:25:15 - :type: SocketError
12:25:15   :message: 'getaddrinfo: Temporary failure in name resolution'
12:25:15 - :type: Redis::CannotConnectError
12:25:15   :message: Error connecting to Redis on redis:6379 (SocketError)
12:25:15 :context:
12:25:15   :environment: rummager-worker
12:25:15   :hostname:
12:25:15   :url:
```

A number of workers neglected to explicitly list redis as a dependency.

(PS: doesn't fix the current issue with publishing-e2e-tests - but does make the tests that little bit healthier and reduces a fair bit of the verbose output).