### PR TITLE
Fix with Guix

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,8 @@
-FROM ruby:2.6.3
+FROM cbaines/ruby-with-guix:2.6.3
+
+RUN guix-daemon --disable-chroot --build-users-group=guixbuilder & \
+  guix install ungoogled-chromium fontconfig font-dejavu
+
 RUN apt-get update -qq && apt-get upgrade -y
 
 RUN curl -sL https://deb.nodesource.com/setup_9.x | bash -
@@ -6,15 +10,11 @@ RUN apt-get install -y build-essential libpq-dev libxml2-dev libxslt1-dev \
     libfontconfig1 libfontconfig1-dev nodejs unzip xvfb && \
   apt-get clean
 
-# Install Google Chrome
-RUN wget -q -O - https://dl-ssl.google.com/linux/linux_signing_key.pub | apt-key add -
-RUN sh -c 'echo "deb [arch=amd64] http://dl.google.com/linux/chrome/deb/ stable main" >> /etc/apt/sources.list.d/google.list'
-RUN apt-get update && apt-get install -y google-chrome-stable
-
-RUN echo "73.0.3683.68" > /root/.chromedriver-version
-
 ENV APP_HOME /app
 RUN mkdir $APP_HOME
+
+RUN echo "source /root/.guix-profile/etc/profile" > /etc/profile.d/guix.sh
+RUN chmod a+x /etc/profile.d/guix.sh
 
 WORKDIR $APP_HOME
 ADD Gemfile* $APP_HOME/

--- a/ruby-with-guix/Dockerfile
+++ b/ruby-with-guix/Dockerfile
@@ -1,0 +1,51 @@
+FROM ruby:2.6.1
+
+ARG GUIX_VER=1.0.1
+ARG GPG_KEYS=3CE464558A84FDC69DB40CFB090B11993D9AEBB5
+ARG REPOBASE=https://ftp.gnu.org/gnu/guix
+ARG TARFILE=guix-binary-$GUIX_VER.x86_64-linux.tar.xz
+ARG NUM_BUILDERS=10
+
+ENV BUILDDIR=/tmp/guix
+ENV BUILDERS_GROUP=guixbuilder
+ENV BUILDERS_USERS=guixbuilder
+ENV PATH="/root/.guix-profile/bin:/root/.config/guix/current/bin:$PATH"
+
+# Add build group
+RUN groupadd --system $BUILDERS_GROUP && \
+    for i in $(seq -w 1 $NUM_BUILDERS); do \
+        useradd -g $BUILDERS_GROUP -G $BUILDERS_GROUP           \
+            -d /var/empty -s "$(command -v nologin)"    \
+            -c "Guix build user $i" --system    \
+            "$BUILDERS_USERS$i"; \
+    done
+
+RUN mkdir ~/.gnupg
+RUN echo "disable-ipv6" >> ~/.gnupg/dirmngr.conf
+
+# Ensure GPG keys and deps are present
+RUN gpg --keyserver pool.sks-keyservers.net \
+        --recv-keys $GPG_KEYS
+
+# Ensure build directory is present
+WORKDIR $BUILDDIR
+
+# Download the distribution, verify it, and extract it
+RUN wget $REPOBASE/$TARFILE && \
+    wget $REPOBASE/$TARFILE.sig && \
+    gpg --verify $TARFILE.sig && \
+    tar -xf $TARFILE && \
+    rm -f $TARFILE $TARFILE.sig
+
+# Install the files
+RUN mv $BUILDDIR/var/guix /var/ && \
+    mv $BUILDDIR/gnu / && \
+    rm -rf $BUILDDIR
+
+RUN ln -s /var/guix/profiles/per-user/root/current-guix/bin/guix /usr/local/bin && \
+    ln -s /var/guix/profiles/per-user/root/current-guix/bin/guix-daemon /usr/local/bin && \
+    mkdir -p ~root/.config/guix && \
+    ln -sf /var/guix/profiles/per-user/root/current-guix ~root/.config/guix/current
+
+# Authorize substitutes
+RUN guix archive --authorize < ~root/.config/guix/current/share/guix/ci.guix.gnu.org.pub


### PR DESCRIPTION
Just a draft Pull Request, as I was interested if using chromium/chromedriver from Guix could make the tests pass within the docker-compose environment.

Back in 2016, the govuk-guix project started as a environment within which to run the Publishing E2E tests: https://github.com/alphagov/govuk-guix/pull/1

A lot has changed since then, but the rigour that Guix brings can help, even to sure up the Dockerfile approach that has been recently contributing to problems with running the Publishing E2E tests.