### PR TITLE
Use chromium instead of google-chrome

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ RUN apt-get update -qq && apt-get upgrade -y
 
 RUN curl -sL https://deb.nodesource.com/setup_9.x | bash -
 RUN apt-get install -y build-essential libpq-dev libxml2-dev libxslt1-dev \
-    libfontconfig1 libfontconfig1-dev nodejs unzip xvfb && \
+    libfontconfig1 libfontconfig1-dev nodejs unzip xvfb chromium chromium-driver fonts-dejavu && \
   apt-get clean
 
 # Install Google Chrome

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,14 +4,7 @@ RUN apt-get update -qq && apt-get upgrade -y
 RUN curl -sL https://deb.nodesource.com/setup_9.x | bash -
 RUN apt-get install -y build-essential libpq-dev libxml2-dev libxslt1-dev \
     libfontconfig1 libfontconfig1-dev nodejs unzip xvfb chromium chromium-driver fonts-dejavu && \
-  apt-get clean
-
-# Install Google Chrome
-RUN wget -q -O - https://dl-ssl.google.com/linux/linux_signing_key.pub | apt-key add -
-RUN sh -c 'echo "deb [arch=amd64] http://dl.google.com/linux/chrome/deb/ stable main" >> /etc/apt/sources.list.d/google.list'
-RUN apt-get update && apt-get install -y google-chrome-stable
-
-RUN echo "73.0.3683.68" > /root/.chromedriver-version
+    apt-get clean
 
 ENV APP_HOME /app
 RUN mkdir $APP_HOME


### PR DESCRIPTION
Swap out google chrome for chromium.
This seems to solve our current crashes that we are experiencing.

We've had publishing e2e test failures since the evening of Friday 7th.
Our tests seemed to be failing with 

```
Selenium::WebDriver::Error::UnknownError:
             unknown error: Chrome failed to start: exited abnormally
             (unknown error: DevToolsActivePort file doesn't exist)
             (The process started from chrome location /usr/bin/google-chrome is no longer running, so ChromeDriver is assuming that Chrome has crashed.)
```

We don't have a good explanation for why this happened, but we have been bitten by chrome and chromedriver being out of sync in the past. At any rate, replacing chrome with chromium seems to solve the issue for now.

[Trello](https://trello.com/c/SRSXn9RY/1068-fix-e2e-tests)