### PR TITLE
Use Google Chrome as the test runner

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,8 +3,14 @@ RUN apt-get update -qq && apt-get upgrade -y
 
 RUN curl -sL https://deb.nodesource.com/setup_9.x | bash -
 RUN apt-get install -y build-essential libpq-dev libxml2-dev libxslt1-dev \
-    libfontconfig1 libfontconfig1-dev nodejs unzip xvfb chromium chromium-driver fonts-dejavu && \
-    apt-get clean
+    libfontconfig1 libfontconfig1-dev nodejs unzip xvfb
+
+# Install Google Chrome
+RUN wget -q -O - https://dl-ssl.google.com/linux/linux_signing_key.pub | apt-key add -
+RUN sh -c 'echo "deb [arch=amd64] http://dl.google.com/linux/chrome/deb/ stable main" >> /etc/apt/sources.list.d/google.list'
+RUN apt-get update && apt-get install -y google-chrome-stable
+
+RUN apt-get clean
 
 ENV APP_HOME /app
 RUN mkdir $APP_HOME

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -117,29 +117,19 @@ RSpec.configure do |config|
 end
 
 Capybara.register_driver :headless_chrome do |app|
-  capabilities = Selenium::WebDriver::Remote::Capabilities.chrome(
-    acceptInsecureCerts: true,
-    chromeOptions: {
-      args: %w(
-        --disable-gpu
-        --disable-web-security
-        --disable-infobars
-        --disable-notifications
-        --headless
-        --no-sandbox
-        --window-size=1400,1400
-      )
-    }
-  )
+  chrome_options = Selenium::WebDriver::Chrome::Options.new
+  chrome_options.headless!
+  chrome_options.add_argument("--disable-web-security")
+  chrome_options.add_argument("--no-sandbox")
+  chrome_options.add_argument("--window-size=1400,1400")
 
   Capybara::Selenium::Driver.new(
     app,
     browser: :chrome,
-    desired_capabilities: capabilities
+    desired_capabilities: { acceptInsecureCerts: true },
+    options: chrome_options
   )
 end
-
-Capybara.javascript_driver = :headless_chrome
 
 # Add support for Headless Chrome screenshots.
 Capybara::Screenshot.register_driver(:headless_chrome) do |driver, path|


### PR DESCRIPTION
This allows these tests to run with Google Chrome again, which broke from Chrome version 75.0.3770.90.

The problems we had running the tests were caused by a change in the means to communicate with Google Chrome via the Chromedriver, that is described here: https://github.com/alphagov/govuk_test/pull/24

As part of this I've removed govuk_test, since it wasn't being used except for dependencies and I have installed selenium-webdriver and webdrivers dependencies directly.

I've tried to reduce the config around setting up chrome too as I don't think it's all needed. The bits around security that remain I'm not too sure if they work as they seem to only be added for Chris Baines' local environment. 

If we were to run the docker file as a user we could likely kill off the `--no-sandbox` argument too, however [my experiment](https://github.com/alphagov/publishing-e2e-tests/commit/09e6022a9baec7c730f9703a83008f30104e84ef) with that failed.

@bevanloon / @thomasleese As fixing this project is frequently a platform health concern I thought I'd defer to you as to if returning to Chrome like this is a good idea or not. I know you're considering other options for the tests. What I'm not sure on is if the chromium tests will begin failing or not in due course.
