### PR TITLE
Configure Chrome using Selenium Options object

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -117,29 +117,19 @@ RSpec.configure do |config|
 end
 
 Capybara.register_driver :headless_chrome do |app|
-  capabilities = Selenium::WebDriver::Remote::Capabilities.chrome(
-    acceptInsecureCerts: true,
-    chromeOptions: {
-      args: %w(
-        --disable-gpu
-        --disable-web-security
-        --disable-infobars
-        --disable-notifications
-        --headless
-        --no-sandbox
-        --window-size=1400,1400
-      )
-    }
-  )
+  chrome_options = Selenium::WebDriver::Chrome::Options.new
+  chrome_options.headless!
+  chrome_options.add_argument("--disable-web-security")
+  chrome_options.add_argument("--no-sandbox")
+  chrome_options.add_argument("--window-size=1400,1400")
 
   Capybara::Selenium::Driver.new(
     app,
     browser: :chrome,
-    desired_capabilities: capabilities
+    desired_capabilities: { acceptInsecureCerts: true },
+    options: chrome_options
   )
 end
-
-Capybara.javascript_driver = :headless_chrome
 
 # Add support for Headless Chrome screenshots.
 Capybara::Screenshot.register_driver(:headless_chrome) do |driver, path|


### PR DESCRIPTION
This resolves a problem that the key to provide options to Chrome has
changed from "chromeOptions" to "goog:chromeOptions". To try reduce our
chances of hitting a similar problem again I've switched to using the
Selenium object to manage chrome options.

I'm not too sure if this will introduce any problems with the
allowInsecureCerts as that isn't a config that is used as part of the
e2e tests.

I've removed a number of options that I couldn't find a reason they were
added. I figure if they're needed we can re-add them and explain why
they are needed in the commit message so that is documented.