### PR TITLE
Update Publisher's test

### DIFF
--- a/spec/publisher/updating_published_content_spec.rb
+++ b/spec/publisher/updating_published_content_spec.rb
@@ -39,7 +39,7 @@ private
 
     click_button "Schedule downtime message"
 
-    expect(page).to have_text(title + " downtime message scheduled")
+    expect(page).to have_text("downtime message scheduled")
   end
 
   def and_i_visit_the_transaction_on_gov_uk


### PR DESCRIPTION
The test is failing after cookie_serializer was changed to hybrid and the
errors ignored by brakeman https://github.com/alphagov/publisher/pull/1114