### PR TITLE
Remove search-api as dependency of some frontends

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -612,7 +612,6 @@ services:
     depends_on:
       - content-store
       - static
-      - rummager
       - diet-error-handler
       - publishing-api
     environment:
@@ -622,7 +621,6 @@ services:
     healthcheck:
       << : *default-healthcheck
     links:
-      - nginx-proxy:rummager.dev.gov.uk
       - nginx-proxy:content-store.dev.gov.uk
       - nginx-proxy:static.dev.gov.uk
       - nginx-proxy:error-handler.dev.gov.uk
@@ -637,7 +635,6 @@ services:
     depends_on:
       - draft-content-store
       - draft-static
-      - rummager
       - diet-error-handler
     environment:
       << : *draft-govuk-app
@@ -645,7 +642,6 @@ services:
       SENTRY_CURRENT_ENV: draft-frontend
       VIRTUAL_HOST: draft-frontend.dev.gov.uk
     links:
-      - nginx-proxy:rummager.dev.gov.uk
       - nginx-proxy:draft-content-store.dev.gov.uk
       - nginx-proxy:draft-static.dev.gov.uk
       - nginx-proxy:error-handler.dev.gov.uk
@@ -739,7 +735,6 @@ services:
     build:
       context: apps/calendars
     depends_on:
-      - rummager
       - content-store
       - static
       - publishing-api
@@ -751,7 +746,6 @@ services:
     links:
       - nginx-proxy:static.dev.gov.uk
       - nginx-proxy:content-store.dev.gov.uk
-      - nginx-proxy:rummager.dev.gov.uk
       - nginx-proxy:publishing-api.dev.gov.uk
       - nginx-proxy:error-handler.dev.gov.uk
     ports:
@@ -1006,7 +1000,6 @@ services:
       - static
       - diet-error-handler
       - memcached
-      - rummager
     environment:
       << : *govuk-app
       MEMCACHE_SERVERS: memcached
@@ -1019,7 +1012,6 @@ services:
       - nginx-proxy:content-store.dev.gov.uk
       - nginx-proxy:static.dev.gov.uk
       - nginx-proxy:error-handler.dev.gov.uk
-      - nginx-proxy:rummager.dev.gov.uk
     ports:
       - "3090"
     volumes:
@@ -1032,7 +1024,6 @@ services:
       - draft-static
       - diet-error-handler
       - memcached
-      - rummager
     environment:
       << : *draft-govuk-app
       MEMCACHE_SERVERS: memcached
@@ -1044,7 +1035,6 @@ services:
       - nginx-proxy:draft-content-store.dev.gov.uk
       - nginx-proxy:draft-static.dev.gov.uk
       - nginx-proxy:error-handler.dev.gov.uk
-      - nginx-proxy:rummager.dev.gov.uk
     ports:
       - "3190"
 


### PR DESCRIPTION
We used to use search to power some in page navigation, but I'm pretty sure that government-frontend, frontend and calendars don't do anything with search anymore.

Related: https://github.com/alphagov/government-frontend/pull/1468

