### PR TITLE
Ensure gov.uk/api/organisations exists when seeding contacts-admin

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -123,6 +123,12 @@ contacts_admin_setup:
 	$(DOCKER_COMPOSE_CMD) run --rm --no-deps contacts-admin bundle exec rake db:drop db:schema:load_if_ruby db:structure:load_if_sql
 
 contacts_admin_seed: wait_for_whitehall_admin
+	# Contacts Admin seeds from the organisations API, which is rendered by
+	# Collections, which gets its data from Search API, which gets indexed by
+	# Whitehall.
+	$(DOCKER_COMPOSE_CMD) exec -T whitehall-admin bundle exec rake search:index:organisations
+	$(DOCKER_COMPOSE_CMD) exec -T collections-publisher bundle exec rake publishing_api:publish_organisations_api_route
+
 	$(DOCKER_COMPOSE_CMD) exec -T contacts-admin bundle exec rake db:seed
 
 setup_queues:


### PR DESCRIPTION
This is to support https://github.com/alphagov/contacts-admin/pull/509 which means that contacts-admin is now using the public organisations API rather than talking directly to Whitehall.

The root problem is that contacts-admin depends on external services to seed its own database. Ideally, this wouldn't be the case.

The ordering here is particular. We can't just publish all the routes before seeding contacts-admin, because contacts-admin itself has some routes to publish. Instead, we have to publish just the /api/organisations route, which is rendered by collections, from data in search-api.

[Trello Card](https://trello.com/c/bKqmj0sG/1274-8-merge-gds-api-adapter-bump-in-contacts-admin)