### PR TITLE
Update rubyLinter call

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -55,7 +55,7 @@ timestamps {
         }
 
         stage("Ruby Lint") {
-          govuk.rubyLinter("spec lib Gemfile", false)
+          govuk.rubyLinter("spec lib Gemfile")
         }
 
       } catch(e) {


### PR DESCRIPTION
[rubyLinter no longer has a parameter for running lint on diffs](https://github.com/alphagov/govuk-jenkinslib/pull/57/files). e2e tests are broken at the linting stage currently because of this.

I'm not sure whether this might cause further problems, but if so, we could always remove the linting section from here altogether (or do something else).