### PR TITLE
Remove Elasticsearch 5 from e2e tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -52,7 +52,7 @@ build: kill
 	$(DOCKER_COMPOSE_CMD) build --pull diet-error-handler publishing-e2e-tests $(APPS_TO_BUILD)
 
 setup_dependencies:
-	$(DOCKER_COMPOSE_CMD) up -d elasticsearch5 elasticsearch6 mongo mysql postgres rabbitmq redis
+	$(DOCKER_COMPOSE_CMD) up -d elasticsearch6 mongo mysql postgres rabbitmq redis
 	bundle exec rake docker:wait_for_dbs
 	$(MAKE) setup_dbs
 	bundle exec rake docker:wait_for_rabbitmq

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -71,18 +71,6 @@ services:
       << : *default-healthcheck
       test: "rabbitmqctl node_health_check"
 
-  elasticsearch5:
-    image: elasticsearch:5.6.14
-    environment:
-      - http.host=0.0.0.0
-      - transport.host=127.0.0.1
-      - xpack.security.enabled=false
-    healthcheck:
-      << : *default-healthcheck
-      test: "curl --silent --fail localhost:9200/_cluster/health || exit 1"
-    volumes:
-      - ./docker/elasticsearch5.yml:/usr/share/elasticsearch/config/elasticsearch.yml
-
   elasticsearch6:
     image: elasticsearch:6.7.0
     environment:
@@ -100,7 +88,6 @@ services:
     build: apps/rummager
     depends_on:
       - redis
-      - elasticsearch5
       - elasticsearch6
       - publishing-api
       - rummager-worker
@@ -124,7 +111,6 @@ services:
   rummager-worker:
     << : *rummager
     depends_on:
-      - elasticsearch5
       - elasticsearch6
       - rabbitmq
       - publishing-api

--- a/docker/elasticsearch5.yml
+++ b/docker/elasticsearch5.yml
@@ -1,1 +1,0 @@
-network.host: 0.0.0.0

--- a/lib/tasks/docker.rake
+++ b/lib/tasks/docker.rake
@@ -2,7 +2,7 @@ require_relative "../docker_service"
 
 namespace :docker do
   task :wait_for_dbs do
-    DockerService.wait_for_healthy_services(services: %w(elasticsearch5 elasticsearch6 mongo mysql postgres redis))
+    DockerService.wait_for_healthy_services(services: %w(elasticsearch6 mongo mysql postgres redis))
   end
 
   task :wait_for_rabbitmq do


### PR DESCRIPTION
Removed as part of the migration to full usage of ES6. We are no
longer using ES5 in our backend and thus the removed called are obsolete.