### PR TITLE
Update mongodb to version 3.4

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -56,7 +56,7 @@ services:
       test: "mysql --user=root --password=root -e 'SELECT 1'"
 
   mongo:
-    image: mongo:2.4
+    image: mongo:3.4
     healthcheck:
       << : *default-healthcheck
       test: "echo 'db.stats().ok' | mongo localhost:27017/test --quiet"


### PR DESCRIPTION
We are seeing errors when pulling version 2.4 from Docker hub - 2.4 is now a few years out of support.