### PR TITLE
Make finder-frontend depend on whitehall-frontend

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -527,7 +527,7 @@ services:
       - static
       - rummager
       - diet-error-handler
-      - whitehall-admin
+      - whitehall-frontend
     environment:
       << : *govuk-app
       SENTRY_CURRENT_ENV: finder-frontend
@@ -539,7 +539,7 @@ services:
       - nginx-proxy:content-store.dev.gov.uk
       - nginx-proxy:static.dev.gov.uk
       - nginx-proxy:error-handler.dev.gov.uk
-      - nginx-proxy:whitehall-admin.dev.gov.uk
+      - nginx-proxy:whitehall-frontend.dev.gov.uk
     ports:
       - "3062"
     volumes:


### PR DESCRIPTION
In https://github.com/alphagov/finder-frontend/commit/bb43ad7818245c041dd2ef1546c8ed746ab3159b, finder-frontend was changed to talk to whitehall-frontend.  So finder-frontend should depend on that in the e2e tests.