### PR TITLE
Move GitHub 'pending' status update before the lock

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -35,11 +35,11 @@ def apps = [
 timestamps {
   node("publishing-e2e-tests") {
     initializeParameters(govuk, apps)
+    
+    originBuildStatus("Running publishing end-to-end tests on Jenkins", "PENDING", params)
 
     lock("publishing-e2e-tests-$NODE_NAME") {
       try {
-        originBuildStatus("Running publishing end-to-end tests on Jenkins", "PENDING", params)
-
         stage("Clean workspace") {
           checkout(scm)
           sh("make -j clean_tmp clean_apps")


### PR DESCRIPTION
Update the GitHub status of a publishing-e2e-tests check _before_ then waiting for a machine to run the tests on.

We quite often have a queue of tests waiting to run (e.g. in a mass dependabot upgrade across multiple repositories).
If the tests are being flaky, the lack of visibility over the status can exacerbate the problem as we may accidentally queue up several test re-runs for the same PR.