### PR TITLE
Remove publish_facets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -63,7 +63,6 @@ setup_apps:
 	$(MAKE) contacts_admin_seed
 	$(MAKE) publish_routes
 	$(MAKE) populate_end_to_end_test_data_from_whitehall
-	$(MAKE) publish_facets
 	$(DOCKER_COMPOSE_CMD) run --rm publishing-e2e-tests bundle exec rake govuk:wait_for_router
 	bundle exec rake docker:wait_for_apps
 
@@ -165,10 +164,6 @@ publish_calendars:
 
 populate_end_to_end_test_data_from_whitehall:
 	$(DOCKER_COMPOSE_CMD) exec -T whitehall-admin bundle exec rake taxonomy:populate_end_to_end_test_data
-
-publish_facets:
-	$(DOCKER_COMPOSE_CMD) exec -T content-tagger bundle exec rake facets:import_facet_group[lib/data/find-eu-exit-guidance-business.yml]
-	$(DOCKER_COMPOSE_CMD) exec -T content-tagger bundle exec rake facets:publish_facet_group[lib/data/find-eu-exit-guidance-business.yml]
 
 clean_apps:
 	$(DOCKER_RUN) bash -c 'rm -rf /app/apps/*'


### PR DESCRIPTION
Trello: https://trello.com/c/MG1iAY1p/509-remove-business-readiness-finder-and-supporting-features-from-content-tagger

We have removed facet groups as a feature as it was solely there to support the business finder which is now removed.

This tidies up the e2e tests, which will also help the tests to pass over here:
https://github.com/alphagov/content-tagger/pull/1050