### PR TITLE
Publishing e2e tests reset docker

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -67,7 +67,7 @@ timestamps {
       def testStatus = [flakyNewFailed: false, mainFailed: false, startUpFailed: false]
 
       cloneApplications(params)
-      buildDockerEnvironmnet(params, testStatus)
+      buildDockerEnvironment(params, testStatus)
 
       try {
         startDockerApps(testStatus)
@@ -206,7 +206,7 @@ def cloneApplications(params) {
   }
 }
 
-def buildDockerEnvironmnet(params, testStatus) {
+def buildDockerEnvironment(params, testStatus) {
   stage("Build docker environment") {
     try {
       sh("make pull")


### PR DESCRIPTION
Adds a `RESET_DOCK_ENV` boolean parameter, with the aim of removing existing Docker containers, in the case that a Docker process hangs and causes mass test failures. Useful as a 'nuclear' option if tests fail continuously and unrelated to the code change.