### PR TITLE
Add deps to finder-frontend

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -532,6 +532,7 @@ services:
       - rummager
       - diet-error-handler
       - whitehall-frontend
+      - router
     environment:
       << : *govuk-app
       SENTRY_CURRENT_ENV: finder-frontend
@@ -544,6 +545,7 @@ services:
       - nginx-proxy:static.dev.gov.uk
       - nginx-proxy:error-handler.dev.gov.uk
       - nginx-proxy:whitehall-frontend.dev.gov.uk
+      - nginx-proxy:www.dev.gov.uk
     ports:
       - "3062"
     volumes:


### PR DESCRIPTION
The world locations API test helpers in gds-api-adapters have been changed so that they point at `Plek.new.website_root` now.

Finder-frontend relies upon the world locations API to populate the world locations facet, so until this is fixed in some way, we need to include router to handle those requests.

It's making the [PR to update gds-api-adapters on finder-frontend](https://github.com/alphagov/finder-frontend/pull/1951) fail end to end tests.