### PR TITLE
Add build display name to Jenkins file

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -35,8 +35,10 @@ def apps = [
 timestamps {
   node("publishing-e2e-tests") {
     initializeParameters(govuk, apps)
-    
+
     originBuildStatus("Running publishing end-to-end tests on Jenkins", "PENDING", params)
+
+    currentBuild.displayName = "#$BUILD_NUMBER - $ORIGIN_REPO"
 
     lock("publishing-e2e-tests-$NODE_NAME") {
       try {


### PR DESCRIPTION
Setting the Jenkins Build name to the current repo under test, for easier identification in the Jenkins UI.

Before:
<img width="200" alt="Screenshot 2020-03-04 at 16 25 36" src="https://user-images.githubusercontent.com/13475227/75900510-eca88980-5e34-11ea-9448-5ad221cb3208.png">

After:
<img width="200" alt="Screenshot 2020-03-04 at 16 24 15" src="https://user-images.githubusercontent.com/13475227/75900376-bb2fbe00-5e34-11ea-9f4e-4faecf8feefb.png">
