### PR TITLE
Only add origin repo to build name if present

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -38,7 +38,9 @@ timestamps {
 
     originBuildStatus("Running publishing end-to-end tests on Jenkins", "PENDING", params)
 
-    currentBuild.displayName = "#$BUILD_NUMBER - $ORIGIN_REPO"
+    if (params.ORIGIN_REPO) {
+      currentBuild.displayName = "#$BUILD_NUMBER - $ORIGIN_REPO"
+    }
 
     lock("publishing-e2e-tests-$NODE_NAME") {
       try {


### PR DESCRIPTION
This PR prevents a hanging `-` in test runs that do not have an origin repo param.

<img width="150" alt="Screenshot 2020-03-04 at 16 55 02" src="https://user-images.githubusercontent.com/13475227/75903179-1d8abd80-5e39-11ea-9eac-3209698b5ce6.png">

Builds without an ORIGIN_REPO will simply display the build number

<img width="150" alt="Screenshot 2020-03-04 at 16 57 05" src="https://user-images.githubusercontent.com/13475227/75903291-457a2100-5e39-11ea-8b54-618ca2ac2c60.png">

