### PR TITLE
Fix for unkown method error

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -59,7 +59,7 @@ timestamps {
         }
 
         stage("Ruby Lint") {
-          govuk.lintRuby("spec lib Gemfile")
+          govuk.lintRuby()
         }
 
       } catch(e) {


### PR DESCRIPTION
should stop the e2e test failing with the following error

`java.lang.NoSuchMethodError: No such DSL method 'lintRuby'`