### PR TITLE
Stop a running container if necessary before removing it

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -46,7 +46,7 @@ clone: $(APPS)
 
 kill:
 	$(DOCKER_COMPOSE_CMD) kill
-	$(DOCKER_COMPOSE_CMD) rm -f
+	$(DOCKER_COMPOSE_CMD) rm -s -f
 
 build: kill
 	$(DOCKER_COMPOSE_CMD) build --pull diet-error-handler publishing-e2e-tests $(APPS_TO_BUILD)


### PR DESCRIPTION
We occasionally see errors related to a container already running.

```
You cannot remove a running container <id>.
Stop the container before attempting removal or force remove
```
This should stop the container before attempting removal: https://docs.docker.com/compose/reference/rm/

I'm not clear on why the container would already be running, but
it's possible that this can happen if cleanup from prior jobs
fails.