### PR TITLE
Retry if document doesn't appear in search results

### DIFF
--- a/spec/publisher/publishing_content_to_government_frontend_spec.rb
+++ b/spec/publisher/publishing_content_to_government_frontend_spec.rb
@@ -38,8 +38,11 @@ private
   end
 
   def and_i_can_view_it_on_finder
-    visit "#{Plek.new.website_root}/search/all?keywords=#{CGI.escape(title)}"
+    search_results = "#{Plek.new.website_root}/search/all?keywords=#{CGI.escape(title)}"
 
+    reload_url_until_match(search_results, :has_text?, title)
+
+    visit "#{Plek.new.website_root}/search/all?keywords=#{CGI.escape(title)}"
     expect_rendering_application("finder-frontend")
     expect(page).to have_content(title)
   end


### PR DESCRIPTION
We occasionally see `Failure/Error: expect(page).to have_content(title)` when checking a new document appears in search results as part of the "Publishing content from Publisher to Government Frontend" test.

It's possible this is due to search not indexing a document quickly enough, since we don't see this error in other cases where we retry the search page, as in the Publishing a contact test.

This adds in a retry to give search time to index and serve the document.