### PR TITLE
Add ASSET_HOST env var to frontend apps

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -534,6 +534,7 @@ services:
       - router
     environment:
       << : *govuk-app
+      ASSET_HOST: finder-frontend.dev.gov.uk
       SENTRY_CURRENT_ENV: finder-frontend
       VIRTUAL_HOST: finder-frontend.dev.gov.uk
     healthcheck:
@@ -605,6 +606,7 @@ services:
       - publishing-api
     environment:
       << : *govuk-app
+      ASSET_HOST: frontend.dev.gov.uk
       SENTRY_CURRENT_ENV: frontend
       VIRTUAL_HOST: frontend.dev.gov.uk
     healthcheck:
@@ -627,6 +629,7 @@ services:
       - diet-error-handler
     environment:
       << : *draft-govuk-app
+      ASSET_HOST: draft-frontend.dev.gov.uk
       PORT: 3105
       SENTRY_CURRENT_ENV: draft-frontend
       VIRTUAL_HOST: draft-frontend.dev.gov.uk
@@ -690,6 +693,7 @@ services:
       - diet-error-handler
     environment:
       << : *govuk-app
+      ASSET_HOST: manuals-frontend.dev.gov.uk
       SENTRY_CURRENT_ENV: manuals-frontend
       VIRTUAL_HOST: manuals-frontend.dev.gov.uk
     links:
@@ -709,6 +713,7 @@ services:
       - diet-error-handler
     environment:
       << : *draft-govuk-app
+      ASSET_HOST: draft-manuals-frontend.dev.gov.uk
       SENTRY_CURRENT_ENV: draft-manuals-frontend
       VIRTUAL_HOST: draft-manuals-frontend.dev.gov.uk
       PORT: 3172
@@ -761,6 +766,7 @@ services:
     << : *whitehall
     environment:
       << : *govuk-app
+      ASSET_HOST: whitehall-frontend.dev.gov.uk
       MEMCACHE_SERVERS: memcached
       VIRTUAL_HOST: whitehall-frontend.dev.gov.uk
       SENTRY_CURRENT_ENV: whitehall-frontend
@@ -771,6 +777,7 @@ services:
     << : *whitehall
     environment:
       << : *govuk-app
+      ASSET_HOST: draft-whitehall-frontend.dev.gov.uk
       MEMCACHE_SERVERS: memcached
       VIRTUAL_HOST: draft-whitehall-frontend.dev.gov.uk
       SENTRY_CURRENT_ENV: draft-whitehall-frontend
@@ -941,6 +948,7 @@ services:
       - diet-error-handler
     environment:
       << : *govuk-app
+      ASSET_HOST: static.dev.gov.uk
       SENTRY_CURRENT_ENV: static
       VIRTUAL_HOST: static.dev.gov.uk
     links:
@@ -954,6 +962,7 @@ services:
     << : *static
     environment:
       << : *draft-govuk-app
+      ASSET_HOST: draft-static.dev.gov.uk
       GOVUK_APP_NAME: draft-static
       PORT: 3113
       REDIS_URL: redis://redis/1
@@ -972,6 +981,7 @@ services:
       - memcached
     environment:
       << : *govuk-app
+      ASSET_HOST: government-frontend.dev.gov.uk
       MEMCACHE_SERVERS: memcached
       SENTRY_CURRENT_ENV: government-frontend
       VIRTUAL_HOST: government-frontend.dev.gov.uk
@@ -996,6 +1006,7 @@ services:
       - memcached
     environment:
       << : *draft-govuk-app
+      ASSET_HOST: draft-government-frontend.dev.gov.uk
       MEMCACHE_SERVERS: memcached
       GOVUK_APP_NAME: draft-government-frontend
       PORT: 3190


### PR DESCRIPTION
Trello: https://trello.com/c/oNEtjIVp/99-serve-static-assets-from-www-hostname

This adds environment variables for all the frontend apps that can be
used to specify the hostname used for assets. This is to support the
change of hostname for assets of GOV.UK apps from the
`assets.publishing.service.gov.uk` hostname to the `www.gov.uk` one.
For more information on this change see: https://github.com/alphagov/govuk-puppet/pull/10360.

To serve assets on an assets hostname in these tests requires a bunch of
nginx configuration to proxy asset requests to the corresponding Rails
application. Rather than moving this configuration to the www hostname I
thought it would be better to take the same approach as govuk-docker and
specify that assets are served by a particular host. This saves the need
for additional nginx configuration.

This change pre-emptively applies this environment variable to all
frontend apps with the expectation that the apps will gradually support
this env var as the apps are migrated. Once all the apps have been
migrated the asset configuration to proxy to apps can then be removed.