### PR TITLE
Remove custom whitehall asset root

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -744,7 +744,6 @@ services:
       VIRTUAL_HOST: whitehall-admin.dev.gov.uk
       MEMCACHE_SERVERS: memcached
       SENTRY_CURRENT_ENV: whitehall-admin
-      GOVUK_ASSET_ROOT: http://whitehall-admin.dev.gov.uk
       LOG_PATH: log/admin.log
       REDIS_URL: redis://redis/1
     healthcheck:


### PR DESCRIPTION
Trello: https://trello.com/c/oNEtjIVp/99-serve-static-assets-from-www-hostname

This is no longer needed for Whitehall since https://github.com/alphagov/whitehall/pull/5685