### PR TITLE
Remove GOVUK_ASSET_HOST

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,7 +7,6 @@ x-govuk-app-env: &govuk-app
   GOVUK_APP_DOMAIN: dev.gov.uk
   GOVUK_APP_DOMAIN_EXTERNAL: dev.gov.uk
   GOVUK_ASSET_ROOT: http://assets-origin.dev.gov.uk
-  GOVUK_ASSET_HOST: http://assets-origin.dev.gov.uk
   GOVUK_WEBSITE_ROOT: http://www.dev.gov.uk
   JWT_AUTH_SECRET: fakejwtsecret
   LOG_PATH: log/live.log


### PR DESCRIPTION
Trello: https://trello.com/c/oNEtjIVp/99-serve-static-assets-from-www-hostname

This environment variable no longer has any effect and I'm planning to
remove GOVUK_ASSET_HOST from the stack.