### PR TITLE
Stop using the govuk.lintRuby function

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -58,7 +58,7 @@ timestamps {
         }
 
         stage("Ruby Lint") {
-          govuk.lintRuby()
+          sh("bundle exec rubocop")
         }
 
       } catch(e) {


### PR DESCRIPTION
Trello: https://trello.com/c/5Gob6WUL/147-for-everyone-ensure-that-rubocop-runs-as-part-of-bundle-exec-rake-as-one-of-the-default-tasks

This has now been removed, we can just call rubocop directly.