### PR TITLE
Add nation applicability option to Whitehall publishing

### DIFF
--- a/spec/support/whitehall_helpers.rb
+++ b/spec/support/whitehall_helpers.rb
@@ -18,6 +18,7 @@ module WhitehallHelpers
     fill_in_opening_date(Date.today)
     fill_in_closing_date(Date.today.next_year)
     select_from_chosen "Test Policy Area", id: "edition_topic_ids"
+    check "Applies to all UK nations"
     check id: "edition_read_consultation_principles"
   end
 

--- a/spec/whitehall/updating_document_spec.rb
+++ b/spec/whitehall/updating_document_spec.rb
@@ -65,6 +65,7 @@ feature "Creating a new edition of a document with Whitehall", whitehall: true, 
 
     fill_in "Title", with: updated_title
     fill_in "Public change note", with: change_note
+    check "Applies to all UK nations"
     click_button("Save and continue")
     check "Test taxon"
     click_button("Save and review legacy tagging")


### PR DESCRIPTION
https://github.com/alphagov/whitehall/pull/5766 adds validations on certain publications to ensure they are applied to correct UK nations.

This PR adds the required checkbox.

Tested against https://github.com/alphagov/whitehall/pull/5766

[trello](https://trello.com/c/GBdunyhP/2082-3-change-excluded-nation-fieldset-in-whitehall)