### PR TITLE
Update Specialist Publisher Unpublishing test to use new document type

### DIFF
--- a/spec/specialist_publisher/unpublishing_spec.rb
+++ b/spec/specialist_publisher/unpublishing_spec.rb
@@ -3,8 +3,8 @@ feature "Unpublishing with Specialist Publisher", specialist_publisher: true, go
 
   let(:title) { "Unpublishing Specialist Publisher #{SecureRandom.uuid}" }
 
-  scenario "Unpublishing a DFID research output" do
-    given_there_is_a_published_dfid_research_output
+  scenario "Unpublishing a Research For Development Output" do
+    given_there_is_a_published_research_for_development_output
     when_i_unpublish_it
     then_i_receive_a_410_on_gov_uk
   end
@@ -15,11 +15,11 @@ feature "Unpublishing with Specialist Publisher", specialist_publisher: true, go
     )
   end
 
-  def given_there_is_a_published_dfid_research_output
+  def given_there_is_a_published_research_for_development_output
     signin_to_signon if use_signon?
-    visit_specialist_publisher("/dfid-research-outputs/new")
+    visit_specialist_publisher("/research-for-development-outputs/new")
 
-    fill_in_dfid_research_output_form(title: title)
+    fill_in_research_for_development_output_form(title: title)
     click_button("Save as draft")
     expect_created_alert(title)
     expect(page).to have_text(/Created #{Regexp.escape(title)}/), "Failed to create draft of #{title}"

--- a/spec/support/specialist_publisher_helpers.rb
+++ b/spec/support/specialist_publisher_helpers.rb
@@ -116,7 +116,7 @@ module SpecialistPublisherHelpers
     fill_in("Body", with: options[:body])
   end
 
-  def fill_in_dfid_research_output_form(options = {})
+  def fill_in_research_for_development_output_form(options = {})
     options = {
       title: unique_title,
       summary: Faker::Lorem.sentence,
@@ -127,11 +127,11 @@ module SpecialistPublisherHelpers
     fill_in("Title", with: options[:title])
     fill_in("Summary", with: options[:summary])
     fill_in("Body", with: options[:body])
-    select2("dfid_research_output_dfid_document_type", "Book")
-    select_all_select2("dfid_research_output_dfid_theme")
-    fill_in("dfid_research_output_first_published_at_year", with: options[:first_published_at].year)
-    fill_in("dfid_research_output_first_published_at_month", with: options[:first_published_at].month)
-    fill_in("dfid_research_output_first_published_at_day", with: options[:first_published_at].day)
+    select2("research_for_development_output_research_document_type", "Book")
+    select_all_select2("research_for_development_output_theme")
+    fill_in("research_for_development_output_first_published_at_year", with: options[:first_published_at].year)
+    fill_in("research_for_development_output_first_published_at_month", with: options[:first_published_at].month)
+    fill_in("research_for_development_output_first_published_at_day", with: options[:first_published_at].day)
   end
 
   def fill_in_eat_decision_form(options = {})


### PR DESCRIPTION
DFID Research Outputs are being replaced by [Research For Development Outputs](https://github.com/alphagov/specialist-publisher/pull/1692). This PR uses the new document format in the Specialist Publisher unpublishing spec.