### PR TITLE
Log into DockerHub before pulling images.

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -211,6 +211,14 @@ def cloneApplications(params) {
 def buildDockerEnvironment(params, testStatus) {
   stage("Build docker environment") {
     try {
+      withCredentials([usernamePassword(credentialsId: 'govukci-docker-hub', usernameVariable: 'DOCKER_USERNAME', passwordVariable: 'DOCKER_PASSWORD')]) {
+        // --password-stdin doesn't actually improve security here but it does
+        // suppress an inapplicable warning message.
+        sh([
+          script: 'echo $DOCKER_PASSWORD | docker login --username "$DOCKER_USERNAME" --password-stdin',
+          label: 'Log into DockerHub'
+        ])
+      }
       sh("make pull")
       sh("make build")
     } catch(e) {


### PR DESCRIPTION
This is to avoid being rate-limited from 1 Nov when DockerHub will limit unauthenticated pulls to to 100 per 6 hours per source IP address - see ([Docker Inc's announcement](https://www.docker.com/blog/scaling-docker-to-serve-millions-more-developers-network-egress/)).

We fetch the govukci DockerHub credentials from the Jenkins credentials-binding plugin and run `docker login`, passing the credentials by substituting environment variables in the shell.

The govukci creds are already present in the CI Jenkins (presumably for pushing images).

This is the first time I've written Groovy so please forgive (and point out) any syntactic solecisms 😅

Relevant docs (to help with reviewing):
https://www.jenkins.io/doc/pipeline/steps/credentials-binding/
https://www.jenkins.io/doc/pipeline/steps/workflow-durable-task-step/#sh-shell-script

Tested: [e2e test suite works on the branch](https://ci.integration.publishing.service.gov.uk/job/publishing-e2e-tests/job/sengi%252Fdocker-login/) and seems to be running the `docker login` command successfully. I haven't figured out a way to tell whether Docker is actually making authenticated requests to DockerHub.

[Trello card](https://trello.com/c/M3zyF5kM/3898)