### PR TITLE
Select HMRC when creating a new contact

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,7 +2,7 @@ source "https://rubygems.org"
 
 gem "byebug"
 gem "capybara-screenshot"
-gem "capybara-select2"
+gem "capybara-select-2"
 gem "docker-api", "~> 1.34"
 gem "docker-compose", "~> 1.1"
 gem "faker", "~> 1.9"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -23,9 +23,7 @@ GEM
     capybara-screenshot (1.0.24)
       capybara (>= 1.0, < 4)
       launchy
-    capybara-select2 (1.0.1)
-      capybara
-      rspec
+    capybara-select-2 (0.5.1)
     childprocess (3.0.0)
     concurrent-ruby (1.1.6)
     diff-lcs (1.3)
@@ -133,7 +131,7 @@ PLATFORMS
 DEPENDENCIES
   byebug
   capybara-screenshot
-  capybara-select2
+  capybara-select-2
   docker-api (~> 1.34)
   docker-compose (~> 1.1)
   faker (~> 1.9)

--- a/Makefile
+++ b/Makefile
@@ -127,6 +127,7 @@ contacts_admin_seed: wait_for_whitehall_admin
 	# Whitehall.
 	$(DOCKER_COMPOSE_CMD) exec -T whitehall-admin bundle exec rake search:index:organisations
 	$(DOCKER_COMPOSE_CMD) exec -T collections-publisher bundle exec rake publishing_api:publish_organisations_api_route
+	$(DOCKER_COMPOSE_CMD) exec -T whitehall-admin bundle exec rake publishing_api:republish_all_organisations
 
 	$(DOCKER_COMPOSE_CMD) exec -T contacts-admin bundle exec rake db:seed
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -19,7 +19,7 @@
 
 require "capybara/rspec"
 require "capybara-screenshot/rspec"
-require "capybara-select2"
+require "capybara-select-2"
 require "faker"
 require "plek"
 require "ptools"

--- a/spec/support/contacts_helpers.rb
+++ b/spec/support/contacts_helpers.rb
@@ -3,6 +3,7 @@ module ContactsHelpers
     visit(Plek.find("contacts-admin") + "/admin/contacts/new")
     fill_in "contact_title", with: title
     fill_in "Description", with: sentence
+    select2("HM Revenue & Customs [HMRC]", from: "Organisation")
     click_button "Create Contact"
   end
 


### PR DESCRIPTION
The current finder for HMRC contacts does not actually filter by organisation and shows contacts for all organisations. This means the e2e test for this will pass regardless of the organisation selected.

In https://github.com/alphagov/contacts-admin/pull/827, we are filtering to only show HMRC contacts, so need to select that organisation when creating the contact.