### PR TITLE
Set REDIS_URL for all apps that use Redis

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -851,6 +851,7 @@ services:
       << : *govuk-app
       ASSET_MANAGER_CLAMSCAN_PATH: /bin/true
       REDIS_HOST: redis
+      REDIS_URL: redis://redis/1
       SENTRY_CURRENT_ENV: asset-manager
       VIRTUAL_HOST: asset-manager.dev.gov.uk
       FAKE_S3_HOST: http://127.0.0.1
@@ -874,6 +875,7 @@ services:
       << : *govuk-app
       ASSET_MANAGER_CLAMSCAN_PATH: /bin/true
       REDIS_HOST: redis
+      REDIS_URL: redis://redis/1
       SENTRY_CURRENT_ENV: asset-manager-worker
       FAKE_S3_HOST: http://127.0.0.1
       ALLOW_FAKE_S3_IN_PRODUCTION_FOR_PUBLISHING_E2E_TESTS: "true"
@@ -896,6 +898,7 @@ services:
       DATABASE_URL: postgresql://postgres:postgres@postgres/email-alert-api
       EMAIL_ALERT_AUTH_TOKEN: 9d3e07ca727cd08cc503191f233919877160bfc57eaaa33541761c2d1ffd951ae205263be5832f26ba2670b142d7c593ec0f6bdd11a84cf325a32dbdd889ff44
       REDIS_HOST: redis
+      REDIS_URL: redis://redis/1
       SENTRY_CURRENT_ENV: email-alert-api
       VIRTUAL_HOST: email-alert-api.dev.gov.uk
     healthcheck:
@@ -916,6 +919,7 @@ services:
       DATABASE_URL: postgresql://postgres:postgres@postgres/email-alert-api
       EMAIL_ALERT_AUTH_TOKEN: 9d3e07ca727cd08cc503191f233919877160bfc57eaaa33541761c2d1ffd951ae205263be5832f26ba2670b142d7c593ec0f6bdd11a84cf325a32dbdd889ff44
       REDIS_HOST: redis
+      REDIS_URL: redis://redis/1
       SENTRY_CURRENT_ENV: email-alert-api-worker
     healthcheck:
       disable: true

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -99,6 +99,7 @@ services:
     environment:
       << : *govuk-app
       GOVUK_APP_NAME: rummager
+      REDIS_URL: redis://redis/1
       SENTRY_CURRENT_ENV: rummager
       VIRTUAL_HOST: rummager.dev.gov.uk
     links:
@@ -121,6 +122,7 @@ services:
     environment:
       << : *govuk-app
       GOVUK_APP_NAME: rummager-worker
+      REDIS_URL: redis://redis/1
       SENTRY_CURRENT_ENV: rummager-worker
     links:
       - nginx-proxy:publishing-api.dev.gov.uk
@@ -133,9 +135,11 @@ services:
     depends_on:
       - diet-error-handler
       - rabbitmq
+      - redis
     environment:
       << : *govuk-app
       GOVUK_APP_NAME: rummager-listener-publishing-queue
+      REDIS_URL: redis://redis/1
       SENTRY_CURRENT_ENV: rummager-listener-publishing-queue
     ports: []
 
@@ -145,9 +149,11 @@ services:
     depends_on:
       - diet-error-handler
       - rabbitmq
+      - redis
     environment:
       << : *govuk-app
       GOVUK_APP_NAME: rummager-listener-insert-data
+      REDIS_URL: redis://redis/1
       SENTRY_CURRENT_ENV: rummager-listener-insert-data
     ports: []
 
@@ -157,9 +163,11 @@ services:
     depends_on:
       - diet-error-handler
       - rabbitmq
+      - redis
     environment:
       << : *govuk-app
       GOVUK_APP_NAME: rummager-listener-bulk-insert-data
+      REDIS_URL: redis://redis/1
       SENTRY_CURRENT_ENV: rummager-listener-bulk-insert-data
     ports: []
 
@@ -306,6 +314,7 @@ services:
       << : *govuk-app
       DATABASE_URL: postgresql://postgres:postgres@postgres/publishing-api
       MEMCACHE_SERVERS: memcached
+      REDIS_URL: redis://redis/1
       SENTRY_CURRENT_ENV: publishing-api
       VIRTUAL_HOST: publishing-api.dev.gov.uk
     links:
@@ -330,6 +339,7 @@ services:
     environment:
       << : *govuk-app
       DATABASE_URL: postgresql://postgres:postgres@postgres/publishing-api
+      REDIS_URL: redis://redis/1
       MEMCACHE_SERVERS: memcached
       SENTRY_CURRENT_ENV: publishing-api-worker
     healthcheck:
@@ -353,6 +363,7 @@ services:
     environment:
       << : *govuk-app
       MONGO_WRITE_CONCERN: 1
+      REDIS_URL: redis://redis/1
       SENTRY_CURRENT_ENV: specialist-publisher
       VIRTUAL_HOST: specialist-publisher.dev.gov.uk
     healthcheck:
@@ -382,6 +393,7 @@ services:
     environment:
       << : *govuk-app
       SENTRY_CURRENT_ENV: travel-advice-publisher
+      REDIS_URL: redis://redis/1
       VIRTUAL_HOST: travel-advice-publisher.dev.gov.uk
     healthcheck:
       << : *default-healthcheck
@@ -401,11 +413,13 @@ services:
     command: foreman run worker
     depends_on:
       - publishing-api
+      - redis
       - diet-error-handler
     healthcheck:
       disable: true
     environment:
       << : *govuk-app
+      REDIS_URL: redis://redis/1
       SENTRY_CURRENT_ENV: travel-advice-publisher-worker
     ports: []
 
@@ -416,11 +430,13 @@ services:
     depends_on:
       - publishing-api
       - mysql
+      - redis
       - rummager
       - collections-publisher-worker
       - diet-error-handler
     environment:
       << : *govuk-app
+      REDIS_URL: redis://redis/1
       SENTRY_CURRENT_ENV: collections-publisher
       VIRTUAL_HOST: collections-publisher.dev.gov.uk
     healthcheck:
@@ -443,6 +459,7 @@ services:
       - redis
     environment:
       << : *govuk-app
+      REDIS_URL: redis://redis/1
       SENTRY_CURRENT_ENV: collections-publisher-worker
     healthcheck:
       disable: true
@@ -565,6 +582,7 @@ services:
       << : *govuk-app
       DISABLE_SECURE_COOKIES: "true"
       DISABLE_EMAIL: "true"
+      REDIS_URL: redis://redis/1
       SENTRY_CURRENT_ENV: publisher
       VIRTUAL_HOST: publisher.dev.gov.uk
       GOVUK_CONTENT_SCHEMAS_PATH: /govuk-content-schemas/
@@ -585,10 +603,12 @@ services:
     << : *publisher
     command: foreman run worker
     depends_on:
+      - redis
       - publishing-api
       - diet-error-handler
     environment:
       << : *govuk-app
+      REDIS_URL: redis://redis/1
       SENTRY_CURRENT_ENV: publisher-worker
     healthcheck:
       disable: true
@@ -650,6 +670,7 @@ services:
       - manuals-publisher-worker
       - mongo
       - publishing-api
+      - redis
       - router
       - rummager
       - whitehall-admin
@@ -674,6 +695,7 @@ services:
     command: foreman run worker
     depends_on:
       - publishing-api
+      - redis
       - diet-error-handler
     environment:
       << : *govuk-app
@@ -811,6 +833,7 @@ services:
     environment:
       << : *govuk-app
       DATABASE_URL: postgresql://postgres:postgres@postgres/content-tagger
+      REDIS_URL: redis://redis/1
       SENTRY_CURRENT_ENV: content-tagger
       VIRTUAL_HOST: content-tagger.dev.gov.uk
     healthcheck:
@@ -829,9 +852,11 @@ services:
     command: bundle exec sidekiq -C ./config/sidekiq.yml
     depends_on:
       - diet-error-handler
+      - redis
     environment:
       << : *govuk-app
       DATABASE_URL: postgresql://postgres:postgres@postgres/content-tagger
+      REDIS_URL: redis://redis/1
       SENTRY_CURRENT_ENV: content-tagger-worker
     healthcheck:
       disable: true
@@ -930,9 +955,11 @@ services:
     build: apps/static
     depends_on:
       - diet-error-handler
+      - redis
     environment:
       << : *govuk-app
       ASSET_HOST: static.dev.gov.uk
+      REDIS_URL: redis://redis/1
       SENTRY_CURRENT_ENV: static
       VIRTUAL_HOST: static.dev.gov.uk
     links:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -100,7 +100,7 @@ services:
       << : *govuk-app
       GOVUK_APP_NAME: rummager
       RACK_ENV: production
-      REDIS_URL: redis://redis/1
+      REDIS_URL: redis://redis
       SENTRY_CURRENT_ENV: rummager
       VIRTUAL_HOST: rummager.dev.gov.uk
     links:
@@ -124,7 +124,7 @@ services:
       << : *govuk-app
       GOVUK_APP_NAME: rummager-worker
       RACK_ENV: production
-      REDIS_URL: redis://redis/1
+      REDIS_URL: redis://redis
       SENTRY_CURRENT_ENV: rummager-worker
     links:
       - nginx-proxy:publishing-api.dev.gov.uk
@@ -142,7 +142,7 @@ services:
       << : *govuk-app
       GOVUK_APP_NAME: rummager-listener-publishing-queue
       RACK_ENV: production
-      REDIS_URL: redis://redis/1
+      REDIS_URL: redis://redis
       SENTRY_CURRENT_ENV: rummager-listener-publishing-queue
     ports: []
 
@@ -157,7 +157,7 @@ services:
       << : *govuk-app
       GOVUK_APP_NAME: rummager-listener-insert-data
       RACK_ENV: production
-      REDIS_URL: redis://redis/1
+      REDIS_URL: redis://redis
       SENTRY_CURRENT_ENV: rummager-listener-insert-data
     ports: []
 
@@ -172,7 +172,7 @@ services:
       << : *govuk-app
       GOVUK_APP_NAME: rummager-listener-bulk-insert-data
       RACK_ENV: production
-      REDIS_URL: redis://redis/1
+      REDIS_URL: redis://redis
       SENTRY_CURRENT_ENV: rummager-listener-bulk-insert-data
     ports: []
 
@@ -319,7 +319,7 @@ services:
       << : *govuk-app
       DATABASE_URL: postgresql://postgres:postgres@postgres/publishing-api
       MEMCACHE_SERVERS: memcached
-      REDIS_URL: redis://redis/1
+      REDIS_URL: redis://redis
       SENTRY_CURRENT_ENV: publishing-api
       VIRTUAL_HOST: publishing-api.dev.gov.uk
     links:
@@ -344,7 +344,7 @@ services:
     environment:
       << : *govuk-app
       DATABASE_URL: postgresql://postgres:postgres@postgres/publishing-api
-      REDIS_URL: redis://redis/1
+      REDIS_URL: redis://redis
       MEMCACHE_SERVERS: memcached
       SENTRY_CURRENT_ENV: publishing-api-worker
     healthcheck:
@@ -368,7 +368,7 @@ services:
     environment:
       << : *govuk-app
       MONGO_WRITE_CONCERN: 1
-      REDIS_URL: redis://redis/1
+      REDIS_URL: redis://redis
       SENTRY_CURRENT_ENV: specialist-publisher
       VIRTUAL_HOST: specialist-publisher.dev.gov.uk
     healthcheck:
@@ -398,7 +398,7 @@ services:
     environment:
       << : *govuk-app
       SENTRY_CURRENT_ENV: travel-advice-publisher
-      REDIS_URL: redis://redis/1
+      REDIS_URL: redis://redis
       VIRTUAL_HOST: travel-advice-publisher.dev.gov.uk
     healthcheck:
       << : *default-healthcheck
@@ -424,7 +424,7 @@ services:
       disable: true
     environment:
       << : *govuk-app
-      REDIS_URL: redis://redis/1
+      REDIS_URL: redis://redis
       SENTRY_CURRENT_ENV: travel-advice-publisher-worker
     ports: []
 
@@ -441,7 +441,7 @@ services:
       - diet-error-handler
     environment:
       << : *govuk-app
-      REDIS_URL: redis://redis/1
+      REDIS_URL: redis://redis
       SENTRY_CURRENT_ENV: collections-publisher
       VIRTUAL_HOST: collections-publisher.dev.gov.uk
     healthcheck:
@@ -464,7 +464,7 @@ services:
       - redis
     environment:
       << : *govuk-app
-      REDIS_URL: redis://redis/1
+      REDIS_URL: redis://redis
       SENTRY_CURRENT_ENV: collections-publisher-worker
     healthcheck:
       disable: true
@@ -587,7 +587,7 @@ services:
       << : *govuk-app
       DISABLE_SECURE_COOKIES: "true"
       DISABLE_EMAIL: "true"
-      REDIS_URL: redis://redis/1
+      REDIS_URL: redis://redis
       SENTRY_CURRENT_ENV: publisher
       VIRTUAL_HOST: publisher.dev.gov.uk
       GOVUK_CONTENT_SCHEMAS_PATH: /govuk-content-schemas/
@@ -613,7 +613,7 @@ services:
       - diet-error-handler
     environment:
       << : *govuk-app
-      REDIS_URL: redis://redis/1
+      REDIS_URL: redis://redis
       SENTRY_CURRENT_ENV: publisher-worker
     healthcheck:
       disable: true
@@ -771,7 +771,7 @@ services:
       MEMCACHE_SERVERS: memcached
       SENTRY_CURRENT_ENV: whitehall-admin
       LOG_PATH: log/admin.log
-      REDIS_URL: redis://redis/1
+      REDIS_URL: redis://redis
     healthcheck:
       << : *default-healthcheck
     links:
@@ -796,7 +796,7 @@ services:
       VIRTUAL_HOST: whitehall-frontend.dev.gov.uk
       SENTRY_CURRENT_ENV: whitehall-frontend
       LOG_PATH: log/frontend.log
-      REDIS_URL: redis://redis/1
+      REDIS_URL: redis://redis
 
   draft-whitehall-frontend:
     << : *whitehall
@@ -807,7 +807,7 @@ services:
       VIRTUAL_HOST: draft-whitehall-frontend.dev.gov.uk
       SENTRY_CURRENT_ENV: draft-whitehall-frontend
       LOG_PATH: log/draft-frontend.log
-      REDIS_URL: redis://redis/1
+      REDIS_URL: redis://redis
 
   whitehall-worker:
     << : *whitehall
@@ -817,7 +817,7 @@ services:
       - redis
     environment:
       << : *govuk-app
-      REDIS_URL: redis://redis/1
+      REDIS_URL: redis://redis
       SENTRY_CURRENT_ENV: whitehall-worker
     healthcheck:
       disable: true
@@ -838,7 +838,7 @@ services:
     environment:
       << : *govuk-app
       DATABASE_URL: postgresql://postgres:postgres@postgres/content-tagger
-      REDIS_URL: redis://redis/1
+      REDIS_URL: redis://redis
       SENTRY_CURRENT_ENV: content-tagger
       VIRTUAL_HOST: content-tagger.dev.gov.uk
     healthcheck:
@@ -861,7 +861,7 @@ services:
     environment:
       << : *govuk-app
       DATABASE_URL: postgresql://postgres:postgres@postgres/content-tagger
-      REDIS_URL: redis://redis/1
+      REDIS_URL: redis://redis
       SENTRY_CURRENT_ENV: content-tagger-worker
     healthcheck:
       disable: true
@@ -881,7 +881,7 @@ services:
       << : *govuk-app
       ASSET_MANAGER_CLAMSCAN_PATH: /bin/true
       REDIS_HOST: redis
-      REDIS_URL: redis://redis/1
+      REDIS_URL: redis://redis
       SENTRY_CURRENT_ENV: asset-manager
       VIRTUAL_HOST: asset-manager.dev.gov.uk
       FAKE_S3_HOST: http://127.0.0.1
@@ -905,7 +905,7 @@ services:
       << : *govuk-app
       ASSET_MANAGER_CLAMSCAN_PATH: /bin/true
       REDIS_HOST: redis
-      REDIS_URL: redis://redis/1
+      REDIS_URL: redis://redis
       SENTRY_CURRENT_ENV: asset-manager-worker
       FAKE_S3_HOST: http://127.0.0.1
       ALLOW_FAKE_S3_IN_PRODUCTION_FOR_PUBLISHING_E2E_TESTS: "true"
@@ -928,7 +928,7 @@ services:
       DATABASE_URL: postgresql://postgres:postgres@postgres/email-alert-api
       EMAIL_ALERT_AUTH_TOKEN: 9d3e07ca727cd08cc503191f233919877160bfc57eaaa33541761c2d1ffd951ae205263be5832f26ba2670b142d7c593ec0f6bdd11a84cf325a32dbdd889ff44
       REDIS_HOST: redis
-      REDIS_URL: redis://redis/1
+      REDIS_URL: redis://redis
       SENTRY_CURRENT_ENV: email-alert-api
       VIRTUAL_HOST: email-alert-api.dev.gov.uk
     healthcheck:
@@ -949,7 +949,7 @@ services:
       DATABASE_URL: postgresql://postgres:postgres@postgres/email-alert-api
       EMAIL_ALERT_AUTH_TOKEN: 9d3e07ca727cd08cc503191f233919877160bfc57eaaa33541761c2d1ffd951ae205263be5832f26ba2670b142d7c593ec0f6bdd11a84cf325a32dbdd889ff44
       REDIS_HOST: redis
-      REDIS_URL: redis://redis/1
+      REDIS_URL: redis://redis
       SENTRY_CURRENT_ENV: email-alert-api-worker
     healthcheck:
       disable: true
@@ -964,7 +964,7 @@ services:
     environment:
       << : *govuk-app
       ASSET_HOST: static.dev.gov.uk
-      REDIS_URL: redis://redis/1
+      REDIS_URL: redis://redis
       SENTRY_CURRENT_ENV: static
       VIRTUAL_HOST: static.dev.gov.uk
     links:
@@ -981,7 +981,7 @@ services:
       ASSET_HOST: draft-static.dev.gov.uk
       GOVUK_APP_NAME: draft-static
       PORT: 3113
-      REDIS_URL: redis://redis/1
+      REDIS_URL: redis://redis
       SENTRY_CURRENT_ENV: draft-static
       VIRTUAL_HOST: draft-static.dev.gov.uk
     ports:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -99,6 +99,7 @@ services:
     environment:
       << : *govuk-app
       GOVUK_APP_NAME: rummager
+      RACK_ENV: production
       REDIS_URL: redis://redis/1
       SENTRY_CURRENT_ENV: rummager
       VIRTUAL_HOST: rummager.dev.gov.uk
@@ -122,6 +123,7 @@ services:
     environment:
       << : *govuk-app
       GOVUK_APP_NAME: rummager-worker
+      RACK_ENV: production
       REDIS_URL: redis://redis/1
       SENTRY_CURRENT_ENV: rummager-worker
     links:
@@ -139,6 +141,7 @@ services:
     environment:
       << : *govuk-app
       GOVUK_APP_NAME: rummager-listener-publishing-queue
+      RACK_ENV: production
       REDIS_URL: redis://redis/1
       SENTRY_CURRENT_ENV: rummager-listener-publishing-queue
     ports: []
@@ -153,6 +156,7 @@ services:
     environment:
       << : *govuk-app
       GOVUK_APP_NAME: rummager-listener-insert-data
+      RACK_ENV: production
       REDIS_URL: redis://redis/1
       SENTRY_CURRENT_ENV: rummager-listener-insert-data
     ports: []
@@ -167,6 +171,7 @@ services:
     environment:
       << : *govuk-app
       GOVUK_APP_NAME: rummager-listener-bulk-insert-data
+      RACK_ENV: production
       REDIS_URL: redis://redis/1
       SENTRY_CURRENT_ENV: rummager-listener-bulk-insert-data
     ports: []


### PR DESCRIPTION
Trello: https://trello.com/c/dXud4WIt/206-inconsistent-redisurl-config

This sets up REDIS_URL env vars on all apps that use Redis with the intention of allowing a transition from REDIS_HOST to REDIS_URL for any apps that still use the old environment variable. It also makes the REDIS_URL explicit in apps that already use it so that we don't need to rely on the env var being specified in the Dockerfile (it was a bit of a strange approach that Dockerfiles default to env vars that correlated to service definitions in this project - and, I'm sure, entirely my fault).

I've also simplified the REDIS_URL definition to not point to a particular database and adding a missing environment variable for Search API so it runs in production mode.