### PR TITLE
Remove REDIS_HOST env var

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -877,7 +877,6 @@ services:
     environment:
       << : *govuk-app
       ASSET_MANAGER_CLAMSCAN_PATH: /bin/true
-      REDIS_HOST: redis
       REDIS_URL: redis://redis
       SENTRY_CURRENT_ENV: asset-manager
       VIRTUAL_HOST: asset-manager.dev.gov.uk
@@ -901,7 +900,6 @@ services:
     environment:
       << : *govuk-app
       ASSET_MANAGER_CLAMSCAN_PATH: /bin/true
-      REDIS_HOST: redis
       REDIS_URL: redis://redis
       SENTRY_CURRENT_ENV: asset-manager-worker
       FAKE_S3_HOST: http://127.0.0.1
@@ -924,7 +922,6 @@ services:
       << : *govuk-app
       DATABASE_URL: postgresql://postgres:postgres@postgres/email-alert-api
       EMAIL_ALERT_AUTH_TOKEN: 9d3e07ca727cd08cc503191f233919877160bfc57eaaa33541761c2d1ffd951ae205263be5832f26ba2670b142d7c593ec0f6bdd11a84cf325a32dbdd889ff44
-      REDIS_HOST: redis
       REDIS_URL: redis://redis
       SENTRY_CURRENT_ENV: email-alert-api
       VIRTUAL_HOST: email-alert-api.dev.gov.uk
@@ -945,7 +942,6 @@ services:
       << : *govuk-app
       DATABASE_URL: postgresql://postgres:postgres@postgres/email-alert-api
       EMAIL_ALERT_AUTH_TOKEN: 9d3e07ca727cd08cc503191f233919877160bfc57eaaa33541761c2d1ffd951ae205263be5832f26ba2670b142d7c593ec0f6bdd11a84cf325a32dbdd889ff44
-      REDIS_HOST: redis
       REDIS_URL: redis://redis
       SENTRY_CURRENT_ENV: email-alert-api-worker
     healthcheck:


### PR DESCRIPTION
All apps have now been updated to remove the need for this environment
variable. Old branches of the apps changed here may need rebasing to
work with this change.