### PR TITLE
Change Contacts Admin contact removal test to account for redirect

### DIFF
--- a/spec/contacts_admin/removing_a_contact_spec.rb
+++ b/spec/contacts_admin/removing_a_contact_spec.rb
@@ -6,7 +6,7 @@ feature "Removing a contact", contacts_admin: true, finder_frontend: true, gover
   scenario "Removing a contact" do
     given_there_is_a_published_contact
     when_i_remove_the_contact
-    then_i_get_a_410_on_gov_uk
+    then_i_get_a_301_on_gov_uk
     and_it_is_not_shown_on_finder
   end
 
@@ -27,21 +27,20 @@ private
   def when_i_remove_the_contact
     search_for_contact(title: title)
     click_link "Edit contact"
-
-    page.accept_confirm do
-      click_link "Delete"
-    end
+    click_link "Delete"
+    fill_in "redirect_url", with: "/world"
+    click_button "Delete contact"
   end
 
-  def then_i_get_a_410_on_gov_uk
-    reload_url_until_status_code(@url, 410, keep_retrying_while: [404, 200])
+  def then_i_get_a_301_on_gov_uk
+    reload_url_until_status_code(@url, 301, keep_retrying_while: [404, 200])
 
     visit(@url)
-    expect(page).to have_content(/gone/i)
+    expect(current_url).to eq("http://www.dev.gov.uk/world")
   end
 
   def and_it_is_not_shown_on_finder
-    contact_finder_url = Pathname.new(current_url).parent.to_s
+    contact_finder_url = Pathname.new(@url).parent.to_s
     reload_url_until_match(contact_finder_url, :has_no_text?, title)
     visit contact_finder_url
     expect_rendering_application("finder-frontend")


### PR DESCRIPTION
Publishers will now be forced to provide a redirect URL.
See https://github.com/alphagov/contacts-admin/pull/838.

Trello: https://trello.com/c/cIv5x8wB/2348-5-add-ability-to-unpublish-with-a-redirect-in-contacts-app