### PR TITLE
Remove section-content class on manuals publisher test

### DIFF
--- a/spec/manuals_publisher/update_published_content_spec.rb
+++ b/spec/manuals_publisher/update_published_content_spec.rb
@@ -49,7 +49,7 @@ feature "Updating content on Manuals Publisher", manuals_publisher: true do
 
   def and_the_update_log_has_the_change_note
     click_link "see all updates"
-    first(".section-content button", text: "Open all").click
+    first("button", text: "Show all sections").click
 
     expect(page).to have_content(change_note)
   end


### PR DESCRIPTION
## What
Removes the `.section-content` class from the test to the update page test for manuals publisher

## Why
[An impending change to how accordions work on manuals-frontend](https://github.com/alphagov/manuals-frontend/pull/1060) which also removes a lot of now redundant css selectors breaks this test. This change removes the specificity from it, allowing it to pass.