### PR TITLE
Add new container running MongoDB 2.6.12 for routing

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -52,7 +52,7 @@ build: kill
 	$(DOCKER_COMPOSE_CMD) build --pull diet-error-handler publishing-e2e-tests $(APPS_TO_BUILD)
 
 setup_dependencies:
-	$(DOCKER_COMPOSE_CMD) up -d elasticsearch6 mongo mysql postgres rabbitmq redis
+	$(DOCKER_COMPOSE_CMD) up -d elasticsearch6 mongo mongo-2.6 mysql postgres rabbitmq redis
 	bundle exec rake docker:wait_for_dbs
 	$(MAKE) setup_dbs
 	bundle exec rake docker:wait_for_rabbitmq

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -60,6 +60,13 @@ services:
       << : *default-healthcheck
       test: "echo 'db.stats().ok' | mongo localhost:27017/test --quiet"
 
+  mongo-2.6:
+    image: mongo:2.6
+    command: ["--replSet", "mongo-2.6-replica-set"]
+    healthcheck:
+      << : *default-healthcheck
+      test: test $$(echo "rs.initiate().ok || rs.status().ok" | mongo localhost:27017/test --quiet) -eq 1
+
   redis:
     image: redis
     healthcheck:
@@ -184,11 +191,12 @@ services:
     image: govuk/router:${ROUTER_COMMITISH:-deployed-to-production}
     build: apps/router
     depends_on:
-      - mongo
+      - mongo-2.6
     environment:
       VIRTUAL_HOST: www.dev.gov.uk
       VIRTUAL_PORT: 3054
       ROUTER_BACKEND_HEADER_TIMEOUT: 60s
+      ROUTER_MONGO_URL: mongo-2.6
     links:
       - nginx-proxy:government-frontend.dev.gov.uk
       - nginx-proxy:collections.dev.gov.uk
@@ -209,6 +217,7 @@ services:
       ROUTER_PUBADDR: ":3154"
       ROUTER_APIADDR: ":3155"
       ROUTER_MONGO_DB: draft-router
+      ROUTER_MONGO_URL: mongo-2.6
       VIRTUAL_HOST: draft-origin.dev.gov.uk
       VIRTUAL_PORT: 3154
     links:
@@ -225,13 +234,15 @@ services:
     image: govuk/router-api:${ROUTER_API_COMMITISH:-deployed-to-production}
     build: apps/router-api
     depends_on:
-      - mongo
+      - mongo-2.6
       - router
       - diet-error-handler
     environment:
       << : *govuk-app
       SENTRY_CURRENT_ENV: router-api
       VIRTUAL_HOST: router-api.dev.gov.uk
+      MONGODB_URI: mongodb://mongo-2.6/router
+      TEST_MONGODB_URI: mongodb://mongo-2.6/router-test
     links:
       - nginx-proxy:error-handler.dev.gov.uk
     ports:
@@ -242,17 +253,17 @@ services:
   draft-router-api:
     << : *router-api
     depends_on:
-      - mongo
+      - mongo-2.6
       - draft-router
       - diet-error-handler
     environment:
       << : *draft-govuk-app
       GOVUK_APP_NAME: draft-router-api
-      MONGODB_URI: mongodb://mongo/draft-router
+      MONGODB_URI: mongodb://mongo-2.6/draft-router
       PORT: 3156
       ROUTER_NODES: "draft-router:3155"
       SENTRY_CURRENT_ENV: draft-router-api
-      TEST_MONGODB_URI: mongodb://mongo/draft-router-test
+      TEST_MONGODB_URI: mongodb://mongo-2.6/draft-router-test
       VIRTUAL_HOST: draft-router-api.dev.gov.uk
     links:
       - nginx-proxy:error-handler.dev.gov.uk

--- a/lib/tasks/docker.rake
+++ b/lib/tasks/docker.rake
@@ -3,7 +3,7 @@ require_relative "../docker_service"
 namespace :docker do
   desc "Wait until database containers are indicating they are healthy"
   task :wait_for_dbs do
-    DockerService.wait_for_healthy_services(services: %w[elasticsearch6 mongo mysql postgres redis])
+    DockerService.wait_for_healthy_services(services: %w[elasticsearch6 mongo mongo-2.6 mysql postgres redis])
   end
 
   desc "Wait for the RabbitMQ container to indicate it is healthy"


### PR DESCRIPTION
This commit adds a new container running MongoDB `2.6.12`, aimed specifically at Router and Router API. The MongoDB version used for Router / Router API in production is already `2.6.12`, however this test suite previously created a single MongoDB instance running at the higher version `3.4` and used this for all apps requiring MongoDB; this commit fixes that misrepresentation.

The reason it's necessary to make the changes in this commit is because we are now polling the MongoDB replica set inside of Router to determine whether or not to pull new routes. The specifics of how a replica set can be polled differs between MongoDB versions `2.6.12` and `3.4`; the results of each are not interchangeable, which means that we can't simply piggy back on the existing `3.4` instance.