### PR TITLE
Fix test that relies on router having a presumed state

### DIFF
--- a/spec/collections_publisher/archiving_child_topic_spec.rb
+++ b/spec/collections_publisher/archiving_child_topic_spec.rb
@@ -76,6 +76,6 @@ private
   def wait_for_the_child_to_redirect
     click_link(child_title)
     url = find_link(link)[:href]
-    reload_url_until_status_code(url, 301, keep_retrying_while: [200])
+    reload_url_until_status_code(url, 301, keep_retrying_while: [200, 404])
   end
 end


### PR DESCRIPTION
Trello: https://trello.com/c/El90C8B4/1132-e2e-tests-intermittently-failing

This test will wait for a recently published piece of content to change
from a 200 response to a 301 redirect. However an assumption of this
test is that the content has made it into router and is returning a 200
response. This assumption, while presumptuous, used to hold until the
recent changes to Router which switched to a polling rather than a
notifying mechanism [1].

To resolve this I've set this wait condition to be able to handle the
state where router hasn't updated yet.

[1]: https://github.com/alphagov/router/pull/195