### PR TITLE
Add ENV variable to skip S3 healthcheck

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -782,6 +782,7 @@ services:
       SENTRY_CURRENT_ENV: whitehall-admin
       LOG_PATH: log/admin.log
       REDIS_URL: redis://redis
+      SKIP_S3_HEALTHCHECK_FOR_PUBLISHING_E2E_TESTS: "true"
     healthcheck:
       << : *default-healthcheck
     links:


### PR DESCRIPTION
This commit add an ENV variable that will be used by Whitehall to
skip the S3 healthcheck if the app is being run from the E2E tests.

More info in the related PR: https://github.com/alphagov/whitehall/pull/6221.