### PR TITLE
Skip S3 healthcheck for Whitehall Frontend

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -808,6 +808,7 @@ services:
       SENTRY_CURRENT_ENV: whitehall-frontend
       LOG_PATH: log/frontend.log
       REDIS_URL: redis://redis
+      SKIP_S3_HEALTHCHECK_FOR_PUBLISHING_E2E_TESTS: "true"
 
   draft-whitehall-frontend:
     << : *whitehall
@@ -819,6 +820,7 @@ services:
       SENTRY_CURRENT_ENV: draft-whitehall-frontend
       LOG_PATH: log/draft-frontend.log
       REDIS_URL: redis://redis
+      SKIP_S3_HEALTHCHECK_FOR_PUBLISHING_E2E_TESTS: "true"
 
   whitehall-worker:
     << : *whitehall


### PR DESCRIPTION
Adding this environment variable [1] for Whitehall Admin did work for
skipping the S3 check [2] but didn't get inherited to Whitehall Frontend
or Draft Whitehall Frontend as I previously thought would happend (<<)
[3].

This commit adds the missing env variables so the healthcheck doesn't
run for the other instances of Whitehall.

Error message:

```
17:45:38  bundle exec rake docker:wait_for_apps
17:47:30  rake aborted!
17:47:30  Container(s) draft-whitehall-frontend,whitehall-frontend were unhealthy after 60 seconds
```

[1]: https://github.com/alphagov/publishing-e2e-tests/pull/424
[2]: https://github.com/alphagov/whitehall/pull/6203
[3]: https://github.com/alphagov/publishing-e2e-tests/blob/9b6488caa6f631a5336e8bd52b709183ae5c4a18/docker-compose.yml#L802