### PR TITLE
Remove S3 healthcheck flag from Whitehall

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -782,7 +782,6 @@ services:
       SENTRY_CURRENT_ENV: whitehall-admin
       LOG_PATH: log/admin.log
       REDIS_URL: redis://redis
-      SKIP_S3_HEALTHCHECK_FOR_PUBLISHING_E2E_TESTS: "true"
     healthcheck:
       << : *default-healthcheck
     links:
@@ -808,7 +807,6 @@ services:
       SENTRY_CURRENT_ENV: whitehall-frontend
       LOG_PATH: log/frontend.log
       REDIS_URL: redis://redis
-      SKIP_S3_HEALTHCHECK_FOR_PUBLISHING_E2E_TESTS: "true"
 
   draft-whitehall-frontend:
     << : *whitehall
@@ -820,7 +818,6 @@ services:
       SENTRY_CURRENT_ENV: draft-whitehall-frontend
       LOG_PATH: log/draft-frontend.log
       REDIS_URL: redis://redis
-      SKIP_S3_HEALTHCHECK_FOR_PUBLISHING_E2E_TESTS: "true"
 
   whitehall-worker:
     << : *whitehall


### PR DESCRIPTION
This was initially added to prevent the S3 healthcheck from running
during the E2E tests as S3 isn't available for these tests. However, an
alternative approach using just one environment variable for the
Whitehall Backend instances has been implemented instead
(https://github.com/alphagov/govuk-puppet/pull/11232).

Dependant on:

- [x] https://github.com/alphagov/whitehall/pull/6228