### PR TITLE
Update selector for Content Tagger select2 upgrade

### DIFF
--- a/spec/content_tagger/adding_taxon_to_external_content_spec.rb
+++ b/spec/content_tagger/adding_taxon_to_external_content_spec.rb
@@ -40,7 +40,7 @@ feature "Adding a taxon to external content", collections: true, content_tagger:
     wait_for_artefact_to_be_viewable(@published_guide_url)
     reload_url_until_status_code(@taxon_url, 200)
     visit_tag_external_content_page(slug: guide_slug)
-    select2(taxon_title, css: "#s2id_tagging_tagging_update_form_taxons")
+    select2(taxon_title, css: "[data-select2-id='1']")
     click_button "Update tagging"
   end
 


### PR DESCRIPTION
In https://github.com/alphagov/content-tagger/pull/1234, we have upgraded `select2-rails`. The updated version no longer applies `s2_id` prefixed IDs to the elements.

Changing the selector to use an attribute instead, to allow this test to function.

[Trello card](https://trello.com/c/V56Gndqj/2629-investigate-fix-dependabot-not-raising-rails-61-prs-3)