### PR TITLE
Download one copy of Chrome per parallel worker

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -114,6 +114,8 @@ RSpec.configure do |config|
   config.add_setting :reload_page_wait_time, default: 60
 end
 
+Webdrivers.install_dir = File.expand_path("~/.webdrivers/#{ENV['TEST_ENV_NUMBER']}")
+
 Capybara.register_driver :headless_chrome do |app|
   chrome_options = Selenium::WebDriver::Chrome::Options.new
   chrome_options.headless!


### PR DESCRIPTION
We've started seeing the error

    ChildProcess::LaunchError:
      Text file busy - /root/.webdrivers/chromedriver

Which sounds a lot like
https://github.com/titusfortner/webdrivers/issues/77, but that fix was
applied in 2019 and it solved the issues we had then.  This is a new
occurrence, possibly related to a new version of Chrome (as one came
out recently).

Downloading one copy of chrome for each test runner isn't great, but
it's acceptable if it fixes the issue.

---

The failure is nondeterministic, but 10 builds of this branch in a row have passed, so I think it's a solution.