### PR TITLE
Change publisher-worker to run Sidekiq directly

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -614,7 +614,7 @@ services:
 
   publisher-worker:
     << : *publisher
-    command: foreman run worker
+    command: bundle exec sidekiq -C config/sidekiq.yml
     depends_on:
       - redis
       - publishing-api


### PR DESCRIPTION
This PR changes publisher-worker to run Sidekiq directly. The reasoning behind this change is that Publisher is part of the initial subset of apps that are being replatformed to Kubernetes and we have removed Foreman as the process runner, instead favouring to run Puma directly; for this reason, the E2E tests will not run in their current state relying on Foreman, so we instead just use the command directly from the app Procfile for the publisher-worker.

Once we replatform all of the other apps to Kubernetes, we will update E2E tests to remove the use of Foreman for them; they aren't being included in this commit as the sooner we make the change, the longer we have before fully moving to Kubernetes where a change could be made to an app's Procfile and not be reflected in E2E tests, potentially causing confusion.

[Trello card](https://trello.com/c/irrbEFMV/668)