### PR TITLE
Specify the PORT env var for frontend.

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -639,6 +639,7 @@ services:
     environment:
       << : *govuk-app
       ASSET_HOST: frontend.dev.gov.uk
+      PORT: 3005
       SENTRY_CURRENT_ENV: frontend
       VIRTUAL_HOST: frontend.dev.gov.uk
     healthcheck:


### PR DESCRIPTION
This will be needed in order to work with the refactored Dockerfile in alphagov/frontend. It also makes sense to specify the port here anyway.

[Trello card](https://trello.com/c/I0G4i2ck/702)