### PR TITLE
Add additional environment variables for Publisher

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -599,6 +599,10 @@ services:
       SENTRY_CURRENT_ENV: publisher
       VIRTUAL_HOST: publisher.dev.gov.uk
       GOVUK_CONTENT_SCHEMAS_PATH: /govuk-content-schemas/
+      MONGODB_URI: mongodb://mongo/govuk_content_development
+      TEST_MONGODB_URI: mongodb://mongo/govuk_content_development-test
+      PORT: 3000
+      ASSETS_PREFIX: /assets/publisher
     healthcheck:
       << : *default-healthcheck
     volumes:


### PR DESCRIPTION
This PR adds some additional environment variables for Publisher within the `docker-compose.yml`. These environment variables are necessary after refactoring Publisher's Dockerfile in https://github.com/alphagov/publisher/pull/1519, removing some of these environment variables from the image where they don't need to be and instead setting them on an environment-specific basis.

Trello: https://trello.com/c/I0G4i2ck