### PR TITLE
Set some required environment variables for content-store.

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -279,7 +279,10 @@ services:
       - diet-error-handler
     environment:
       << : *govuk-app
+      GOVUK_CONTENT_SCHEMAS_PATH: /govuk-content-schemas
       MONGO_WRITE_CONCERN: 1
+      MONGODB_URI: mongodb://mongo/content-store
+      PORT: 3068
       SENTRY_CURRENT_ENV: content-store
       VIRTUAL_HOST: content-store.dev.gov.uk
     links:
@@ -299,8 +302,9 @@ services:
       - diet-error-handler
     environment:
       << : *draft-govuk-app
-      MONGO_WRITE_CONCERN: 1
       GOVUK_APP_NAME: draft-content-store
+      GOVUK_CONTENT_SCHEMAS_PATH: /govuk-content-schemas
+      MONGO_WRITE_CONCERN: 1
       MONGODB_URI: mongodb://mongo/draft-content-store
       PORT: 3100
       SENTRY_CURRENT_ENV: draft-content-store


### PR DESCRIPTION
`GOVUK_CONTENT_SCHEMAS_PATH`, `MONGODB_URI` and `PORT` were previously set in the Dockerfile, but they don't belong there because they need to be defined by the container orchestration system. For example, `GOVUK_CONTENT_SCHEMAS_PATH` would typically relate to a mount point configured in a Pod spec or a docker-compose manifest.

These variables were removed from the content-store's Dockerfile in alphagov/content-store@18c3b6d.

Tested:

- With content-store:deployed-to-production image: https://ci.integration.publishing.service.gov.uk/job/publishing-e2e-tests/job/sengi%252Ffix-content-store-env/2/
- With content-store image built from alphagov/content-store@18c3b6d ([sengi/multistage-docker branch](https://github.com/alphagov/content-store/tree/sengi/multistage-docker)): https://ci.integration.publishing.service.gov.uk/job/publishing-e2e-tests/job/sengi%252Ffix-content-store-env/4/