### PR TITLE
Use Postgres 13 to match production infrastructure

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -36,7 +36,7 @@ services:
       - ./docker/nginx.tmpl:/app/nginx.tmpl
 
   postgres:
-    image: postgres:9.6
+    image: postgres:13
     environment:
       POSTGRES_PASSWORD: postgres
     healthcheck:


### PR DESCRIPTION
Now that our apps are using Postgres 13 in production, we need to update the End-to-End test suite to also use Postgres 13 when spinning up its production-like environment in Docker.

Trello: https://trello.com/c/OAXlOC6H/89-update-publishing-e2e-tests-to-use-upgraded-postgresql-db-version