### PR TITLE
Switch MySQL to use version 8

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -47,7 +47,8 @@ services:
     image: memcached:alpine
 
   mysql:
-    image: mysql:5.5.58
+    image: mysql:8
+    command: --default-authentication-plugin=mysql_native_password
     environment:
       MYSQL_ROOT_PASSWORD: root
     healthcheck:


### PR DESCRIPTION
Trello: https://trello.com/c/Pr1YPLbE/37-update-publishing-e2e-tests-to-use-upgraded-mysql-db-versions

All GOV.UK MySQL applications are now running with version 8 rather than
MySQL 5.5.

This adds the line to use the mysql_native_password authentication
approach, this has been added so that clients can continue to
authenticate with this server - which does not work without it:

```
14:52:17  RSA Encryption not supported - caching_sha2_password plugin was built with GnuTLS support
14:52:17  Couldn't drop database 'whitehall_development'
14:52:17  rake aborted!
14:52:17  ActiveRecord::ConnectionNotEstablished: RSA Encryption not supported - caching_sha2_password plugin was built with GnuTLS support
14:52:17
   /usr/local/bundle/gems/activerecord-6.1.4.4/lib/active_record/connection_adapters/mysql2_adapter.rb:45:in
   `rescue in new_client'`
```

From learning about `caching_sha2_password` [1] I understand that two
factors need to be in place to use the new authentication system: 1)
client library supports it and 2) that TLS/RSA key/socket connection as
used. In this test suite the connection to the database is done over an
unencrypted HTTP connection without RSA keys, which means - even if the
clients fully support `caching_sha2_password` - we still can't use it.

[1]: https://dev.mysql.com/doc/refman/8.0/en/upgrading-from-previous-series.html#upgrade-caching-sha2-password