### PR TITLE
Set-up switching from master to main branch

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,22 +2,17 @@
 
 This guide covers the basics for contributing to this project.
 
-- [Coding/commit style](#codingcommit-style)
+- [Coding style](#coding-style)
 - [Adding new tests](#adding-new-tests)
 - [Dealing with flaky tests](#dealing-with-flaky-tests)
 - [Testing new applications](#testing-new-applications)
 
-## Coding/commit style
-
-Code and commits should be written in styles conforming to the GDS
-[Ruby][ruby-styleguide] and [Git][git-styleguide] styleguides.
+## Coding style
 
 The feature tests are written in a style consistent with this article:
 [How we write readable feature tests with rspec][readable-feature-tests].
 
 [readable-feature-tests]: https://about.futurelearn.com/blog/how-we-write-readable-feature-tests-with-rspec
-[ruby-styleguide]: https://github.com/alphagov/styleguides/blob/master/ruby.md
-[git-styleguide]: https://github.com/alphagov/styleguides/blob/master/git.md
 
 ## Adding new tests
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -265,7 +265,7 @@ def runTests(params, testStatus) {
 }
 
 def pushTestAgainstBranch() {
-  if (env.BRANCH_NAME == "master") {
+  if (env.BRANCH_NAME == "main") {
     echo 'Pushing to test-against branch'
     sshagent(['govuk-ci-ssh-key']) {
       sh("git push git@github.com:alphagov/publishing-e2e-tests.git HEAD:refs/heads/test-against --force")
@@ -311,8 +311,8 @@ def stopDocker() {
 def alertTestOutcome(params, testStatus) {
   def channel = "#govuk-e2e-tests"
   // post to slack just when it's an important branch
-  if (env.BRANCH_NAME == "master" && (testStatus.mainFailed || testStatus.startUpFailed)) {
-    def message = "Publishing end-to-end tests <${BUILD_URL}|failed> for master branch, changes not pushed to test-against"
+  if (env.BRANCH_NAME == "main" && (testStatus.mainFailed || testStatus.startUpFailed)) {
+    def message = "Publishing end-to-end tests <${BUILD_URL}|failed> for main branch, changes not pushed to test-against"
     slackSend(color: "#d40100", channel: channel, message: message)
   } else if (env.BRANCH_NAME == "test-against" && testStatus.startUpFailed) {
     def message = "Publishing end-to-end tests start up <${BUILD_URL}|failed> for $NODE_NAME"
@@ -328,7 +328,7 @@ def alertTestOutcome(params, testStatus) {
   }
 
   if (testStatus.mainFailed) {
-    def guideUrl = "https://github.com/alphagov/publishing-e2e-tests/blob/master/CONTRIBUTING.md#dealing-with-flaky-tests"
+    def guideUrl = "https://github.com/alphagov/publishing-e2e-tests/blob/main/CONTRIBUTING.md#dealing-with-flaky-tests"
     currentBuild.description = "<p style=\"color: red\">Is the failure unrelated to your change?</p>" +
                                "<p>We have <a href=\"${guideUrl}\">flaky test advice available</a> to help.</p>"
   }

--- a/docs/breaking-app-change.md
+++ b/docs/breaking-app-change.md
@@ -37,8 +37,8 @@ against your change.
 4. Deploy your application change to production as you would normally,
    waiting for deployed-to-production to be updated.
 
-5. Merge your E2E tests change into master branch. This will trigger the
-   master build which also updates the test-against branch.  Once test-against
+5. Merge your E2E tests change into main branch. This will trigger the
+   main build which also updates the test-against branch.  Once test-against
    branch is updated any subsequent test runs will use both your updated tests
    and your updated application code on deployed-to-production.
 

--- a/docs/what-belongs-in-these-tests.md
+++ b/docs/what-belongs-in-these-tests.md
@@ -42,4 +42,4 @@ for more testing insights.
 [testing-ice-cream-cone]: http://saeedgatson.com/the-software-testing-ice-cream-cone/
 [contract-tested]: https://martinfowler.com/articles/consumerDrivenContracts.html
 [pact]: https://docs.pact.io/
-[whitehall-testing-guide]: https://github.com/alphagov/whitehall/blob/master/docs/testing_guide.md
+[whitehall-testing-guide]: https://github.com/alphagov/whitehall/blob/099f53e35cdd0ea63a2349be3766c98e65521ce3/docs/testing.md


### PR DESCRIPTION
Trello: https://trello.com/c/Pr1YPLbE/37-update-publishing-e2e-tests-to-use-upgraded-mysql-db-versions

This repo is one of the few GOV.UK ones that still uses a master branch rather than a main. This PR makes changes, and some loosely related fixes, to enable that.