### PR TITLE
updated docker-compose for collections

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -491,6 +491,7 @@ services:
       << : *govuk-app
       SENTRY_CURRENT_ENV: collections
       VIRTUAL_HOST: collections.dev.gov.uk
+      PORT: 3070
     links:
       - nginx-proxy:search-api.dev.gov.uk
       - nginx-proxy:content-store.dev.gov.uk


### PR DESCRIPTION
added port number to collections to tie in with removing it from the docker file in collections as part of https://github.com/alphagov/collections/pull/2646