### PR TITLE
Call Sidekiq directly (replacing foreman) for some apps

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -341,7 +341,7 @@ services:
 
   publishing-api-worker:
     << : *publishing-api
-    command: foreman run worker
+    command: bundle exec sidekiq -C ./config/sidekiq.yml
     depends_on:
       - postgres
       - redis
@@ -424,7 +424,7 @@ services:
 
   travel-advice-publisher-worker:
     << : *travel-advice-publisher
-    command: foreman run worker
+    command: bundle exec sidekiq -C ./config/sidekiq.yml
     depends_on:
       - publishing-api
       - redis
@@ -466,7 +466,7 @@ services:
 
   collections-publisher-worker:
     << : *collections-publisher
-    command: foreman run worker
+    command: bundle exec sidekiq -C ./config/sidekiq.yml
     depends_on:
       - publishing-api
       - diet-error-handler
@@ -715,7 +715,7 @@ services:
 
   manuals-publisher-worker:
     << : *manuals-publisher
-    command: foreman run worker
+    command: bundle exec sidekiq -C ./config/sidekiq.yml
     depends_on:
       - publishing-api
       - redis
@@ -968,7 +968,7 @@ services:
 
   email-alert-api-worker:
     << : *email-alert-api
-    command: foreman run worker
+    command: bundle exec sidekiq -C ./config/sidekiq.yml
     depends_on:
       - diet-error-handler
       - redis


### PR DESCRIPTION
This will enable us to drop `foreman` as a dependency when building the container images for these apps.

I've kept in search-api as there are a fair few commands in the Procfile, but we could replace those too.