### PR TITLE
Skip failing change note test

### DIFF
--- a/spec/specialist_publisher/change_note_spec.rb
+++ b/spec/specialist_publisher/change_note_spec.rb
@@ -37,7 +37,7 @@ feature "Change notes on Specialist Publisher", specialist_publisher: true, gove
     click_link("Edit document")
 
     fill_in("Body", with: new_body)
-    choose("Update type major")
+    choose("Major")
     fill_in("Change note", with: change_note)
 
     click_button("Save as draft")


### PR DESCRIPTION
This is failing due to some UI changes on Specialist Publisher and is causing the build to fail https://ci.integration.publishing.service.gov.uk/job/publishing-e2e-tests/job/test-against/64659/console
