### PR TITLE
Add PORT env to manuals-frontend in docker-compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -741,6 +741,7 @@ services:
       ASSET_HOST: manuals-frontend.dev.gov.uk
       SENTRY_CURRENT_ENV: manuals-frontend
       VIRTUAL_HOST: manuals-frontend.dev.gov.uk
+      PORT: 3072
     links:
       - nginx-proxy:content-store.dev.gov.uk
       - nginx-proxy:static.dev.gov.uk


### PR DESCRIPTION
We are removing the PORT env from the manuals-frontend dockerfile,
hence we need to add it here in the docker-compose file so that
the publishing-e2e-tests still works.

Ref:
1. [manuals frontend pr](https://github.com/alphagov/manuals-frontend/pull/1267)
2. [trello card](https://trello.com/c/dP4vi19p/835-package-manuals-frontend-for-migration)