### PR TITLE
Add Frontend as a dependency of Publisher

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -590,6 +590,7 @@ services:
       context: apps/publisher
     depends_on:
       - publishing-api
+      - frontend
       - publisher-worker
       - diet-error-handler
       - redis


### PR DESCRIPTION
Publisher uses the Calendars API to serve some pages, which is served by Frontend.