### PR TITLE
Add frontend Nginx to publisher links 

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -614,6 +614,7 @@ services:
       - apps/govuk-content-schemas/:/govuk-content-schemas/
     links:
       - nginx-proxy:publishing-api.dev.gov.uk
+      - nginx-proxy:frontend.dev.gov.uk
       - nginx-proxy:error-handler.dev.gov.uk
       - nginx-proxy:www.dev.gov.uk
     ports:


### PR DESCRIPTION
E2E tests are [failing for publisher](https://ci.integration.publishing.service.gov.uk/job/publishing-e2e-tests/job/test-against/64950/) and it looks like we need to provide a Frontend Nginx in order for `frontend.dev.gov.uk` to be reachable by publisher in the test suite.