### PR TITLE
Revert "Add Frontend as a dependency of Publisher"

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -590,7 +590,6 @@ services:
       context: apps/publisher
     depends_on:
       - publishing-api
-      - frontend
       - publisher-worker
       - diet-error-handler
       - redis


### PR DESCRIPTION
After discussing with @kevindew we have decided to continue consuming these APIs via the public endpoint rather than using an internal endpoint.

The reasoning is that we prefer all requests to frontend applications to go through Fastly and router. This is particularly useful because Fastly caches requests to the APIs, and we have seen an incident in the past where these APIs could not handle high volumes of requests (and so require caching). We believe these APIs should probably not be served by frontend apps, and instead should be served by a different backend service, but this is out of scope of the replatforming project.

Reverts alphagov/publishing-e2e-tests#451