### PR TITLE
Update database schema loading for contacts-admin

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -120,7 +120,7 @@ wait_for_whitehall_admin:
 contacts_admin_setup:
 	# Because someone made the rather bizarre decision that Whitehall needs to be
 	# running to seed the contacts admin database we have to do this in 2-steps
-	$(DOCKER_COMPOSE_CMD) run --rm --no-deps contacts-admin bundle exec rake db:drop db:schema:load_if_ruby db:structure:load_if_sql
+	$(DOCKER_COMPOSE_CMD) run --rm --no-deps contacts-admin bundle exec rake db:drop db:create db:schema:load
 
 contacts_admin_seed: wait_for_whitehall_admin
 	# Contacts Admin seeds from the organisations API, which is rendered by


### PR DESCRIPTION
In Rails 7, the `db:schema:load_if_ruby` and `db:structure:load_if_sql` rake tasks [have been deprecated](https://github.com/rails/rails/commit/cf269d51fbc4758cb6ae0110c6c151546c0889d9).

Therefore replacing with `db:create db:schema:load`.

We cannot use `db:setup` here as contacts-admin requires the seeding to take place after Whitehall has been set up.

[Trello card](https://trello.com/c/nmJc03Gd/249-upgrade-contacts-admin-from-rails-61x-to-70x)