### PR TITLE
Use Mongo 3.6 rather than 3.4 and cleanup Mongo config inconsistencies

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -52,7 +52,7 @@ build: kill
 	$(DOCKER_COMPOSE_CMD) build --pull diet-error-handler publishing-e2e-tests $(APPS_TO_BUILD)
 
 setup_dependencies:
-	$(DOCKER_COMPOSE_CMD) up -d elasticsearch6 memcached mongo mongo-2.6 mysql postgres rabbitmq redis
+	$(DOCKER_COMPOSE_CMD) up -d elasticsearch6 memcached mongo-2.6 mongo-3.6 mysql postgres rabbitmq redis
 	bundle exec rake docker:wait_for_dbs
 	$(MAKE) setup_dbs
 	bundle exec rake docker:wait_for_rabbitmq

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -604,7 +604,7 @@ services:
       SENTRY_CURRENT_ENV: publisher
       VIRTUAL_HOST: publisher.dev.gov.uk
       GOVUK_CONTENT_SCHEMAS_PATH: /govuk-content-schemas/
-      MONGODB_URI: mongodb://mongo-3.6/govuk_content_development
+      MONGODB_URI: mongodb://mongo-3.6/publisher
       PORT: 3000
       ASSETS_PREFIX: /assets/publisher
     healthcheck:
@@ -629,7 +629,7 @@ services:
       - diet-error-handler
     environment:
       << : *govuk-app
-      MONGODB_URI: mongodb://mongo-3.6/govuk_content_development
+      MONGODB_URI: mongodb://mongo-3.6/publisher
       REDIS_URL: redis://redis
       SENTRY_CURRENT_ENV: publisher-worker
     healthcheck:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -426,6 +426,7 @@ services:
     << : *travel-advice-publisher
     command: bundle exec sidekiq -C ./config/sidekiq.yml
     depends_on:
+      - mongo-3.6
       - publishing-api
       - redis
       - diet-error-handler
@@ -624,6 +625,7 @@ services:
     << : *publisher
     command: bundle exec sidekiq -C config/sidekiq.yml
     depends_on:
+      - mongo-3.6
       - redis
       - publishing-api
       - diet-error-handler
@@ -719,6 +721,7 @@ services:
     << : *manuals-publisher
     command: bundle exec sidekiq -C ./config/sidekiq.yml
     depends_on:
+      - mongo-3.6
       - publishing-api
       - redis
       - diet-error-handler
@@ -931,6 +934,7 @@ services:
     << : *asset-manager
     command: bundle exec sidekiq -C config/sidekiq.yml
     depends_on:
+      - mongo-3.6
       - diet-error-handler
       - redis
     environment:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -56,7 +56,7 @@ services:
       test: "mysql --user=root --password=root -e 'SELECT 1'"
 
   mongo:
-    image: mongo:3.4
+    image: mongo:3.6
     healthcheck:
       << : *default-healthcheck
       test: "echo 'db.stats().ok' | mongo localhost:27017/test --quiet"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -243,7 +243,6 @@ services:
       SENTRY_CURRENT_ENV: router-api
       VIRTUAL_HOST: router-api.dev.gov.uk
       MONGODB_URI: mongodb://mongo-2.6/router
-      TEST_MONGODB_URI: mongodb://mongo-2.6/router-test
     links:
       - nginx-proxy:error-handler.dev.gov.uk
     ports:
@@ -264,7 +263,6 @@ services:
       PORT: 3156
       ROUTER_NODES: "draft-router:3155"
       SENTRY_CURRENT_ENV: draft-router-api
-      TEST_MONGODB_URI: mongodb://mongo-2.6/draft-router-test
       VIRTUAL_HOST: draft-router-api.dev.gov.uk
     links:
       - nginx-proxy:error-handler.dev.gov.uk
@@ -604,7 +602,6 @@ services:
       VIRTUAL_HOST: publisher.dev.gov.uk
       GOVUK_CONTENT_SCHEMAS_PATH: /govuk-content-schemas/
       MONGODB_URI: mongodb://mongo/govuk_content_development
-      TEST_MONGODB_URI: mongodb://mongo/govuk_content_development-test
       PORT: 3000
       ASSETS_PREFIX: /assets/publisher
     healthcheck:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -273,13 +273,13 @@ services:
     image: govuk/content-store:${CONTENT_STORE_COMMITISH:-deployed-to-production}
     build: apps/content-store
     depends_on:
-      - mongo
+      - mongo-2.6
       - router-api
       - diet-error-handler
     environment:
       << : *govuk-app
       MONGO_WRITE_CONCERN: 1
-      MONGODB_URI: mongodb://mongo/content-store
+      MONGODB_URI: mongodb://mongo-2.6/content-store
       PORT: 3068
       SENTRY_CURRENT_ENV: content-store
       VIRTUAL_HOST: content-store.dev.gov.uk
@@ -295,14 +295,14 @@ services:
   draft-content-store:
     << : *content-store
     depends_on:
-      - mongo
+      - mongo-2.6
       - draft-router-api
       - diet-error-handler
     environment:
       << : *draft-govuk-app
       GOVUK_APP_NAME: draft-content-store
       MONGO_WRITE_CONCERN: 1
-      MONGODB_URI: mongodb://mongo/draft-content-store
+      MONGODB_URI: mongodb://mongo-2.6/draft-content-store
       PORT: 3100
       SENTRY_CURRENT_ENV: draft-content-store
       VIRTUAL_HOST: draft-content-store.dev.gov.uk

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -55,7 +55,7 @@ services:
       << : *default-healthcheck
       test: "mysql --user=root --password=root -e 'SELECT 1'"
 
-  mongo:
+  mongo-3.6:
     image: mongo:3.6
     healthcheck:
       << : *default-healthcheck
@@ -367,7 +367,7 @@ services:
     build:
       context: apps/specialist-publisher
     depends_on:
-      - mongo
+      - mongo-3.6
       - redis
       - publishing-api
       - asset-manager
@@ -394,7 +394,7 @@ services:
     build:
       context: apps/travel-advice-publisher
     depends_on:
-      - mongo
+      - mongo-3.6
       - redis
       - publishing-api
       - asset-manager
@@ -591,7 +591,7 @@ services:
       - publisher-worker
       - diet-error-handler
       - redis
-      - mongo
+      - mongo-3.6
       - router
     environment:
       << : *govuk-app
@@ -601,7 +601,7 @@ services:
       SENTRY_CURRENT_ENV: publisher
       VIRTUAL_HOST: publisher.dev.gov.uk
       GOVUK_CONTENT_SCHEMAS_PATH: /govuk-content-schemas/
-      MONGODB_URI: mongodb://mongo/govuk_content_development
+      MONGODB_URI: mongodb://mongo-3.6/govuk_content_development
       PORT: 3000
       ASSETS_PREFIX: /assets/publisher
     healthcheck:
@@ -687,7 +687,7 @@ services:
       - collections
       - diet-error-handler
       - manuals-publisher-worker
-      - mongo
+      - mongo-3.6
       - publishing-api
       - redis
       - router
@@ -898,7 +898,7 @@ services:
     depends_on:
       - asset-manager-worker
       - diet-error-handler
-      - mongo
+      - mongo-3.6
       - redis
     links:
       - nginx-proxy:error-handler.dev.gov.uk
@@ -910,7 +910,7 @@ services:
       VIRTUAL_HOST: asset-manager.dev.gov.uk
       FAKE_S3_HOST: http://127.0.0.1
       ALLOW_FAKE_S3_IN_PRODUCTION_FOR_PUBLISHING_E2E_TESTS: "true"
-      MONGODB_URI: mongodb://mongo/asset-manager
+      MONGODB_URI: mongodb://mongo-3.6/asset-manager
       PORT: 3037
     healthcheck:
       << : *default-healthcheck
@@ -934,7 +934,7 @@ services:
       SENTRY_CURRENT_ENV: asset-manager-worker
       FAKE_S3_HOST: http://127.0.0.1
       ALLOW_FAKE_S3_IN_PRODUCTION_FOR_PUBLISHING_E2E_TESTS: "true"
-      MONGODB_URI: mongodb://mongo/asset-manager
+      MONGODB_URI: mongodb://mongo-3.6/asset-manager
       PORT: 3037
     healthcheck:
       disable: true

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -375,6 +375,7 @@ services:
     environment:
       << : *govuk-app
       MONGO_WRITE_CONCERN: 1
+      MONGODB_URI: mongodb://mongo-3.6/specialist-publisher
       REDIS_URL: redis://redis
       SENTRY_CURRENT_ENV: specialist-publisher
       VIRTUAL_HOST: specialist-publisher.dev.gov.uk
@@ -404,6 +405,7 @@ services:
       - diet-error-handler
     environment:
       << : *govuk-app
+      MONGODB_URI: mongodb://mongo-3.6/travel-advice-publisher
       SENTRY_CURRENT_ENV: travel-advice-publisher
       REDIS_URL: redis://redis
       VIRTUAL_HOST: travel-advice-publisher.dev.gov.uk
@@ -431,6 +433,7 @@ services:
       disable: true
     environment:
       << : *govuk-app
+      MONGODB_URI: mongodb://mongo-3.6/travel-advice-publisher
       REDIS_URL: redis://redis
       SENTRY_CURRENT_ENV: travel-advice-publisher-worker
     ports: []
@@ -626,6 +629,7 @@ services:
       - diet-error-handler
     environment:
       << : *govuk-app
+      MONGODB_URI: mongodb://mongo-3.6/govuk_content_development
       REDIS_URL: redis://redis
       SENTRY_CURRENT_ENV: publisher-worker
     healthcheck:
@@ -695,6 +699,7 @@ services:
       - whitehall-admin
     environment:
       << : *govuk-app
+      MONGODB_URI: mongodb://mongo-3.6/manuals-publisher
       REDIS_URL: redis://redis
       SENTRY_CURRENT_ENV: manuals-publisher
       VIRTUAL_HOST: manuals-publisher.dev.gov.uk
@@ -719,6 +724,7 @@ services:
       - diet-error-handler
     environment:
       << : *govuk-app
+      MONGODB_URI: mongodb://mongo-3.6/manuals-publisher
       REDIS_URL: redis://redis
       SENTRY_CURRENT_ENV: manuals-publisher-worker
     healthcheck:

--- a/lib/tasks/docker.rake
+++ b/lib/tasks/docker.rake
@@ -3,7 +3,7 @@ require_relative "../docker_service"
 namespace :docker do
   desc "Wait until database containers are indicating they are healthy"
   task :wait_for_dbs do
-    DockerService.wait_for_healthy_services(services: %w[elasticsearch6 mongo mongo-2.6 mysql postgres redis])
+    DockerService.wait_for_healthy_services(services: %w[elasticsearch6 mongo-2.6 mongo-3.6 mysql postgres redis])
   end
 
   desc "Wait for the RabbitMQ container to indicate it is healthy"


### PR DESCRIPTION
The MongoDB version defined in these tests is behind the version used in GOV.UK production code (v3.6 via DocumentDB). This updates Mongo to 3.6 to apply this.

It also updates the config approach of Mongo 3.6 to match Mongo 2.6, which has been inconsistent since 2.6 was introduced in https://github.com/alphagov/publishing-e2e-tests/commit/61d401e23e87ec91268568649f3dca3725d25c15 and adds environment variables that are now needed for it. It also fixes some config misses that didn't seem to cause problems but could under certain circumstances.

This is easiest reviewed commit-by-commit.