### PR TITLE
remove foreman from search-api-*

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -126,7 +126,7 @@ services:
       - publishing-api
       - diet-error-handler
       - redis
-    command: foreman run worker
+    command: bundle exec sidekiq -C ./config/sidekiq.yml
     environment:
       << : *govuk-app
       RACK_ENV: production
@@ -139,7 +139,7 @@ services:
 
   search-api-listener-publishing-queue:
     << : *search-api
-    command: foreman run publishing-queue-listener
+    command: bundle exec rake message_queue:listen_to_publishing_queue
     depends_on:
       - diet-error-handler
       - rabbitmq
@@ -153,7 +153,7 @@ services:
 
   search-api-listener-insert-data:
     << : *search-api
-    command: foreman run govuk-index-queue-listener
+    command: bundle exec rake message_queue:insert_data_into_govuk
     depends_on:
       - diet-error-handler
       - rabbitmq
@@ -167,7 +167,7 @@ services:
 
   search-api-listener-bulk-insert-data:
     << : *search-api
-    command: foreman run bulk-reindex-queue-listener
+    command: bundle exec rake message_queue:bulk_insert_data_into_govuk
     depends_on:
       - diet-error-handler
       - rabbitmq


### PR DESCRIPTION
Remove foreman command from search-api-* containers since this is removed from its Dockerfile (see [pr](https://github.com/alphagov/search-api/pull/2367)).

The `foreman` commands are replaced by their direct equivalent `bundle exec` commands directly as found in [here](https://github.com/alphagov/search-api/blob/main/Procfile)