### PR TITLE
Enable file logging for search-api after default logging change

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -35,6 +35,7 @@ x-search-api-env: &search-api-env
   RABBITMQ_PASSWORD: guest
   RACK_ENV: production
   REDIS_URL: redis://redis
+  LOG_TO_STDOUT: "false"
 
 services:
   nginx-proxy:


### PR DESCRIPTION
In [PR](https://github.com/alphagov/search-api/pull/2371), the
Dockerfile of search-api was changed so that stdout is the default
logging destination. This is needed for EKS platform.

In order to keep the same behaviour in the publishing-e2e tests,
we enable file logging again here.