### PR TITLE
Add removed env vars from router-api Dockerfile

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -248,6 +248,7 @@ services:
       SENTRY_CURRENT_ENV: router-api
       VIRTUAL_HOST: router-api.dev.gov.uk
       MONGODB_URI: mongodb://mongo-2.6/router
+      TEST_MONGODB_URI: mongodb://mongo/router-test
     links:
       - nginx-proxy:error-handler.dev.gov.uk
     ports:
@@ -265,6 +266,7 @@ services:
       << : *draft-govuk-app
       GOVUK_APP_NAME: draft-router-api
       MONGODB_URI: mongodb://mongo-2.6/draft-router
+      TEST_MONGODB_URI: mongodb://mongo/router-test
       PORT: 3156
       ROUTER_NODES: "draft-router:3155"
       SENTRY_CURRENT_ENV: draft-router-api


### PR DESCRIPTION
Some env vars were removed from router-api Dockerfile because they
should not default to that. We add them back to the publishing-e2e
docker-compose so that the test continues to work.

Ref:
1. [trello card](https://trello.com/c/UHJvZubq/828-package-router-api-for-migration)
2. [router-api pr](https://github.com/alphagov/router-api/pull/441)