### PR TITLE
Update mainstream topic tests

### DIFF
--- a/spec/collections_publisher/archiving_child_topic_spec.rb
+++ b/spec/collections_publisher/archiving_child_topic_spec.rb
@@ -28,9 +28,9 @@ private
 
   def and_i_archive_it
     click_link("Archive")
-    select2(parent_title, from: "Choose a specialist sector to redirect to")
+    select parent_title, from: "Choose a specialist sector to redirect to"
     click_button "Archive and redirect to a specialist sector"
-    expect(page).to have_text("archived")
+    expect(page).to have_text(/archived/i)
   end
 
   def then_when_i_visit_the_child_on_gov_uk_i_am_redirected_to_the_parent
@@ -69,8 +69,8 @@ private
   end
 
   def publish_topic
-    click_link("Publish")
-    expect(page).to have_text("published")
+    click_on("Publish")
+    expect(page).to have_text(/published/i)
   end
 
   def wait_for_the_child_to_redirect

--- a/spec/collections_publisher/publishing_parent_and_child_topic_spec.rb
+++ b/spec/collections_publisher/publishing_parent_and_child_topic_spec.rb
@@ -48,21 +48,23 @@ private
   end
 
   def and_i_publish_it
-    click_link("Publish")
-    expect(page).to have_text("published")
+    click_on("Publish")
+    expect(page).to have_text(/published/i)
   end
 
   def then_i_can_view_both_on_gov_uk
     url = find_link(link)[:href]
     reload_url_until_status_code(url, 200)
 
-    click_link(link)
-    expect_rendering_application("collections")
-    expect_url_matches_live_gov_uk
-    expect(page).to have_content(child_title)
+    window = window_opened_by { click_link(link) }
+    within_window(window) do
+      expect_rendering_application("collections")
+      expect_url_matches_live_gov_uk
+      expect(page).to have_content(child_title)
 
-    first(:link, parent_title).click
-    expect_url_matches_live_gov_uk
-    expect(current_url).to end_with(parent_slug)
+      first(:link, parent_title).click
+      expect_url_matches_live_gov_uk
+      expect(current_url).to end_with(parent_slug)
+    end
   end
 end

--- a/spec/support/collections_publisher_helpers.rb
+++ b/spec/support/collections_publisher_helpers.rb
@@ -4,7 +4,7 @@ module CollectionsPublisherHelpers
   end
 
   def fill_in_topic_form(slug:, title:, parent: nil)
-    select2(parent, from: "Parent") if parent
+    select parent, from: "Parent" if parent
 
     fill_in "Slug", with: slug
     fill_in "Title", with: title


### PR DESCRIPTION
As a result of us porting over Collections Publisher to use the GOV.UK Design System some of the E2E test need updating.

This involves getting rid of select2 and accounting for labels being added to states (published, draft etc.) Which gives them the visual presentation of being upcased.