### PR TITLE
Simpler set-up for Contacts Admin seeding

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -337,6 +337,9 @@ services:
       REDIS_URL: redis://redis
       SENTRY_CURRENT_ENV: publishing-api
       VIRTUAL_HOST: publishing-api.dev.gov.uk
+    healthcheck:
+      << : *default-healthcheck
+      test: "curl --silent --fail localhost:3093/healthcheck/live || exit 1"
     links:
       - nginx-proxy:error-handler.dev.gov.uk
     ports:

--- a/lib/tasks/docker.rake
+++ b/lib/tasks/docker.rake
@@ -16,11 +16,6 @@ namespace :docker do
     DockerService.wait_for_healthy_services(services: %w[publishing-api])
   end
 
-  desc "Wait for the Whitheall Admin container to indicate it is healthy"
-  task :wait_for_whitehall_admin do
-    DockerService.wait_for_healthy_services(services: %w[whitehall-admin], reload_seconds: 180)
-  end
-
   desc "Wait for all apps to indicate they are healthy"
   task :wait_for_apps do
     DockerService.wait_for_healthy_services(except: %w[publishing-e2e-tests])


### PR DESCRIPTION
https://github.com/alphagov/contacts-admin/pull/963 reduced the complexity involved in the `db:seed` operation for Contacts Admin (which, unusually, required API calls). This continues that work by removing the configuration complexity that was needed for that (publishing data in Whitehall, spinning up Router and collections apps).

More details in the commits.