### PR TITLE
Remove the Preview Design System permission for Travel Advice tests

### DIFF
--- a/spec/support/travel_advice_publisher_helpers.rb
+++ b/spec/support/travel_advice_publisher_helpers.rb
@@ -72,4 +72,10 @@ module TravelAdvicePublisherHelpers
     reload_url_until_status_code(url, 200)
     reload_url_until_match(url, :has_text?, ignore_quotes_regex(summary))
   end
+
+  def remove_preview_design_system_permission
+    # TODO: remove method when Travel Advice is fully ported over to the design
+    # system.
+    current_user.permissions.reject! { |permission| permission == "Preview Design System" }
+  end
 end

--- a/spec/travel_advice_publisher/creating_draft_spec.rb
+++ b/spec/travel_advice_publisher/creating_draft_spec.rb
@@ -23,6 +23,7 @@ feature "Creating a draft on Travel Advice Publisher", feature: true, travel_adv
 
   def when_i_create_a_draft_of_chad
     signin_to_signon if use_signon?
+    remove_preview_design_system_permission
     visit_travel_advice_publisher("/admin")
     click_link(country)
 

--- a/spec/travel_advice_publisher/creating_live_spec.rb
+++ b/spec/travel_advice_publisher/creating_live_spec.rb
@@ -18,6 +18,7 @@ feature "Creating a live edition on Travel Advice Publisher", feature: true, tra
 
   def when_i_create_a_live_edition_of_malta
     signin_to_signon if use_signon?
+    remove_preview_design_system_permission
     visit_travel_advice_publisher("/admin")
     click_link(country)
 

--- a/spec/travel_advice_publisher/upload_attachments_spec.rb
+++ b/spec/travel_advice_publisher/upload_attachments_spec.rb
@@ -23,6 +23,7 @@ feature "Upload attachments on Travel Advice Publisher", feature: true, travel_a
 
   def when_i_create_a_draft_of_congo
     signin_to_signon if use_signon?
+    remove_preview_design_system_permission
     visit_travel_advice_publisher("/admin")
     click_link(country)
 


### PR DESCRIPTION
The `Preview Design System` is added by default for Travel Advice users by the seed data. We are currently working on this bit of functionality behind a feature flag. Currently it's not ready for E2E tests and to be shipped.

Once ready we will port over the E2E tests to use the new flow. This commit ensures the existing flow that users see continues to be tested.