### PR TITLE
Remove Slack failure notifications for this repo

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -326,10 +326,4 @@ def alertTestOutcome(params, testStatus) {
     message += (params.ORIGIN_REPO) ? " for ${params.ORIGIN_REPO}" : ""
     slackSend(color: "#ffff94", channel: channel, message: message)
   }
-
-  if (testStatus.mainFailed) {
-    def guideUrl = "https://github.com/alphagov/publishing-e2e-tests/blob/main/CONTRIBUTING.md#dealing-with-flaky-tests"
-    currentBuild.description = "<p style=\"color: red\">Is the failure unrelated to your change?</p>" +
-                               "<p>We have <a href=\"${guideUrl}\">flaky test advice available</a> to help.</p>"
-  }
 }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -82,8 +82,6 @@ timestamps {
         throw e
       } finally {
         makeLogsAvailable()
-        alertTestOutcome(params, testStatus)
-
         stopDocker()
 
         // Docker leaves these owned by root which makes it difficult for
@@ -305,25 +303,5 @@ def makeLogsAvailable() {
 def stopDocker() {
   stage("Stop Docker") {
     sh("make stop")
-  }
-}
-
-def alertTestOutcome(params, testStatus) {
-  def channel = "#govuk-e2e-tests"
-  // post to slack just when it's an important branch
-  if (env.BRANCH_NAME == "main" && (testStatus.mainFailed || testStatus.startUpFailed)) {
-    def message = "Publishing end-to-end tests <${BUILD_URL}|failed> for main branch, changes not pushed to test-against"
-    slackSend(color: "#d40100", channel: channel, message: message)
-  } else if (env.BRANCH_NAME == "test-against" && testStatus.startUpFailed) {
-    def message = "Publishing end-to-end tests start up <${BUILD_URL}|failed> for $NODE_NAME"
-    slackSend(color: "#d40100", channel: channel, message: message)
-  } else if (env.BRANCH_NAME == "test-against" && testStatus.mainFailed) {
-    def message = "Publishing end-to-end tests <${BUILD_URL}|failed>"
-    message += (params.ORIGIN_REPO) ? " for ${params.ORIGIN_REPO}" : ""
-    slackSend(color: "#d40100", channel: channel, message: message)
-  } else if (env.BRANCH_NAME == "test-against" && testStatus.flakyNewFailed) {
-    def message = "Publishing end-to-end flaky/new tests <${BUILD_URL}|failed>"
-    message += (params.ORIGIN_REPO) ? " for ${params.ORIGIN_REPO}" : ""
-    slackSend(color: "#ffff94", channel: channel, message: message)
   }
 }


### PR DESCRIPTION
https://trello.com/c/fRihmgQ8/266-add-top-level-guidance-about-where-we-write-tests-on-govuk

To help with: https://github.com/alphagov/publishing-e2e-tests/pull/474

I'm not aware anyone is monitoring this channel, especially when
there is no specific team maintaining the repo. The artifical
environment the tests run in is also not relevant for any kind of
transient failure checks - comparing with Smokey, for example.

We still have good visibility of failures as part of the CI checks
on all apps involved in this repo as well as PRs on the repo itself.

Note: the slackSend function comes from the Jenkins Slack plugin [^1],
which is used elsewhere so there's no further cleanup needed here.

[^1]: https://www.jenkins.io/doc/pipeline/steps/slack/