### PR TITLE
Avoid running prometheus-exporter in tests.

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,6 +8,7 @@ x-govuk-app-env: &govuk-app
   GOVUK_APP_DOMAIN_EXTERNAL: dev.gov.uk
   GOVUK_ASSET_ROOT: http://assets-origin.dev.gov.uk
   GOVUK_WEBSITE_ROOT: http://www.dev.gov.uk
+  GOVUK_PROMETHEUS_EXPORTER: "false"
   JWT_AUTH_SECRET: fakejwtsecret
   LOG_PATH: log/live.log
   PLEK_SERVICE_SEARCH_URI: http://search-api.dev.gov.uk


### PR DESCRIPTION
It's not needed and it causes EADDRINUSE errors when running rake tasks in the same container as the server (which we shouldn't be doing anyway, but meh).