### PR TITLE
Minor tweaks to testing documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,8 @@
 A suite of end-to-end tests for publisher user journeys. The tests are written in [RSpec](http://rspec.info/) / [Capybara](https://github.com/teamcapybara/capybara) and mimic the behaviour of content editors in a web browser, using [headless Chrome](https://github.com/alphagov/publishing-e2e-tests/blob/2044d7eb3c00194d9fd6d1452849b7afc77b3608/spec/spec_helper.rb#L119).
 
 > **Warning: this repo is DEPRECATED as of [RFC 128 (Continuous Deployment)](https://github.com/alphagov/govuk-rfcs/blob/main/rfc-128-continuous-deployment.md#delete-publishing-e2e-tests)**. The tests are slow and brittle and do not run in a realistic GOV.UK environment. Do not add any new tests to this repo.
+>
+> [Read about alternatives to Publishing End-to-end Tests](docs/writing-tests.md#what-belongs-here).
 
 ## Technical documentation
 

--- a/docs/writing-tests.md
+++ b/docs/writing-tests.md
@@ -10,6 +10,8 @@ This repo contains tests for critical publishing actions and their impact on the
 
 Do not add tests that can be implemented in other ways. We want this to be the tip of of the [testing pyramid][testing-pyramid], not a [testing ice cream cone][testing-ice-cream-cone]. Instead of adding a test here, you can:
 
+- Add or extend [health checks for application infrastructure](https://github.com/alphagov/govuk_app_config/blob/main/docs/healthchecks.md). For example, drafting a document in a publishing app involves connecting to infrastructure like a database or AWS S3.
+
 - Add [contract tests](https://docs.publishing.service.gov.uk/manual/pact-broker.html) to cover the chain of APIs in a publishing action. For example, publishing a document involves Publishing API, Email Alert API, Content Store and Router.
 
 - Add unit or integration tests to cover in-app behaviour. For example, the way each document format is rendered can be tested in the frontend app that does the rendering.


### PR DESCRIPTION
This fixes an omitted alternative to writing tests here and better
signposts the full set of alternatives from the README.