### PR TITLE
Change rendering app to government-frontend

### DIFF
--- a/spec/manuals_publisher/creating_draft_spec.rb
+++ b/spec/manuals_publisher/creating_draft_spec.rb
@@ -27,7 +27,7 @@ feature "Creating a draft on Manuals Publisher", manuals_publisher: true do
     reload_url_until_status_code(url, 200)
 
     click_link "Preview draft"
-    expect_rendering_application("manuals-frontend")
+    expect_rendering_application("government-frontend")
     expect(page).to have_content(title)
     expect_url_matches_draft_gov_uk
   end

--- a/spec/manuals_publisher/publish_live_spec.rb
+++ b/spec/manuals_publisher/publish_live_spec.rb
@@ -30,7 +30,7 @@ feature "Publishing content on Manuals Publisher", manuals_publisher: true do
     reload_url_until_status_code(url, 200)
 
     click_link "View on website"
-    expect_rendering_application("manuals-frontend")
+    expect_rendering_application("government-frontend")
     expect(page).to have_content(title)
     expect_url_matches_live_gov_uk
   end

--- a/spec/manuals_publisher/removing_content_spec.rb
+++ b/spec/manuals_publisher/removing_content_spec.rb
@@ -59,7 +59,7 @@ feature "Removing content on Manuals Publisher", manuals_publisher: true do
 
     visit removed_section_url
 
-    expect_rendering_application("manuals-frontend")
+    expect_rendering_application("government-frontend")
     expect(current_url).to eq(url)
     expect(page).to have_content(title)
     expect_url_matches_live_gov_uk

--- a/spec/manuals_publisher/update_published_content_spec.rb
+++ b/spec/manuals_publisher/update_published_content_spec.rb
@@ -41,7 +41,7 @@ feature "Updating content on Manuals Publisher", manuals_publisher: true do
     reload_url_until_match(url, :has_text?, section_title)
 
     click_link "View on website"
-    expect_rendering_application("manuals-frontend")
+    expect_rendering_application("government-frontend")
     expect(page).to have_content(title)
     expect(page).to have_content(section_title)
     expect_url_matches_live_gov_uk

--- a/spec/manuals_publisher/upload_attachment_spec.rb
+++ b/spec/manuals_publisher/upload_attachment_spec.rb
@@ -52,7 +52,7 @@ feature "Uploading an attachment on Manuals Publisher", manuals_publisher: true 
     reload_url_until_match(section_url, :has_text?, attachment_title)
 
     click_link(section_title)
-    expect_rendering_application("manuals-frontend")
+    expect_rendering_application("government-frontend")
     expect_url_matches_draft_gov_uk
 
     attachment_link = find_link(attachment_title)[:href]
@@ -68,6 +68,6 @@ feature "Uploading an attachment on Manuals Publisher", manuals_publisher: true 
     reload_url_until_status_code(url, 200)
 
     click_link("Preview draft")
-    expect_rendering_application("manuals-frontend")
+    expect_rendering_application("government-frontend")
   end
 end


### PR DESCRIPTION
Manuals are soon to be rendered by Government Frontend (from Manuals
Frontend) so updates these tests.

Trello:
https://trello.com/c/e8XNP4Sk/1128-manuals-change-manuals-publisher-and-hmrc-manuals-api-rendering-app