### PR TITLE
Update Travel Advice Publisher flash message for saved drafts

### DIFF
--- a/spec/support/travel_advice_publisher_helpers.rb
+++ b/spec/support/travel_advice_publisher_helpers.rb
@@ -23,7 +23,7 @@ module TravelAdvicePublisherHelpers
 
     title ||= "#{country} travel advice"
 
-    expect(page).to have_text("#{title} updated"), fail_reason
+    expect(page).to have_text("#{title} draft has been saved"), fail_reason
   end
 
   def fill_in_advice_form(options)


### PR DESCRIPTION
This flash message now has a different message when you save a draft to when you save and publish. This means that the new message needs to be passed into the helper method.

The corresponding code that updated the flash message can be found in this PR https://github.com/alphagov/travel-advice-publisher/pull/1362