### PR TITLE
Remove redundant manuals-frontend

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -17,7 +17,6 @@ def apps = [
   [constantPrefix: "FRONTEND", app: "frontend", name: "Frontend"],
   [constantPrefix: "GOVUK_CONTENT_SCHEMAS", app: "govuk-content-schemas", name: "GOV.UK Content Schemas"],
   [constantPrefix: "GOVERNMENT_FRONTEND", app: "government-frontend", name: "Government Frontend"],
-  [constantPrefix: "MANUALS_FRONTEND", app: "manuals-frontend", name: "Manuals Frontend"],
   [constantPrefix: "MANUALS_PUBLISHER", app: "manuals-publisher", name: "Manuals Publisher"],
   [constantPrefix: "PUBLISHER", app: "publisher", name: "Publisher"],
   [constantPrefix: "PUBLISHING_API", app: "publishing-api", name: "Publishing API"],

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ APPS = asset-manager content-store govuk-content-schemas government-frontend \
 	publishing-api router router-api search-api \
 	specialist-publisher static travel-advice-publisher collections-publisher \
 	collections frontend publisher  \
-	manuals-publisher manuals-frontend whitehall content-tagger \
+	manuals-publisher whitehall content-tagger \
 	contacts-admin finder-frontend email-alert-api
 
 RUBY_VERSION = `cat .ruby-version`

--- a/docker-compose.development.yml
+++ b/docker-compose.development.yml
@@ -92,14 +92,6 @@ services:
     ports:
       - "33205:3205"
 
-  manuals-frontend:
-    ports:
-      - "33072:3072"
-
-  draft-manuals-frontend:
-    ports:
-      - "33172:3172"
-
   whitehall-admin:
     ports:
       - "33020:3020"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -208,7 +208,6 @@ services:
       - nginx-proxy:government-frontend.dev.gov.uk
       - nginx-proxy:collections.dev.gov.uk
       - nginx-proxy:frontend.dev.gov.uk
-      - nginx-proxy:manuals-frontend.dev.gov.uk
       - nginx-proxy:whitehall-frontend.dev.gov.uk
       - nginx-proxy:finder-frontend.dev.gov.uk
     ports:
@@ -231,7 +230,6 @@ services:
       - nginx-proxy:draft-government-frontend.dev.gov.uk
       - nginx-proxy:draft-collections.dev.gov.uk
       - nginx-proxy:draft-frontend.dev.gov.uk
-      - nginx-proxy:draft-manuals-frontend.dev.gov.uk
       - nginx-proxy:draft-whitehall-frontend.dev.gov.uk
     ports:
       - "3154"
@@ -746,48 +744,6 @@ services:
       disable: true
     ports: []
 
-  manuals-frontend: &manuals-frontend
-    image: govuk/manuals-frontend:${MANUALS_FRONTEND_COMMITISH:-deployed-to-production}
-    build:
-      context: apps/manuals-frontend
-    depends_on:
-      - content-store
-      - static
-      - diet-error-handler
-    environment:
-      << : *govuk-app
-      ASSET_HOST: manuals-frontend.dev.gov.uk
-      SENTRY_CURRENT_ENV: manuals-frontend
-      VIRTUAL_HOST: manuals-frontend.dev.gov.uk
-      PORT: 3072
-    links:
-      - nginx-proxy:content-store.dev.gov.uk
-      - nginx-proxy:static.dev.gov.uk
-      - nginx-proxy:error-handler.dev.gov.uk
-    ports:
-      - "3072"
-    volumes:
-      - ./apps/manuals-frontend/log:/app/log
-
-  draft-manuals-frontend: &draft-manuals-frontend
-    << : *manuals-frontend
-    depends_on:
-      - draft-content-store
-      - draft-static
-      - diet-error-handler
-    environment:
-      << : *draft-govuk-app
-      ASSET_HOST: draft-manuals-frontend.dev.gov.uk
-      SENTRY_CURRENT_ENV: draft-manuals-frontend
-      VIRTUAL_HOST: draft-manuals-frontend.dev.gov.uk
-      PORT: 3172
-    links:
-      - nginx-proxy:draft-content-store.dev.gov.uk
-      - nginx-proxy:draft-static.dev.gov.uk
-      - nginx-proxy:error-handler.dev.gov.uk
-    ports:
-      - "3172"
-
   whitehall-admin: &whitehall
     image: govuk/whitehall:${WHITEHALL_COMMITISH:-deployed-to-production}
     build:
@@ -1104,7 +1060,6 @@ services:
       - nginx-proxy:draft-origin.dev.gov.uk
       - nginx-proxy:draft-frontend.dev.gov.uk
       - nginx-proxy:draft-government-frontend.dev.gov.uk
-      - nginx-proxy:draft-manuals-frontend.dev.gov.uk
       - nginx-proxy:draft-whitehall-frontend.dev.gov.uk
       - nginx-proxy:draft-static.dev.gov.uk
       # Live frontend
@@ -1112,7 +1067,6 @@ services:
       - nginx-proxy:finder-frontend.dev.gov.uk
       - nginx-proxy:frontend.dev.gov.uk
       - nginx-proxy:government-frontend.dev.gov.uk
-      - nginx-proxy:manuals-frontend.dev.gov.uk
       - nginx-proxy:static.dev.gov.uk
       - nginx-proxy:whitehall-frontend.dev.gov.uk
       - nginx-proxy:www.dev.gov.uk


### PR DESCRIPTION
Depends on: https://github.com/alphagov/manuals-frontend/pull/1324

This is no longer used. By removing this we can speed up the build
time a little bit and clarify it's not actually needed.