### PR TITLE
Update label value in whitehall tagging UI

### DIFF
--- a/spec/support/whitehall_helpers.rb
+++ b/spec/support/whitehall_helpers.rb
@@ -5,7 +5,7 @@ module WhitehallHelpers
     click_button("Save and continue")
     expect(page).to have_text("The document has been saved")
     check "Test taxon"
-    click_button("Save and review legacy tagging")
+    click_button("Save and review specialist topic tagging")
     expect(page).to have_text("The tags have been updated")
     click_button("Save")
     expect(page).to have_text("The associations have been saved")

--- a/spec/whitehall/updating_document_spec.rb
+++ b/spec/whitehall/updating_document_spec.rb
@@ -68,7 +68,7 @@ feature "Creating a new edition of a document with Whitehall", whitehall: true, 
     check "Applies to all UK nations"
     click_button("Save and continue")
     check "Test taxon"
-    click_button("Save and review legacy tagging")
+    click_button("Save and review specialist topic tagging")
     click_button("Save")
     expect(page).to have_text("The associations have been saved")
   end

--- a/spec/whitehall/uploading_attachment_spec.rb
+++ b/spec/whitehall/uploading_attachment_spec.rb
@@ -28,7 +28,7 @@ feature "Uploading an attachment on Whitehall", whitehall: true, government_fron
     fill_in_consultation_form(title: title, body: "Attached image\n\n#{image_markdown}")
     click_button("Save and continue")
     check "Test taxon"
-    click_button("Save and review legacy tagging")
+    click_button("Save and review specialist topic tagging")
     click_button("Save")
     expect(page).to have_text("The associations have been saved")
   end


### PR DESCRIPTION
## What

We are amending some of the button labels in the Whitehall UI. The e2e tests need updating so that capybara can find the correct button to click.

Related PR:
- https://github.com/alphagov/whitehall/pull/6632

https://trello.com/c/Sbws55cL/928-whitehall-update-copy-based-on-jenns-doc-m
