### PR TITLE
Update name of public change note field to match new design changes

### DIFF
--- a/spec/whitehall/updating_document_spec.rb
+++ b/spec/whitehall/updating_document_spec.rb
@@ -64,7 +64,7 @@ feature "Creating a new edition of a document with Whitehall", whitehall: true, 
     click_button "Create new edition to edit"
 
     fill_in "Title", with: updated_title
-    fill_in "Public change note", with: change_note
+    fill_in "Describe the change for users", with: change_note
     check "Applies to all UK nations"
     click_button("Save and continue")
     check "Test taxon"


### PR DESCRIPTION
dependant on: https://github.com/alphagov/whitehall/pull/6639 

Trello card: https://trello.com/c/isH3BtNG/419-display-attachment-changes-in-edition-change-note