### PR TITLE
Update organisation republish rake task

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -135,7 +135,7 @@ publish_whitehall:
 	$(DOCKER_COMPOSE_CMD) exec -T whitehall-admin bundle exec rake publishing_api:publish_special_routes
 
 populate_end_to_end_test_data_from_whitehall:
-	$(DOCKER_COMPOSE_CMD) exec -T whitehall-admin bundle exec rake publishing_api:republish:all_organisations
+	$(DOCKER_COMPOSE_CMD) exec -T whitehall-admin bundle exec rake publishing_api:bulk_republish:document_type[Organisation]
 	$(DOCKER_COMPOSE_CMD) exec -T whitehall-admin bundle exec rake taxonomy:populate_end_to_end_test_data
 
 clean_apps:


### PR DESCRIPTION
In https://github.com/alphagov/whitehall/pull/6715, we have consolidated the bulk republishing rake tasks.

This updates the `Makefile` to reflect this change.

[Trello card](https://trello.com/c/dOpjWvGr/169-update-rake-task-for-republishing-content-items)