### PR TITLE
Allow 404 response while waiting for an unpublished taxon

### DIFF
--- a/spec/content_tagger/removing_taxon_spec.rb
+++ b/spec/content_tagger/removing_taxon_spec.rb
@@ -38,7 +38,7 @@ feature "Removing content from Content Tagger", collections: true, content_tagge
   end
 
   def then_visiting_the_removed_taxon_redirects_to_the_other_taxon
-    reload_url_until_status_code(@redirected_taxon_url, 301, keep_retrying_while: [200, 500])
+    reload_url_until_status_code(@redirected_taxon_url, 301, keep_retrying_while: [200, 404, 500])
     visit @redirected_taxon_url
     expect_rendering_application("collections")
     expect(current_url).to eq(@redirection_destination_url)


### PR DESCRIPTION
Sometimes we get a brief 404 when redirecting a taxon. This test then fails.

Permitting a 404 response provided we see the redirect after a retry.

There is prior art for retrying on a 404 after unpublishing in the Specialist Publisher tests: https://github.com/alphagov/publishing-e2e-tests/blob/484dd7d0dd016ee133ea04752827a69430bc927f/spec/specialist_publisher/unpublishing_spec.rb#L37