### PR TITLE
Wait for uploaded asset to exist

### DIFF
--- a/spec/whitehall/uploading_attachment_spec.rb
+++ b/spec/whitehall/uploading_attachment_spec.rb
@@ -48,7 +48,7 @@ feature "Uploading an attachment on Whitehall", whitehall: true, government_fron
     attachment_url = find(:xpath, "//img[@alt=\"#{attachment_alt_text}\"]")[:src]
 
     # Asset manager returns a 302 to a placeholder image until the asset is available
-    reload_url_until_status_code(attachment_url, 200, keep_retrying_while: 302)
+    reload_url_until_status_code(attachment_url, 200, keep_retrying_while: [302, 404])
     expect_matching_uploaded_file(attachment_url, attachment_file)
   end
 end


### PR DESCRIPTION
The test for uploading an attachment in Whitehall was failing when receiving a HTTP 404 Not Found error.

This resulted in the test suite failing frequently, presumably due to a race condition between the 'publish' action and the 'preview' step of this test.

This change follows in the footsteps of #496 and #104.