### PR TITLE
Adding health check cmd for finder frontend

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -509,6 +509,7 @@ services:
       VIRTUAL_HOST: finder-frontend.dev.gov.uk
       PORT: 3062
     healthcheck:
+      test: "curl --silent --fail localhost:3062/healthcheck/ready || exit 1"
       << : *default-healthcheck
     links:
       - nginx-proxy:search-api.dev.gov.uk


### PR DESCRIPTION
Healthcheck was removed from the finder-frontend Dockerfile
https://github.com/alphagov/finder-frontend/pull/2852

Adding health check.

https://trello.com/c/KgpXafSS/983-update-app-dockerfiles-to-remove-env-values-and-update-e2e-test