### PR TITLE
Adapt test for new 'Taxonomy topic tags' page in Whitehall

### DIFF
--- a/spec/support/whitehall_helpers.rb
+++ b/spec/support/whitehall_helpers.rb
@@ -4,7 +4,7 @@ module WhitehallHelpers
     fill_in_consultation_form(title: title)
     click_button("Save and continue")
     expect(page).to have_text("The document has been saved")
-    check "Test taxon"
+    find(".miller-columns .govuk-checkboxes__item", text: "Test taxon").click
     click_button("Update and review specialist topic tags")
     expect(page).to have_text("The tags have been updated")
     click_button("Save")

--- a/spec/support/whitehall_helpers.rb
+++ b/spec/support/whitehall_helpers.rb
@@ -5,7 +5,7 @@ module WhitehallHelpers
     click_button("Save and continue")
     expect(page).to have_text("The document has been saved")
     check "Test taxon"
-    click_button("Save and review specialist topic tagging")
+    click_button("Update and review specialist topic tags")
     expect(page).to have_text("The tags have been updated")
     click_button("Save")
     expect(page).to have_text("The associations have been saved")

--- a/spec/whitehall/publishing_document_spec.rb
+++ b/spec/whitehall/publishing_document_spec.rb
@@ -3,7 +3,7 @@ feature "Publishing a document with Whitehall", whitehall: true, government_fron
 
   let(:title) { "Publishing Whitehall #{SecureRandom.uuid}" }
 
-  scenario "Publishing a document with Whitehall", flaky: true do
+  scenario "Publishing a document with Whitehall" do
     given_i_have_a_draft_document
     when_i_publish_it
     then_i_can_view_it_on_gov_uk

--- a/spec/whitehall/unpublish_document_spec.rb
+++ b/spec/whitehall/unpublish_document_spec.rb
@@ -4,7 +4,7 @@ feature "Unpublishing a document by consolidating into another page on Whitehall
   let(:title) { "Unpublishing Whitehall #{SecureRandom.uuid}" }
   let(:redirection_destination) { Plek.new.website_root + "/help" }
 
-  scenario "Unpublishing a document on Whitehall by consolidating into another page ", flaky: true do
+  scenario "Unpublishing a document on Whitehall by consolidating into another page " do
     given_i_have_a_published_document
     when_i_unpublish_it_and_redirect_to_another_page
     then_i_am_redirected_when_i_visit_the_page_on_gov_uk

--- a/spec/whitehall/updating_document_spec.rb
+++ b/spec/whitehall/updating_document_spec.rb
@@ -66,10 +66,7 @@ feature "Creating a new edition of a document with Whitehall", whitehall: true, 
     fill_in "Title", with: updated_title
     fill_in "Describe the change for users", with: change_note
     check "Applies to all UK nations"
-    click_button("Save and continue")
-    check "Test taxon"
-    click_button("Save and review specialist topic tagging")
     click_button("Save")
-    expect(page).to have_text("The associations have been saved")
+    expect(page).to have_text("The document has been saved")
   end
 end

--- a/spec/whitehall/updating_document_spec.rb
+++ b/spec/whitehall/updating_document_spec.rb
@@ -5,7 +5,7 @@ feature "Creating a new edition of a document with Whitehall", whitehall: true, 
   let(:updated_title) { "Updating Whitehall After #{SecureRandom.uuid}" }
   let(:change_note) { "Testing update behaviour" }
 
-  scenario "Creating a new edition of a document with Whitehall", flaky: true do
+  scenario "Creating a new edition of a document with Whitehall" do
     given_i_have_a_published_document
     when_i_publish_a_new_edition_of_the_document
     then_i_can_view_the_updated_content_on_gov_uk

--- a/spec/whitehall/uploading_attachment_spec.rb
+++ b/spec/whitehall/uploading_attachment_spec.rb
@@ -5,7 +5,7 @@ feature "Uploading an attachment on Whitehall", whitehall: true, government_fron
   let(:attachment_file) { File.expand_path("../fixtures/whitehall/public_health.png", __dir__) }
   let(:attachment_alt_text) { "Public Health Attachment" }
 
-  scenario "Uploading an attachment on Whitehall", flaky: true do
+  scenario "Uploading an attachment on Whitehall" do
     given_i_have_a_draft_document_with_attachment
     when_i_view_the_draft_document
     then_i_can_view_the_image

--- a/spec/whitehall/uploading_attachment_spec.rb
+++ b/spec/whitehall/uploading_attachment_spec.rb
@@ -28,7 +28,7 @@ feature "Uploading an attachment on Whitehall", whitehall: true, government_fron
     fill_in_consultation_form(title: title, body: "Attached image\n\n#{image_markdown}")
     click_button("Save and continue")
     check "Test taxon"
-    click_button("Save and review specialist topic tagging")
+    click_button("Update and review specialist topic tags")
     click_button("Save")
     expect(page).to have_text("The associations have been saved")
   end

--- a/spec/whitehall/uploading_attachment_spec.rb
+++ b/spec/whitehall/uploading_attachment_spec.rb
@@ -27,7 +27,7 @@ feature "Uploading an attachment on Whitehall", whitehall: true, government_fron
     image_markdown = "!!1"
     fill_in_consultation_form(title: title, body: "Attached image\n\n#{image_markdown}")
     click_button("Save and continue")
-    check "Test taxon"
+    find(".miller-columns .govuk-checkboxes__item", text: "Test taxon").click
     click_button("Update and review specialist topic tags")
     click_button("Save")
     expect(page).to have_text("The associations have been saved")

--- a/spec/whitehall/withdraw_document_spec.rb
+++ b/spec/whitehall/withdraw_document_spec.rb
@@ -4,7 +4,7 @@ feature "Withdraw a document with Whitehall", whitehall: true, government_fronte
   let(:title) { "Withdraw Whitehall #{SecureRandom.uuid}" }
   let(:withdrawal_explanation) { "Testing withdrawing a document" }
 
-  scenario "Withdrawing a document with Whitehall", flaky: true do
+  scenario "Withdrawing a document with Whitehall" do
     given_i_have_a_published_document
     when_i_withdraw_it
     then_i_can_view_the_withdrawal_notice_on_gov_uk


### PR DESCRIPTION
The 'Taxonomy topic tags' page in Whitehall changed in alphagov/whitehall#6893, causing some Publishing E2E tests to break.

As an initial temporary fix, we marked the affected tests as flaky so they didn't run (#505).

This PR updates the tests to work with the new page design, and re-enables the tests. See individual commits for details of changes made.