### PR TITLE
Update test to navigate to summary page after save

### DIFF
--- a/spec/whitehall/updating_document_spec.rb
+++ b/spec/whitehall/updating_document_spec.rb
@@ -66,7 +66,7 @@ feature "Creating a new edition of a document with Whitehall", whitehall: true, 
     fill_in "Title", with: updated_title
     fill_in "Describe the change for users", with: change_note
     check "Applies to all UK nations"
-    click_button("Save")
-    expect(page).to have_text("The document has been saved")
+    click_button "Save and continue"
+    click_button "Update tags"
   end
 end


### PR DESCRIPTION
## Description 

Now we're reverting saves behaviour we need to update this test to navigate to the summary page in order to force publish it

## Trello card

https://trello.com/c/6lZphXit/806-revert-changes-to-save-redirect