### PR TITLE
Ensure correct backend URL for search-api on draft apps.

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,6 +12,7 @@ x-govuk-app-env: &govuk-app
   JWT_AUTH_SECRET: fakejwtsecret
   LOG_PATH: log/live.log
   PLEK_SERVICE_SEARCH_URI: http://search-api.dev.gov.uk
+  PLEK_UNPREFIXABLE_HOSTS: search-api
   RAILS_ENV: production
   RAILS_SERVE_STATIC_FILES: "true"
   SECRET_KEY_BASE: 875c6bf4c48da9bb41f4cfd25d09bf5e2a62d88b39efc4bd9c498e6c8f61e4df740af87386f97269525e01b5f74402512eb6a4723882579f10aa95f6e2971fc2


### PR DESCRIPTION
This is needed for alphagov/gds-api-adapters#1170.

The `PLEK_SERVICE_SEARCH_URI` override doesn't just paper over the historical name change; it's also what was preventing Plek from prefixing the hostname with `draft-` for apps that have `PLEK_HOSTNAME_PREFIX=draft-`. (`search`/`search-api` doesn't have a draft flavour.)