### PR TITLE
Remove no-longer-needed `PLEK_SERVICE_SEARCH_API_URI`.

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,7 +11,6 @@ x-govuk-app-env: &govuk-app
   GOVUK_PROMETHEUS_EXPORTER: "false"
   JWT_AUTH_SECRET: fakejwtsecret
   LOG_PATH: log/live.log
-  PLEK_SERVICE_SEARCH_API_URI: http://search-api.dev.gov.uk
   PLEK_UNPREFIXABLE_HOSTS: search-api
   RAILS_ENV: production
   RAILS_SERVE_STATIC_FILES: "true"


### PR DESCRIPTION
Now that we have `PLEK_UNPREFIXABLE_HOSTS=search-api` and `search-api` is referred to everywhere by that name, we no longer need to override this address for this backend.

See https://github.com/alphagov/gds-api-adapters/pull/1170.